### PR TITLE
Feature PWM_OUTPUT_ENABLE

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -516,6 +516,12 @@
     "featureONESHOT125Tip": {
         "message": "Disconnect flight battery and remove props before enabling."
     },
+    "featurePWM_OUTPUT_ENABLE": {
+        "message": "Enable motor output"
+    },
+    "featurePWM_OUTPUT_ENABLETip": {
+        "message": "Enabling this option is required for INAV to send signals to ESC. It is a safety precaution that prevents servos from being damaged right after flashing flight controller."
+    },
     "featureBLACKBOX": {
         "message": "Blackbox flight data recorder"
     },

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -33,6 +33,12 @@
                 </div>
                 <div class="spacer_box">
 
+                    <table cellpadding="0" cellspacing="0">
+                        <tbody class="features esc-priority">
+                            <!-- table generated here -->
+                        </tbody>
+                    </table>
+
                     <div id="esc-protocols">
                         <div class="select">
                             <label for="esc-protocol"> <span class="freelabel"

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -157,6 +157,14 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             );
         }
 
+        if (semver.gt(CONFIG.flightControllerVersion, "1.3.0")) {
+            features.push(
+                {bit: 28, group: 'esc-priority', name: 'PWM_OUTPUT_ENABLE', haveTip: true}
+            );
+        } else {
+            $('.features.esc-priority').parent().hide();
+        }
+
         if (semver.gte(CONFIG.apiVersion, "1.12.0")) {
             features.push(
                 {bit: 20, group: 'other', name: 'CHANNEL_FORWARDING'}

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -157,7 +157,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             );
         }
 
-        if (semver.gt(CONFIG.flightControllerVersion, "1.3.0")) {
+        if (semver.gte(CONFIG.flightControllerVersion, "1.4.0")) {
             features.push(
                 {bit: 28, group: 'esc-priority', name: 'PWM_OUTPUT_ENABLE', haveTip: true}
             );


### PR DESCRIPTION
This PR addresses iNavFlight/inav#706

Enabled for any INAV version > 1.3 (1.3.1 1.4 and so on)
- [x] Possibility to enable PWM output as a feature
- [ ] Clear way of informing the user he/she has to do it
