### PR TITLE
Gui interval refactoring

### DIFF
--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -802,7 +802,7 @@ function configuration_restore(callback) {
             function reinitialize() {
                 GUI.log(chrome.i18n.getMessage('deviceRebooting'));
 
-                GUI.timeout_add('waiting_for_bootup', function waiting_for_bootup() {
+                helper.timeout.add('waiting_for_bootup', function waiting_for_bootup() {
                     MSP.send_message(MSPCodes.MSP_IDENT, false, false, function () {
                         GUI.log(chrome.i18n.getMessage('deviceReady'));
 

--- a/js/eventFrequencyAnalyzer.js
+++ b/js/eventFrequencyAnalyzer.js
@@ -1,0 +1,77 @@
+'use s';
+
+var helper = helper || {};
+
+/**
+ * Simple analyzer that returns frequency of events using 5s buffer
+ * Usage: register periodic events with 'put', then call 'get' to get results
+ */
+helper.eventFrequencyAnalyzer = (function () {
+
+    var privateScope = {},
+        publicScope = {},
+        bufferPeriod = 5000;
+
+    privateScope.data = {};
+    privateScope.output = {};
+    privateScope.intervalHandler;
+
+    /**
+     * Periodically executed aggregation task
+     * @returns {{}|*}
+     */
+    publicScope.analyze = function () {
+        privateScope.output = {};
+
+        for (var i in privateScope.data) {
+            if (privateScope.data.hasOwnProperty(i)) {
+                privateScope.output[i] = privateScope.data[i] / bufferPeriod * 1000;
+            }
+        }
+
+        privateScope.data = {};
+        return privateScope.output;
+    };
+
+    /**
+     * Return event list with frequencies
+     * @returns {{}|*}
+     */
+    publicScope.get = function () {
+        return privateScope.output;
+    };
+
+    /**
+     * Returns raw data
+     * @returns {{}|*}
+     */
+    publicScope.getRaw = function () {
+        return privateScope.data;
+    };
+
+    /**
+     * Put event into analyzer
+     * @param {object} event
+     */
+    publicScope.put = function (event) {
+        if (privateScope.data[event]) {
+            privateScope.data[event]++;
+        } else {
+            privateScope.data[event] = 1;
+        }
+    };
+
+    /**
+     *
+     * @param {number} buffer buffer length in milliseconds
+     */
+    publicScope.setBufferPeriod = function (buffer) {
+        bufferPeriod = buffer;
+        clearInterval(privateScope.intervalHandler);
+        privateScope.intervalHandler = setInterval(publicScope.analyze, bufferPeriod);
+    };
+
+    privateScope.intervalHandler = setInterval(publicScope.analyze, bufferPeriod);
+
+    return publicScope;
+})();

--- a/js/gui.js
+++ b/js/gui.js
@@ -76,7 +76,7 @@ GUI_control.prototype.log = function (message) {
 GUI_control.prototype.tab_switch_cleanup = function (callback) {
     MSP.callbacks_cleanup(); // we don't care about any old data that might or might not arrive
 
-    helper.interval.killAll();
+    helper.interval.killAll(['global_data_refresh']);
 
     if (this.active_tab) {
         TABS[this.active_tab].cleanup(callback);

--- a/js/gui.js
+++ b/js/gui.js
@@ -11,8 +11,6 @@ var GUI_control = function () {
     this.active_tab;
     this.tab_switch_in_progress = false;
     this.operating_system;
-    this.interval_array = [];
-    this.timeout_array = [];
     this.defaultAllowedTabsWhenDisconnected = [
         'landing',
         'firmware_flasher',
@@ -51,162 +49,6 @@ var GUI_control = function () {
     else this.operating_system = "Unknown";
 };
 
-// Timer managing methods
-
-// name = string
-// code = function reference (code to be executed)
-// interval = time interval in miliseconds
-// first = true/false if code should be ran initially before next timer interval hits
-GUI_control.prototype.interval_add = function (name, code, interval, first) {
-    var data = {'name': name, 'timer': null, 'code': code, 'interval': interval, 'fired': 0, 'paused': false};
-
-    if (first == true) {
-        code(); // execute code
-
-        data.fired++; // increment counter
-    }
-
-    data.timer = setInterval(function() {
-        code(); // execute code
-
-        data.fired++; // increment counter
-    }, interval);
-
-    this.interval_array.push(data); // push to primary interval array
-
-    return data;
-};
-
-// name = string
-GUI_control.prototype.interval_remove = function (name) {
-    for (var i = 0; i < this.interval_array.length; i++) {
-        if (this.interval_array[i].name == name) {
-            clearInterval(this.interval_array[i].timer); // stop timer
-
-            this.interval_array.splice(i, 1); // remove element/object from array
-
-            return true;
-        }
-    }
-
-    return false;
-};
-
-// name = string
-GUI_control.prototype.interval_pause = function (name) {
-    for (var i = 0; i < this.interval_array.length; i++) {
-        if (this.interval_array[i].name == name) {
-            clearInterval(this.interval_array[i].timer);
-            this.interval_array[i].paused = true;
-
-            return true;
-        }
-    }
-
-    return false;
-};
-
-// name = string
-GUI_control.prototype.interval_resume = function (name) {
-    for (var i = 0; i < this.interval_array.length; i++) {
-        if (this.interval_array[i].name == name && this.interval_array[i].paused) {
-            var obj = this.interval_array[i];
-
-            obj.timer = setInterval(function() {
-                obj.code(); // execute code
-
-                obj.fired++; // increment counter
-            }, obj.interval);
-
-            obj.paused = false;
-
-            return true;
-        }
-    }
-
-    return false;
-};
-
-// input = array of timers thats meant to be kept, or nothing
-// return = returns timers killed in last call
-GUI_control.prototype.interval_kill_all = function (keep_array) {
-    var self = this;
-    var timers_killed = 0;
-
-    for (var i = (this.interval_array.length - 1); i >= 0; i--) { // reverse iteration
-        var keep = false;
-        if (keep_array) { // only run through the array if it exists
-            keep_array.forEach(function (name) {
-                if (self.interval_array[i].name == name) {
-                    keep = true;
-                }
-            });
-        }
-
-        if (!keep) {
-            clearInterval(this.interval_array[i].timer); // stop timer
-
-            this.interval_array.splice(i, 1); // remove element/object from array
-
-            timers_killed++;
-        }
-    }
-
-    return timers_killed;
-};
-
-// name = string
-// code = function reference (code to be executed)
-// timeout = timeout in miliseconds
-GUI_control.prototype.timeout_add = function (name, code, timeout) {
-    var self = this;
-    var data = {'name': name, 'timer': null, 'timeout': timeout};
-
-    // start timer with "cleaning" callback
-    data.timer = setTimeout(function() {
-        code(); // execute code
-
-        // remove object from array
-        var index = self.timeout_array.indexOf(data);
-        if (index > -1) self.timeout_array.splice(index, 1);
-    }, timeout);
-
-    this.timeout_array.push(data); // push to primary timeout array
-
-    return data;
-};
-
-// name = string
-GUI_control.prototype.timeout_remove = function (name) {
-    for (var i = 0; i < this.timeout_array.length; i++) {
-        if (this.timeout_array[i].name == name) {
-            clearTimeout(this.timeout_array[i].timer); // stop timer
-
-            this.timeout_array.splice(i, 1); // remove element/object from array
-
-            return true;
-        }
-    }
-
-    return false;
-};
-
-// no input paremeters
-// return = returns timers killed in last call
-GUI_control.prototype.timeout_kill_all = function () {
-    var timers_killed = 0;
-
-    for (var i = 0; i < this.timeout_array.length; i++) {
-        clearTimeout(this.timeout_array[i].timer); // stop timer
-
-        timers_killed++;
-    }
-
-    this.timeout_array = []; // drop objects
-
-    return timers_killed;
-};
-
 // message = string
 GUI_control.prototype.log = function (message) {
     var command_log = $('div#log');
@@ -233,7 +75,8 @@ GUI_control.prototype.log = function (message) {
 // default switch doesn't require callback to be set
 GUI_control.prototype.tab_switch_cleanup = function (callback) {
     MSP.callbacks_cleanup(); // we don't care about any old data that might or might not arrive
-    GUI.interval_kill_all(); // all intervals (mostly data pulling) needs to be removed on tab switch
+
+    helper.interval.killAll();
 
     if (this.active_tab) {
         TABS[this.active_tab].cleanup(callback);

--- a/js/intervals.js
+++ b/js/intervals.js
@@ -18,6 +18,12 @@ helper.interval = (function () {
      * @returns {{name: *, timer: null, code: *, interval: *, fired: number, paused: boolean}}
      */
     publicScope.add = function (name, code, interval, first) {
+
+        /*
+         * Kill existing interval with this name if exists
+         */
+        publicScope.remove(name);
+
         var data = {
             'name': name,
             'timer': null,

--- a/js/intervals.js
+++ b/js/intervals.js
@@ -14,7 +14,7 @@ helper.interval = (function () {
      * @param {String} name
      * @param {Function} code function reference (code to be executed)
      * @param {int} interval time interval in milliseconds
-     * @param {boolean} first true/false if code should be ran initially before next timer interval hits
+     * @param {boolean=} first true/false if code should be ran initially before next timer interval hits
      * @returns {{name: *, timer: null, code: *, interval: *, fired: number, paused: boolean}}
      */
     publicScope.add = function (name, code, interval, first) {

--- a/js/intervals.js
+++ b/js/intervals.js
@@ -1,0 +1,131 @@
+'use strict';
+
+var helper = helper || {};
+
+helper.interval = (function () {
+
+    var privateScope = {},
+        publicScope = {};
+
+    privateScope.intervals = [];
+
+    /**
+     *
+     * @param {String} name
+     * @param {Function} code function reference (code to be executed)
+     * @param {int} interval time interval in milliseconds
+     * @param {boolean} first true/false if code should be ran initially before next timer interval hits
+     * @returns {{name: *, timer: null, code: *, interval: *, fired: number, paused: boolean}}
+     */
+    publicScope.add = function (name, code, interval, first) {
+        var data = {
+            'name': name,
+            'timer': null,
+            'code': code,
+            'interval': interval,
+            'fired': 0,
+            'paused': false
+        };
+
+        if (first == true) {
+            code(); // execute code
+            data.fired++; // increment counter
+        }
+
+        data.timer = setInterval(function() {
+            code();
+            data.fired++;
+        }, interval);
+
+        privateScope.intervals.push(data);
+
+        return data;
+    };
+
+    /**
+     * Method removes and stop execution of interval callback
+     * @param {string} name
+     * @returns {boolean}
+     */
+    publicScope.remove = function (name) {
+        for (var i = 0; i < privateScope.intervals.length; i++) {
+            if (privateScope.intervals[i].name == name) {
+                clearInterval(privateScope.intervals[i].timer); // stop timer
+                privateScope.intervals.splice(i, 1);
+                return true;
+            }
+        }
+        return false;
+    };
+
+    /**
+     *
+     * @param {string} name
+     * @returns {boolean}
+     */
+    publicScope.pause = function (name) {
+        for (var i = 0; i < privateScope.intervals.length; i++) {
+            if (privateScope.intervals[i].name == name) {
+                clearInterval(privateScope.intervals[i].timer);
+                privateScope.intervals[i].paused = true;
+
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    /**
+     *
+     * @param {string} name
+     * @returns {boolean}
+     */
+    publicScope.resume = function (name) {
+        for (var i = 0; i < privateScope.intervals.length; i++) {
+            if (privateScope.intervals[i].name == name && privateScope.intervals[i].paused) {
+                var obj = privateScope.intervals[i];
+
+                obj.timer = setInterval(function() {
+                    obj.code(); // execute code
+                    obj.fired++; // increment counter
+                }, obj.interval);
+
+                obj.paused = false;
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    /**
+     *
+     * @param {=} keep_array
+     * @returns {number}
+     */
+    publicScope.killAll = function (keep_array) {
+        var timers_killed = 0;
+
+        for (var i = (privateScope.intervals.length - 1); i >= 0; i--) { // reverse iteration
+            var keep = false;
+            if (keep_array) { // only run through the array if it exists
+                keep_array.forEach(function (name) {
+                    if (privateScope.intervals[i].name == name) {
+                        keep = true;
+                    }
+                });
+            }
+
+            if (!keep) {
+                clearInterval(privateScope.intervals[i].timer); // stop timer
+                privateScope.intervals.splice(i, 1); // remove element/object from array
+                timers_killed++;
+            }
+        }
+
+        return timers_killed;
+    };
+
+    return publicScope;
+})();

--- a/js/msp.js
+++ b/js/msp.js
@@ -114,6 +114,11 @@ var MSP = {
             bufView,
             i;
 
+        /*
+         * For debug reasons, check how ofter MSP frames are executed
+         */
+        helper.eventFrequencyAnalyzer.put(code);
+
         // always reserve 6 bytes for protocol overhead !
         if (data) {
             var size = data.length + 6,

--- a/js/msp.js
+++ b/js/msp.js
@@ -177,7 +177,7 @@ var MSP = {
                 console.log('MSP data request timed-out: ' + code);
 
                 serial.send(bufferOut, false);
-            }, 1000); // we should be able to define timeout in the future
+            }, serial.getTimeout()); // we should be able to define timeout in the future
         }
 
         MSP.callbacks.push(obj);

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -53,6 +53,7 @@ var mspHelper = (function (gui) {
                 CONFIG.capability = data.getUint32(3, true);
                 break;
             case MSPCodes.MSP_STATUS:
+                console.log('Using deprecated msp command: MSP_STATUS');
                 CONFIG.cycleTime = data.getUint16(0, true);
                 CONFIG.i2cError = data.getUint16(2, true);
                 CONFIG.activeSensors = data.getUint16(4, true);
@@ -86,6 +87,7 @@ var mspHelper = (function (gui) {
                     sensor_status(CONFIG.activeSensors);
                 }
                 gui.updateStatusBar();
+                gui.updateProfileChange();
                 break;
 
             case MSPCodes.MSP_SENSOR_STATUS:

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1823,6 +1823,14 @@ var mspHelper = (function (gui) {
         }
     };
 
+    self.loadSensorStatus = function (callback) {
+        if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
+            MSP.send_message(MSPCodes.MSP_SENSOR_STATUS, false, false, callback);
+        } else {
+            callback();
+        }
+    };
+
     self.loadRcDeadband = function (callback) {
         if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
             MSP.send_message(MSPCodes.MSP_RC_DEADBAND, false, false, callback);
@@ -1841,6 +1849,10 @@ var mspHelper = (function (gui) {
 
     self.loadAccTrim = function (callback) {
         MSP.send_message(MSPCodes.MSP_ACC_TRIM, false, false, callback);
+    };
+
+    self.loadAnalog = function (callback) {
+        MSP.send_message(MSPCodes.MSP_ANALOG, false, false, callback);
     };
 
     self.saveToEeprom = function saveToEeprom(callback) {

--- a/js/periodicStatusUpdater.js
+++ b/js/periodicStatusUpdater.js
@@ -1,0 +1,120 @@
+'use strict';
+
+var helper = helper || {};
+
+helper.periodicStatusUpdater = (function () {
+
+    var publicScope = {},
+        privateScope = {};
+
+    /**
+     *
+     * @param {number=} baudSpeed
+     * @returns {number}
+     */
+    publicScope.getUpdateInterval = function (baudSpeed) {
+
+        if (!baudSpeed) {
+            baudSpeed = 115200;
+        }
+
+        if (baudSpeed >= 115200) {
+            return 100;
+        } else if (baudSpeed >= 57600) {
+            return 200;
+        } else if (baudSpeed >= 38400) {
+            return 250;
+        } else if (baudSpeed >= 19200) {
+            return 400;
+        } else if (baudSpeed >= 9600) {
+            return 500;
+        } else {
+            return 1000;
+        }
+    };
+
+    publicScope.run = function () {
+
+        if (!CONFIGURATOR.connectionValid) {
+            return;
+        }
+
+        $(".quad-status-contents").css({
+            display: 'inline-block'
+        });
+
+        //FIXME MSP_SENSOR_STATUS has to be added here!!
+        if (GUI.active_tab != 'cli') {
+
+            if (semver.gte(CONFIG.flightControllerVersion, "1.2.0")) {
+                MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false);
+            } else {
+                MSP.send_message(MSPCodes.MSP_STATUS, false, false);
+            }
+
+            MSP.send_message(MSPCodes.MSP_ANALOG, false, false);
+        }
+
+        var active = ((Date.now() - MSP.analog_last_received_timestamp) < 300);
+
+        for (var i = 0; i < AUX_CONFIG.length; i++) {
+            if (AUX_CONFIG[i] == 'ARM') {
+                if (bit_check(CONFIG.mode, i))
+                    $(".armedicon").css({
+                        'background-image': 'url(images/icons/cf_icon_armed_active.svg)'
+                    });
+                else
+                    $(".armedicon").css({
+                        'background-image': 'url(images/icons/cf_icon_armed_grey.svg)'
+                    });
+            }
+            if (AUX_CONFIG[i] == 'FAILSAFE') {
+                if (bit_check(CONFIG.mode, i))
+                    $(".failsafeicon").css({
+                        'background-image': 'url(images/icons/cf_icon_failsafe_active.svg)'
+                    });
+                else
+                    $(".failsafeicon").css({
+                        'background-image': 'url(images/icons/cf_icon_failsafe_grey.svg)'
+                    });
+            }
+        }
+
+        if (ANALOG != undefined) {
+            var nbCells = Math.floor(ANALOG.voltage / MISC.vbatmaxcellvoltage) + 1;
+            if (ANALOG.voltage == 0)
+                nbCells = 1;
+
+            var min = MISC.vbatmincellvoltage * nbCells;
+            var max = MISC.vbatmaxcellvoltage * nbCells;
+            var warn = MISC.vbatwarningcellvoltage * nbCells;
+
+            $(".battery-status").css({
+                width: ((ANALOG.voltage - min) / (max - min) * 100) + "%",
+                display: 'inline-block'
+            });
+
+            if (active) {
+                $(".linkicon").css({
+                    'background-image': 'url(images/icons/cf_icon_link_active.svg)'
+                });
+            } else {
+                $(".linkicon").css({
+                    'background-image': 'url(images/icons/cf_icon_link_grey.svg)'
+                });
+            }
+
+            if (ANALOG.voltage < warn) {
+                $(".battery-status").css('background-color', '#D42133');
+            } else {
+                $(".battery-status").css('background-color', '#59AA29');
+            }
+
+            $(".battery-legend").text(ANALOG.voltage + " V");
+        }
+
+        $('#quad-status_wrapper').show();
+    };
+
+    return publicScope;
+})();

--- a/js/port_handler.js
+++ b/js/port_handler.js
@@ -112,7 +112,7 @@ PortHandler.check = function () {
             if (GUI.auto_connect && !GUI.connecting_to && !GUI.connected_to) {
                 // we need firmware flasher protection over here
                 if (GUI.active_tab != 'firmware_flasher') {
-                    GUI.timeout_add('auto-connect_timeout', function () {
+                    helper.timeout.add('auto-connect_timeout', function () {
                         $('div#port-picker a.connect').click();
                     }, 100); // timeout so bus have time to initialize after being detected by the system
                 }

--- a/js/protocols/stm32.js
+++ b/js/protocols/stm32.js
@@ -154,7 +154,7 @@ STM32_protocol.prototype.initialize = function () {
         self.read(info);
     });
 
-    GUI.interval_add('STM32_timeout', function () {
+    helper.interval.add('STM32_timeout', function () {
         if (self.upload_process_alive) { // process is running
             self.upload_process_alive = false;
         } else {
@@ -166,7 +166,7 @@ STM32_protocol.prototype.initialize = function () {
             googleAnalytics.sendEvent('Flashing', 'Programming', 'timeout');
 
             // protocol got stuck, clear timer and disconnect
-            GUI.interval_remove('STM32_timeout');
+            helper.interval.remove('STM32_timeout');
 
             // exit
             self.upload_procedure(99);
@@ -361,10 +361,10 @@ STM32_protocol.prototype.upload_procedure = function (step) {
             $('span.progressLabel').text('Contacting bootloader ...');
 
             var send_counter = 0;
-            GUI.interval_add('stm32_initialize_mcu', function () { // 200 ms interval (just in case mcu was already initialized), we need to break the 2 bytes command requirement
+            helper.interval.add('stm32_initialize_mcu', function () { // 200 ms interval (just in case mcu was already initialized), we need to break the 2 bytes command requirement
                 self.send([0x7F], 1, function (reply) {
                     if (reply[0] == 0x7F || reply[0] == self.status.ACK || reply[0] == self.status.NACK) {
-                        GUI.interval_remove('stm32_initialize_mcu');
+                        helper.interval.remove('stm32_initialize_mcu');
                         console.log('STM32 - Serial interface initialized on the MCU side');
 
                         // proceed to next step
@@ -373,7 +373,7 @@ STM32_protocol.prototype.upload_procedure = function (step) {
                         $('span.progressLabel').text('Communication with bootloader failed');
                         self.progress_bar_e.addClass('invalid');
 
-                        GUI.interval_remove('stm32_initialize_mcu');
+                        helper.interval.remove('stm32_initialize_mcu');
 
                         // disconnect
                         self.upload_procedure(99);
@@ -387,8 +387,8 @@ STM32_protocol.prototype.upload_procedure = function (step) {
                     $('span.progressLabel').text('No response from the bootloader, programming: FAILED');
                     self.progress_bar_e.addClass('invalid');
 
-                    GUI.interval_remove('stm32_initialize_mcu');
-                    GUI.interval_remove('STM32_timeout');
+                    helper.interval.remove('stm32_initialize_mcu');
+                    helper.interval.remove('STM32_timeout');
 
                     // exit
                     self.upload_procedure(99);
@@ -749,7 +749,7 @@ STM32_protocol.prototype.upload_procedure = function (step) {
             break;
         case 99:
             // disconnect
-            GUI.interval_remove('STM32_timeout'); // stop STM32 timeout timer (everything is finished now)
+            helper.interval.remove('STM32_timeout'); // stop STM32 timeout timer (everything is finished now)
 
             // close connection
             serial.disconnect(function (result) {

--- a/js/serial.js
+++ b/js/serial.js
@@ -292,6 +292,18 @@ var serial = {
     emptyOutputBuffer: function () {
         this.outputBuffer = [];
         this.transmitting = false;
+    },
+
+    /**
+     * Default timeout value for serial messages
+     * @returns {number} [ms]
+     */
+    getTimeout: function () {
+        if (serial.bitrate >= 57600) {
+            return 1000;
+        } else {
+            return 2000;
+        }
     }
 
 };

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -499,6 +499,7 @@ function update_live_status() {
        display: 'inline-block'
     });
 
+    //FIXME probably this is a duplication on status polling... one of those is probably very very not needed
     if (GUI.active_tab != 'cli') {
         MSP.send_message(MSPCodes.MSP_BOXNAMES, false, false);
         if (semver.gte(CONFIG.flightControllerVersion, "1.2.0"))

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -500,12 +500,16 @@ function update_live_status() {
     });
 
     //FIXME probably this is a duplication on status polling... one of those is probably very very not needed
+    //FIXME MSP_SENSOR_STATUS has to be added here!!
     if (GUI.active_tab != 'cli') {
         MSP.send_message(MSPCodes.MSP_BOXNAMES, false, false);
-        if (semver.gte(CONFIG.flightControllerVersion, "1.2.0"))
-        	MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false);
-        else
-        	MSP.send_message(MSPCodes.MSP_STATUS, false, false);
+
+        if (semver.gte(CONFIG.flightControllerVersion, "1.2.0")) {
+            MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false);
+        } else {
+            MSP.send_message(MSPCodes.MSP_STATUS, false, false);
+        }
+
         MSP.send_message(MSPCodes.MSP_ANALOG, false, false);
     }
 
@@ -534,36 +538,36 @@ function update_live_status() {
        }
     }
     if (ANALOG != undefined) {
-    var nbCells = Math.floor(ANALOG.voltage / MISC.vbatmaxcellvoltage) + 1;
-    if (ANALOG.voltage == 0)
-           nbCells = 1;
+        var nbCells = Math.floor(ANALOG.voltage / MISC.vbatmaxcellvoltage) + 1;
+        if (ANALOG.voltage == 0)
+            nbCells = 1;
 
-       var min = MISC.vbatmincellvoltage * nbCells;
-       var max = MISC.vbatmaxcellvoltage * nbCells;
-       var warn = MISC.vbatwarningcellvoltage * nbCells;
+        var min = MISC.vbatmincellvoltage * nbCells;
+        var max = MISC.vbatmaxcellvoltage * nbCells;
+        var warn = MISC.vbatwarningcellvoltage * nbCells;
 
-       $(".battery-status").css({
-          width: ((ANALOG.voltage - min) / (max - min) * 100) + "%",
-          display: 'inline-block'
-       });
+        $(".battery-status").css({
+            width: ((ANALOG.voltage - min) / (max - min) * 100) + "%",
+            display: 'inline-block'
+        });
 
-       if (active) {
-           $(".linkicon").css({
-               'background-image': 'url(images/icons/cf_icon_link_active.svg)'
-           });
-       } else {
-           $(".linkicon").css({
-               'background-image': 'url(images/icons/cf_icon_link_grey.svg)'
-           });
-       }
+        if (active) {
+            $(".linkicon").css({
+                'background-image': 'url(images/icons/cf_icon_link_active.svg)'
+            });
+        } else {
+            $(".linkicon").css({
+                'background-image': 'url(images/icons/cf_icon_link_grey.svg)'
+            });
+        }
 
-       if (ANALOG.voltage < warn) {
-           $(".battery-status").css('background-color', '#D42133');
-       } else  {
-           $(".battery-status").css('background-color', '#59AA29');
-       }
+        if (ANALOG.voltage < warn) {
+            $(".battery-status").css('background-color', '#D42133');
+        } else {
+            $(".battery-status").css('background-color', '#59AA29');
+        }
 
-       $(".battery-legend").text(ANALOG.voltage + " V");
+        $(".battery-legend").text(ANALOG.voltage + " V");
     }
 
     statuswrapper.show();

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -35,7 +35,7 @@ $(document).ready(function () {
             }, 5000);
         } else {
 
-            GUI.timeout_add('waiting_for_bootup', function waiting_for_bootup() {
+            helper.timeout.add('waiting_for_bootup', function waiting_for_bootup() {
                 MSP.send_message(MSPCodes.MSP_IDENT, false, false, function () {
                     //noinspection JSUnresolvedVariable
                     GUI.log(chrome.i18n.getMessage('deviceReady'));
@@ -98,8 +98,8 @@ $(document).ready(function () {
 
                     serial.connect(selected_port, {bitrate: selected_baud}, onOpen);
                 } else {
-                    GUI.timeout_kill_all();
-                    GUI.interval_kill_all();
+                    helper.timeout.killAll();
+                    helper.interval.killAll();
                     GUI.tab_switch_cleanup();
                     GUI.tab_switch_in_progress = false;
 
@@ -213,7 +213,7 @@ function onOpen(openInfo) {
         serial.onReceive.addListener(read_serial);
 
         // disconnect after 10 seconds with error if we don't get IDENT data
-        GUI.timeout_add('connecting', function () {
+        helper.timeout.add('connecting', function () {
             if (!CONFIGURATOR.connectionValid) {
                 GUI.log(chrome.i18n.getMessage('noConfigurationReceived'));
 
@@ -306,7 +306,7 @@ function onOpen(openInfo) {
 }
 
 function onConnect() {
-    GUI.timeout_remove('connecting'); // kill connecting timer
+    helper.timeout.remove('connecting'); // kill connecting timer
     $('div#connectbutton a.connect_state').text(chrome.i18n.getMessage('disconnect')).addClass('active');
     $('div#connectbutton a.connect').addClass('active');
     $('#tabs ul.mode-disconnected').hide();
@@ -488,7 +488,7 @@ function update_dataflash_global() {
 
 function startLiveDataRefreshTimer() {
     // live data refresh
-    GUI.timeout_add('data_refresh', function () { update_live_status(); }, 100);
+    helper.timeout.add('data_refresh', function () { update_live_status(); }, 100);
 }
 
 function update_live_status() {
@@ -566,7 +566,7 @@ function update_live_status() {
     }
 
     statuswrapper.show();
-    GUI.timeout_remove('data_refresh');
+    helper.timeout.remove('data_refresh');
     startLiveDataRefreshTimer();
 }
 

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -323,7 +323,7 @@ function onConnect() {
      */
     MSP.send_message(MSPCodes.MSP_BOXNAMES, false, false);
 
-    helper.interval.add('global_data_refresh', helper.periodicStatusUpdater.run, helper.periodicStatusUpdater.getUpdateInterval(serial.bitrate), true);
+    helper.interval.add('global_data_refresh', helper.periodicStatusUpdater.run, helper.periodicStatusUpdater.getUpdateInterval(serial.bitrate), false);
 }
 
 function onClosed(result) {

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var helper = helper || {};
+
+helper.task = (function () {
+
+    var publicScope = {},
+        privateScope = {};
+
+    privateScope.getStatusPullInterval = function () {
+        //TODO use serial connection speed to determine update interval
+        return 250;
+    };
+
+    publicScope.statusPullStart = function () {
+        helper.interval.add('status_pull', function () {
+            MSP.send_message(MSPCodes.MSP_STATUS, false, false, function () {
+                if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
+                    MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
+                }
+            });
+
+        }, privateScope.getStatusPullInterval(), true);
+    };
+
+    return publicScope;
+})();

--- a/js/timeouts.js
+++ b/js/timeouts.js
@@ -1,0 +1,66 @@
+'use strict';
+
+var helper = helper || {};
+
+helper.timeout = (function () {
+
+    var privateScope = {},
+        publicScope = {};
+
+    privateScope.timeouts = [];
+
+    /**
+     *
+     * @param {string} name
+     * @param {function } code
+     * @param {number} timeout
+     * @returns {{name: *, timer: null, timeout: *}}
+     */
+    publicScope.add = function (name, code, timeout) {
+        var data = {'name': name, 'timer': null, 'timeout': timeout};
+
+        // start timer with "cleaning" callback
+        data.timer = setTimeout(function() {
+            code(); // execute code
+
+            // remove object from array
+            var index = privateScope.timeouts.indexOf(data);
+            if (index > -1) privateScope.timeouts.splice(index, 1);
+        }, timeout);
+
+        privateScope.timeouts.push(data); // push to primary timeout array
+
+        return data;
+    };
+
+    publicScope.remove = function (name) {
+        for (var i = 0; i < privateScope.timeouts.length; i++) {
+            if (privateScope.timeouts[i].name == name) {
+                clearTimeout(privateScope.timeouts[i].timer); // stop timer
+                privateScope.timeouts.splice(i, 1); // remove element/object from array
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    /**
+     *
+     * @returns {number} number of killed timeouts
+     */
+    publicScope.killAll = function () {
+        var timers_killed = 0;
+
+        for (var i = 0; i < privateScope.timeouts.length; i++) {
+            clearTimeout(privateScope.timeouts[i].timer); // stop timer
+            timers_killed++;
+        }
+
+        privateScope.timeouts = []; // drop objects
+
+        return timers_killed;
+    };
+
+    return publicScope;
+})();

--- a/main.html
+++ b/main.html
@@ -94,6 +94,7 @@
 <script type="text/javascript" src="./tabs/osd.js"></script>
 <script type="text/javascript" src="./tabs/profiles.js"></script>
 <script type="text/javascript" src="./js/eventFrequencyAnalyzer.js"></script>
+<script type="text/javascript" src="./js/periodicStatusUpdater.js"></script>
 <title></title>
 </head>
 <body>

--- a/main.html
+++ b/main.html
@@ -50,6 +50,8 @@
 <script type="text/javascript" src="./js/libraries/inflection.min.js"></script>
 <script type="text/javascript" src="./js/libraries/bluebird.min.js"></script>
 <script type="text/javascript" src="./js/injected_methods.js"></script>
+<script type="text/javascript" src="./js/intervals.js"></script>
+<script type="text/javascript" src="./js/timeouts.js"></script>
 <script type="text/javascript" src="./js/gui.js"></script>
 <script type="text/javascript" src="./js/msp/MSPCodes.js"></script>
 <script type="text/javascript" src="./js/msp/MSPHelper.js"></script>

--- a/main.html
+++ b/main.html
@@ -93,6 +93,7 @@
 <script type="text/javascript" src="./tabs/transponder.js"></script>
 <script type="text/javascript" src="./tabs/osd.js"></script>
 <script type="text/javascript" src="./tabs/profiles.js"></script>
+<script type="text/javascript" src="./js/eventFrequencyAnalyzer.js"></script>
 <title></title>
 </head>
 <body>

--- a/main.html
+++ b/main.html
@@ -69,6 +69,7 @@
 <script type="text/javascript" src="./js/protocols/stm32usbdfu.js"></script>
 <script type="text/javascript" src="./js/localization.js"></script>
 <script type="text/javascript" src="./js/boards.js"></script>
+<script type="text/javascript" src="./js/tasks.js"></script>
 <script type="text/javascript" src="./main.js"></script>
 <script type="text/javascript" src="./tabs/landing.js"></script>
 <script type="text/javascript" src="./tabs/setup.js"></script>

--- a/main.html
+++ b/main.html
@@ -55,7 +55,7 @@
 <script type="text/javascript" src="./js/gui.js"></script>
 <script type="text/javascript" src="./js/msp/MSPCodes.js"></script>
 <script type="text/javascript" src="./js/msp/MSPHelper.js"></script>
-<script type="text/javascript" src="./js/msp/MSPChainer.js"></script>
+<script type="text/javascript" src="./js/msp/MSPchainer.js"></script>
 <script type="text/javascript" src="./js/port_handler.js"></script>
 <script type="text/javascript" src="./js/port_usage.js"></script>
 <script type="text/javascript" src="./js/serial.js"></script>

--- a/tabs/adjustments.js
+++ b/tabs/adjustments.js
@@ -269,10 +269,10 @@ TABS.adjustments.initialize = function (callback) {
         update_ui();
 
         // enable data pulling
-        GUI.interval_add('aux_data_pull', get_rc_data, 50);
+        helper.interval.add('aux_data_pull', get_rc_data, 50);
 
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function () {
+        helper.interval.add('status_pull', function () {
             MSP.send_message(MSPCodes.MSP_STATUS);
             
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {

--- a/tabs/adjustments.js
+++ b/tabs/adjustments.js
@@ -271,14 +271,7 @@ TABS.adjustments.initialize = function (callback) {
         // enable data pulling
         helper.interval.add('aux_data_pull', get_rc_data, 50);
 
-        // status data pulled via separate timer with static speed
-        helper.interval.add('status_pull', function () {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-            
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-        }, 250, true);
+        helper.task.statusPullStart();
 
         GUI.content_ready(callback);
     }

--- a/tabs/adjustments.js
+++ b/tabs/adjustments.js
@@ -271,8 +271,6 @@ TABS.adjustments.initialize = function (callback) {
         // enable data pulling
         helper.interval.add('aux_data_pull', get_rc_data, 50);
 
-        helper.task.statusPullStart();
-
         GUI.content_ready(callback);
     }
 };

--- a/tabs/auxiliary.js
+++ b/tabs/auxiliary.js
@@ -288,10 +288,10 @@ TABS.auxiliary.initialize = function (callback) {
         update_ui();
 
         // enable data pulling
-        GUI.interval_add('aux_data_pull', get_rc_data, 50);
+        helper.interval.add('aux_data_pull', get_rc_data, 50);
 
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function () {
+        helper.interval.add('status_pull', function () {
             MSP.send_message(MSPCodes.MSP_STATUS);
             
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {

--- a/tabs/auxiliary.js
+++ b/tabs/auxiliary.js
@@ -290,14 +290,7 @@ TABS.auxiliary.initialize = function (callback) {
         // enable data pulling
         helper.interval.add('aux_data_pull', get_rc_data, 50);
 
-        // status data pulled via separate timer with static speed
-        helper.interval.add('status_pull', function () {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-            
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-        }, 250, true);
+        helper.task.statusPullStart();
 
         GUI.content_ready(callback);
     }

--- a/tabs/auxiliary.js
+++ b/tabs/auxiliary.js
@@ -290,8 +290,6 @@ TABS.auxiliary.initialize = function (callback) {
         // enable data pulling
         helper.interval.add('aux_data_pull', get_rc_data, 50);
 
-        helper.task.statusPullStart();
-
         GUI.content_ready(callback);
     }
 };

--- a/tabs/cli.js
+++ b/tabs/cli.js
@@ -55,7 +55,7 @@ TABS.cli.initialize = function (callback) {
         // give input element user focus
         textarea.focus();
 
-        GUI.timeout_add('enter_cli', function enter_cli() {
+        helper.timeout.add('enter_cli', function enter_cli() {
             // Enter CLI mode
             var bufferOut = new ArrayBuffer(1);
             var bufView = new Uint8Array(bufferOut);
@@ -88,7 +88,7 @@ TABS.cli.history.next = function () {
 };
 
 TABS.cli.sendSlowly = function (out_arr, i, timeout_needle) {
-    GUI.timeout_add('CLI_send_slowly', function () {
+    helper.timeout.add('CLI_send_slowly', function () {
         var bufferOut = new ArrayBuffer(out_arr[i].length + 1);
         var bufView = new Uint8Array(bufferOut);
 
@@ -202,7 +202,7 @@ TABS.cli.cleanup = function (callback) {
         // (another approach is however much more complicated):
         // we can setup an interval asking for data lets say every 200ms, when data arrives, callback will be triggered and tab switched
         // we could probably implement this someday
-        GUI.timeout_add('waiting_for_bootup', function waiting_for_bootup() {
+        helper.timeout.add('waiting_for_bootup', function waiting_for_bootup() {
             if (callback) callback();
         }, 1000); // if we dont allow enough time to reboot, CRC of "first" command sent will fail, keep an eye for this one
         CONFIGURATOR.cliActive = false;

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -632,9 +632,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             saveChainer.execute();
         });
 
-        // status data pulled via separate timer with static speed
-        helper.task.statusPullStart();
-
         helper.interval.add('config_load_analog', function () {
             $('#batteryvoltage').val([ANALOG.voltage.toFixed(1)]);
             $('#batterycurrent').val([ANALOG.amperage.toFixed(2)]);

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -633,13 +633,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         });
 
         // status data pulled via separate timer with static speed
-        helper.interval.add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-            
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-        }, 250, true);
+        helper.task.statusPullStart();
+
         helper.interval.add('config_load_analog', function () {
             MSP.send_message(MSPCodes.MSP_ANALOG, false, false, function () {
                 $('#batteryvoltage').val([ANALOG.voltage.toFixed(1)]);

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -636,11 +636,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         helper.task.statusPullStart();
 
         helper.interval.add('config_load_analog', function () {
-            MSP.send_message(MSPCodes.MSP_ANALOG, false, false, function () {
-                $('#batteryvoltage').val([ANALOG.voltage.toFixed(1)]);
-                $('#batterycurrent').val([ANALOG.amperage.toFixed(2)]);
-            });
-        }, 250, true); // 4 fps
+            $('#batteryvoltage').val([ANALOG.voltage.toFixed(1)]);
+            $('#batterycurrent').val([ANALOG.amperage.toFixed(2)]);
+        }, 100, true); // 10 fps
         GUI.content_ready(callback);
     }
 };

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -633,14 +633,14 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         });
 
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
+        helper.interval.add('status_pull', function status_pull() {
             MSP.send_message(MSPCodes.MSP_STATUS);
             
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
                 MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
             }
         }, 250, true);
-        GUI.interval_add('config_load_analog', function () {
+        helper.interval.add('config_load_analog', function () {
             MSP.send_message(MSPCodes.MSP_ANALOG, false, false, function () {
                 $('#batteryvoltage').val([ANALOG.voltage.toFixed(1)]);
                 $('#batterycurrent').val([ANALOG.amperage.toFixed(2)]);

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -23,8 +23,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         mspHelper.loadSensorAlignment,
         mspHelper.loadAdvancedConfig,
         mspHelper.loadINAVPidConfig,
-        mspHelper.loadSensorConfig,
-        mspHelper.loadAccTrim
+        mspHelper.loadSensorConfig
     ]);
     loadChainer.setExitPoint(load_html);
     loadChainer.execute();

--- a/tabs/failsafe.js
+++ b/tabs/failsafe.js
@@ -358,8 +358,6 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             }
         });
 
-        helper.task.statusPullStart();
-
         GUI.content_ready(callback);
     }
 };

--- a/tabs/failsafe.js
+++ b/tabs/failsafe.js
@@ -359,7 +359,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         });
 
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
+        helper.interval.add('status_pull', function status_pull() {
             MSP.send_message(MSPCodes.MSP_STATUS);
             
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {

--- a/tabs/failsafe.js
+++ b/tabs/failsafe.js
@@ -358,14 +358,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             }
         });
 
-        // status data pulled via separate timer with static speed
-        helper.interval.add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-            
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-        }, 250, true);
+        helper.task.statusPullStart();
 
         GUI.content_ready(callback);
     }

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -513,7 +513,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                                 console.log('Detected: ' + port + ' - triggering flash on connect');
 
                                 // Trigger regular Flashing sequence
-                                GUI.timeout_add('initialization_timeout', function () {
+                                helper.timeout.add('initialization_timeout', function () {
                                     $('a.flash_firmware').click();
                                 }, 100); // timeout so bus have time to initialize after being detected by the system
                             } else {

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -102,7 +102,7 @@ TABS.gps.initialize = function (callback) {
         }
 
         // enable data pulling
-        GUI.interval_add('gps_pull', function gps_update() {
+        helper.interval.add('gps_pull', function gps_update() {
             // avoid usage of the GPS commands until a GPS sensor is detected for targets that are compiled without GPS support.
             if (!have_sensor(CONFIG.activeSensors, 'gps')) {
                 //return;
@@ -112,7 +112,7 @@ TABS.gps.initialize = function (callback) {
         }, 75, true);
 
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
+        helper.interval.add('status_pull', function status_pull() {
             MSP.send_message(MSPCodes.MSP_STATUS);
             
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -111,15 +111,7 @@ TABS.gps.initialize = function (callback) {
             get_raw_gps_data();
         }, 75, true);
 
-        // status data pulled via separate timer with static speed
-        helper.interval.add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-            
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-        }, 250, true);
-
+        helper.task.statusPullStart();
 
         //check for internet connection on load
         if (navigator.onLine) {

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -13,7 +13,7 @@ TABS.gps.initialize = function (callback) {
         $('#content').load("./tabs/gps.html", process_html);
     }
 
-    MSP.send_message(MSPCodes.MSP_STATUS, false, false, load_html);
+    load_html();
     
     function set_online(){
         $('#connect').hide();
@@ -110,8 +110,6 @@ TABS.gps.initialize = function (callback) {
             
             get_raw_gps_data();
         }, 75, true);
-
-        helper.task.statusPullStart();
 
         //check for internet connection on load
         if (navigator.onLine) {

--- a/tabs/logging.js
+++ b/tabs/logging.js
@@ -87,7 +87,7 @@ TABS.logging.initialize = function (callback) {
                             GUI.log(chrome.i18n.getMessage('loggingErrorOneProperty'));
                         }
                     } else {
-                        helper.interval.killAll();
+                        helper.interval.killAll(['global_data_refresh']);
 
                         $('.speed').prop('disabled', false);
                         $(this).text(chrome.i18n.getMessage('loggingStart'));

--- a/tabs/logging.js
+++ b/tabs/logging.js
@@ -65,8 +65,8 @@ TABS.logging.initialize = function (callback) {
                                 }
                             }
 
-                            GUI.interval_add('log_data_poll', log_data_poll, parseInt($('select.speed').val()), true); // refresh rate goes here
-                            GUI.interval_add('write_data', function write_data() {
+                            helper.interval.add('log_data_poll', log_data_poll, parseInt($('select.speed').val()), true); // refresh rate goes here
+                            helper.interval.add('write_data', function write_data() {
                                 if (log_buffer.length) { // only execute when there is actual data to write
                                     if (fileWriter.readyState == 0 || fileWriter.readyState == 2) {
                                         append_to_file(log_buffer.join('\n'));
@@ -87,7 +87,7 @@ TABS.logging.initialize = function (callback) {
                             GUI.log(chrome.i18n.getMessage('loggingErrorOneProperty'));
                         }
                     } else {
-                        GUI.interval_kill_all();
+                        helper.interval.killAll();
 
                         $('.speed').prop('disabled', false);
                         $(this).text(chrome.i18n.getMessage('loggingStart'));

--- a/tabs/modes.js
+++ b/tabs/modes.js
@@ -142,10 +142,10 @@ TABS.modes.initialize = function (callback) {
         update_ui();
 
         // enable data pulling
-        GUI.interval_add('aux_data_pull', get_rc_data, 50);
+        helper.interval.add('aux_data_pull', get_rc_data, 50);
 
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
+        helper.interval.add('status_pull', function status_pull() {
             MSP.send_message(MSPCodes.MSP_STATUS);
             
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {

--- a/tabs/modes.js
+++ b/tabs/modes.js
@@ -144,14 +144,7 @@ TABS.modes.initialize = function (callback) {
         // enable data pulling
         helper.interval.add('aux_data_pull', get_rc_data, 50);
 
-        // status data pulled via separate timer with static speed
-        helper.interval.add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-            
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-        }, 250, true);
+        helper.task.statusPullStart();
 
         GUI.content_ready(callback);
     }

--- a/tabs/modes.js
+++ b/tabs/modes.js
@@ -144,8 +144,6 @@ TABS.modes.initialize = function (callback) {
         // enable data pulling
         helper.interval.add('aux_data_pull', get_rc_data, 50);
 
-        helper.task.statusPullStart();
-
         GUI.content_ready(callback);
     }
 };

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -239,9 +239,9 @@ TABS.motors.initialize = function (callback) {
             accelHelpers = initGraphHelpers('#accel', samples_accel_i, [-scale, scale]);
 
             // timer initialization
-            GUI.interval_kill_all(['motor_and_status_pull']);
+            helper.interval.killAll(['motor_and_status_pull']);
 
-            GUI.interval_add('IMU_pull', function imu_data_pull() {
+            helper.interval.add('IMU_pull', function imu_data_pull() {
                 MSP.send_message(MSPCodes.MSP_RAW_IMU, false, false, update_accel_graph);
             }, rate, true);
 
@@ -519,7 +519,7 @@ TABS.motors.initialize = function (callback) {
         }
 
         // enable Status and Motor data pulling
-        GUI.interval_add('motor_and_status_pull', periodicUpdateHandler, 75, true);
+        helper.interval.add('motor_and_status_pull', periodicUpdateHandler, 75, true);
 
         GUI.content_ready(callback);
     }

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -235,7 +235,7 @@ TABS.motors.initialize = function (callback) {
             accelHelpers = initGraphHelpers('#accel', samples_accel_i, [-scale, scale]);
 
             // timer initialization
-            helper.interval.killAll(['motor_and_status_pull']);
+            helper.interval.killAll(['motor_and_status_pull', 'global_data_refresh']);
 
             helper.interval.add('IMU_pull', function imu_data_pull() {
                 MSP.send_message(MSPCodes.MSP_RAW_IMU, false, false, update_accel_graph);

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -19,10 +19,6 @@ TABS.motors.initialize = function (callback) {
         googleAnalytics.sendAppView('Motors');
     }
 
-    function get_arm_status() {
-        MSP.send_message(MSPCodes.MSP_STATUS, false, false, load_config);
-    }
-    
     function load_config() {
         MSP.send_message(MSPCodes.MSP_BF_CONFIG, false, false, load_3d);
     }
@@ -40,7 +36,7 @@ TABS.motors.initialize = function (callback) {
         $('#content').load("./tabs/motors.html", process_html);
     }
 
-    MSP.send_message(MSPCodes.MSP_MISC, false, false, get_arm_status);
+    MSP.send_message(MSPCodes.MSP_MISC, false, false, load_config);
 
     function update_arm_status() {
         self.armed = bit_check(CONFIG.mode, 0);
@@ -448,23 +444,6 @@ TABS.motors.initialize = function (callback) {
 
         $motorsEnableTestMode.change();
         
-        // data pulling functions used inside interval timer
-        
-        function periodicUpdateHandler() {
-
-            MSP.send_message(MSPCodes.MSP_STATUS);
-
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                getPeriodicSensorStatus();
-            } else {
-                getPeriodicMotorOutput();
-            }
-        }
-        
-        function getPeriodicSensorStatus() {
-            MSP.send_message(MSPCodes.MSP_SENSOR_STATUS, false, false, getPeriodicMotorOutput);
-        }
-
         function getPeriodicMotorOutput() {
             MSP.send_message(MSPCodes.MSP_MOTOR, false, false, getPeriodicServoOutput);
         }
@@ -475,7 +454,7 @@ TABS.motors.initialize = function (callback) {
 
         var full_block_scale = MISC.maxthrottle - MISC.mincommand;
         
-        function update_ui() {            
+        function update_ui() {
             var previousArmState = self.armed;                                   
             var block_height = $('div.m-block:first').height();
 
@@ -519,7 +498,7 @@ TABS.motors.initialize = function (callback) {
         }
 
         // enable Status and Motor data pulling
-        helper.interval.add('motor_and_status_pull', periodicUpdateHandler, 75, true);
+        helper.interval.add('motor_and_status_pull', getPeriodicMotorOutput, 75, true);
 
         GUI.content_ready(callback);
     }

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -10,7 +10,6 @@ TABS.pid_tuning.initialize = function (callback) {
     var loadChainer = new MSPChainerClass();
 
     loadChainer.setChain([
-        mspHelper.loadStatus,
         mspHelper.loadPidNames,
         mspHelper.loadPidData,
         mspHelper.loadRcTuningData,
@@ -288,8 +287,6 @@ TABS.pid_tuning.initialize = function (callback) {
 
             send_pids();
         });
-
-        helper.task.statusPullStart();
 
         GUI.content_ready(callback);
     }

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -290,7 +290,7 @@ TABS.pid_tuning.initialize = function (callback) {
         });
 
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
+        helper.interval.add('status_pull', function status_pull() {
             MSP.send_message(MSPCodes.MSP_STATUS);
         }, 250, true);
 

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -289,10 +289,7 @@ TABS.pid_tuning.initialize = function (callback) {
             send_pids();
         });
 
-        // status data pulled via separate timer with static speed
-        helper.interval.add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-        }, 250, true);
+        helper.task.statusPullStart();
 
         GUI.content_ready(callback);
     }

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -222,7 +222,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         $('a.save').click(on_save_handler);
 
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
+        helper.interval.add('status_pull', function status_pull() {
             MSP.send_message(MSPCodes.MSP_STATUS);
 
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -221,14 +221,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
 
         $('a.save').click(on_save_handler);
 
-        // status data pulled via separate timer with static speed
-        helper.interval.add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-        }, 250, true);
+        helper.task.statusPullStart();
 
         GUI.content_ready(callback);
     }

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -221,8 +221,6 @@ TABS.ports.initialize = function (callback, scrollPosition) {
 
         $('a.save').click(on_save_handler);
 
-        helper.task.statusPullStart();
-
         GUI.content_ready(callback);
     }
 

--- a/tabs/profiles.js
+++ b/tabs/profiles.js
@@ -368,7 +368,7 @@ TABS.profiles.initialize = function (callback, scrollPosition) {
             content: $('#presetApplyContent')
         });
 
-        GUI.interval_add('status_pull', function status_pull() {
+        helper.interval.add('status_pull', function status_pull() {
             MSP.send_message(MSPCodes.MSP_STATUS);
 
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {

--- a/tabs/profiles.js
+++ b/tabs/profiles.js
@@ -368,13 +368,7 @@ TABS.profiles.initialize = function (callback, scrollPosition) {
             content: $('#presetApplyContent')
         });
 
-        helper.interval.add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-        }, 250, true);
+        helper.task.statusPullStart();
         GUI.content_ready(callback);
     }
 };

--- a/tabs/profiles.js
+++ b/tabs/profiles.js
@@ -368,7 +368,6 @@ TABS.profiles.initialize = function (callback, scrollPosition) {
             content: $('#presetApplyContent')
         });
 
-        helper.task.statusPullStart();
         GUI.content_ready(callback);
     }
 };

--- a/tabs/receiver.js
+++ b/tabs/receiver.js
@@ -464,14 +464,14 @@ TABS.receiver.initialize = function (callback) {
             }
 
             // timer initialization
-            GUI.interval_remove('receiver_pull');
+            helper.interval.remove('receiver_pull');
 
             // enable RC data pulling
-            GUI.interval_add('receiver_pull', get_rc_data, plot_update_rate, true);
+            helper.interval.add('receiver_pull', get_rc_data, plot_update_rate, true);
         });
 
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
+        helper.interval.add('status_pull', function status_pull() {
             MSP.send_message(MSPCodes.MSP_STATUS);
 
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {

--- a/tabs/receiver.js
+++ b/tabs/receiver.js
@@ -470,15 +470,7 @@ TABS.receiver.initialize = function (callback) {
             helper.interval.add('receiver_pull', get_rc_data, plot_update_rate, true);
         });
 
-        // status data pulled via separate timer with static speed
-        helper.interval.add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-        }, 250, true);
-
+        helper.task.statusPullStart();
         GUI.content_ready(callback);
     }
 };

--- a/tabs/receiver.js
+++ b/tabs/receiver.js
@@ -470,7 +470,6 @@ TABS.receiver.initialize = function (callback) {
             helper.interval.add('receiver_pull', get_rc_data, plot_update_rate, true);
         });
 
-        helper.task.statusPullStart();
         GUI.content_ready(callback);
     }
 };

--- a/tabs/sensors.js
+++ b/tabs/sensors.js
@@ -443,8 +443,6 @@ TABS.sensors.initialize = function (callback) {
             }
         });
 
-        helper.task.statusPullStart();
-
         GUI.content_ready(callback);
     });
 };

--- a/tabs/sensors.js
+++ b/tabs/sensors.js
@@ -356,29 +356,29 @@ TABS.sensors.initialize = function (callback) {
             });
 
             // timer initialization
-            GUI.interval_kill_all(['status_pull']);
+            helper.interval.killAll(['status_pull']);
 
             // data pulling timers
             if (checkboxes[0] || checkboxes[1] || checkboxes[2]) {
-                GUI.interval_add('IMU_pull', function imu_data_pull() {
+                helper.interval.add('IMU_pull', function imu_data_pull() {
                     MSP.send_message(MSPCodes.MSP_RAW_IMU, false, false, update_imu_graphs);
                 }, fastest, true);
             }
 
             if (checkboxes[3]) {
-                GUI.interval_add('altitude_pull', function altitude_data_pull() {
+                helper.interval.add('altitude_pull', function altitude_data_pull() {
                     MSP.send_message(MSPCodes.MSP_ALTITUDE, false, false, update_altitude_graph);
                 }, rates.baro, true);
             }
 
             if (checkboxes[4]) {
-                GUI.interval_add('sonar_pull', function sonar_data_pull() {
+                helper.interval.add('sonar_pull', function sonar_data_pull() {
                     MSP.send_message(MSPCodes.MSP_SONAR, false, false, update_sonar_graphs);
                 }, rates.sonar, true);
             }
 
             if (checkboxes[5]) {
-                GUI.interval_add('debug_pull', function debug_data_pull() {
+                helper.interval.add('debug_pull', function debug_data_pull() {
                     MSP.send_message(MSPCodes.MSP_DEBUG, false, false, update_debug_graphs);
                 }, rates.debug, true);
             }
@@ -444,7 +444,7 @@ TABS.sensors.initialize = function (callback) {
         });
 
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
+        helper.interval.add('status_pull', function status_pull() {
             MSP.send_message(MSPCodes.MSP_STATUS);
 
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {

--- a/tabs/sensors.js
+++ b/tabs/sensors.js
@@ -356,7 +356,7 @@ TABS.sensors.initialize = function (callback) {
             });
 
             // timer initialization
-            helper.interval.killAll(['status_pull']);
+            helper.interval.killAll(['status_pull', 'global_data_refresh']);
 
             // data pulling timers
             if (checkboxes[0] || checkboxes[1] || checkboxes[2]) {

--- a/tabs/sensors.js
+++ b/tabs/sensors.js
@@ -443,14 +443,7 @@ TABS.sensors.initialize = function (callback) {
             }
         });
 
-        // status data pulled via separate timer with static speed
-        helper.interval.add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-        }, 250, true);
+        helper.task.statusPullStart();
 
         GUI.content_ready(callback);
     });

--- a/tabs/servos.js
+++ b/tabs/servos.js
@@ -171,7 +171,7 @@ TABS.servos.initialize = function (callback) {
         $('table.directions select, table.directions input, table.fields select, table.fields input').change(function () {
             if ($('div.live input').is(':checked')) {
                 // apply small delay as there seems to be some funky update business going wrong
-                GUI.timeout_add('servos_update', servos_update, 10);
+                helper.timeout.add('servos_update', servos_update, 10);
             }
         });
 
@@ -189,7 +189,7 @@ TABS.servos.initialize = function (callback) {
         localize();
 
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function () {
+        helper.interval.add('status_pull', function () {
             MSP.send_message(MSPCodes.MSP_STATUS);
 
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {

--- a/tabs/servos.js
+++ b/tabs/servos.js
@@ -188,14 +188,7 @@ TABS.servos.initialize = function (callback) {
         // translate to user-selected language
         localize();
 
-        // status data pulled via separate timer with static speed
-        helper.interval.add('status_pull', function () {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-        }, 250, true);
+        helper.task.statusPullStart();
 
         GUI.content_ready(callback);
     }

--- a/tabs/servos.js
+++ b/tabs/servos.js
@@ -188,8 +188,6 @@ TABS.servos.initialize = function (callback) {
         // translate to user-selected language
         localize();
 
-        helper.task.statusPullStart();
-
         GUI.content_ready(callback);
     }
 };

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -175,14 +175,6 @@ TABS.setup.initialize = function (callback) {
                 MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
             }
 
-            //TODO ah man.... compare with update_live_status from serial_backend.js
-            MSP.send_message(MSPCodes.MSP_ANALOG, false, false, function () {
-                bat_voltage_e.text(chrome.i18n.getMessage('initialSetupBatteryValue', [ANALOG.voltage]));
-                bat_mah_drawn_e.text(chrome.i18n.getMessage('initialSetupBatteryMahValue', [ANALOG.mAhdrawn]));
-                bat_mah_drawing_e.text(chrome.i18n.getMessage('initialSetupBatteryAValue', [ANALOG.amperage.toFixed(2)]));
-                rssi_e.text(chrome.i18n.getMessage('initialSetupRSSIValue', [((ANALOG.rssi / 1023) * 100).toFixed(0)]));
-            });
-
             if (have_sensor(CONFIG.activeSensors, 'gps')) {
                 MSP.send_message(MSPCodes.MSP_RAW_GPS, false, false, function () {
                     var gpsFixType = chrome.i18n.getMessage('gpsFixNone');
@@ -210,6 +202,12 @@ TABS.setup.initialize = function (callback) {
 
         helper.interval.add('setup_data_pull_fast', get_fast_data, 33, true); // 30 fps
         helper.interval.add('setup_data_pull_slow', get_slow_data, 250, true); // 4 fps
+        helper.interval.add('gui_analog_update', function () {
+                bat_voltage_e.text(chrome.i18n.getMessage('initialSetupBatteryValue', [ANALOG.voltage]));
+                bat_mah_drawn_e.text(chrome.i18n.getMessage('initialSetupBatteryMahValue', [ANALOG.mAhdrawn]));
+                bat_mah_drawing_e.text(chrome.i18n.getMessage('initialSetupBatteryAValue', [ANALOG.amperage.toFixed(2)]));
+                rssi_e.text(chrome.i18n.getMessage('initialSetupRSSIValue', [((ANALOG.rssi / 1023) * 100).toFixed(0)]));
+        }, 100, true);
 
         function updateArminFailure() {
             var flagNames = FC.getArmingFlags();

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -70,15 +70,16 @@ TABS.setup.initialize = function (callback) {
 
                 // During this period MCU won't be able to process any serial commands because its locked in a for/while loop
                 // until this operation finishes, sending more commands through data_poll() will result in serial buffer overflow
-                GUI.interval_pause('setup_data_pull');
+                helper.interval.pause('setup_data_pull');
+
                 MSP.send_message(MSPCodes.MSP_ACC_CALIBRATION, false, false, function () {
                     GUI.log(chrome.i18n.getMessage('initialSetupAccelCalibStarted'));
                     $('#accel_calib_running').show();
                     $('#accel_calib_rest').hide();
                 });
 
-                GUI.timeout_add('button_reset', function () {
-                    GUI.interval_resume('setup_data_pull');
+                helper.timeout.add('button_reset', function () {
+                    helper.interval.resume('setup_data_pull');
 
                     GUI.log(chrome.i18n.getMessage('initialSetupAccelCalibEnded'));
 
@@ -101,7 +102,7 @@ TABS.setup.initialize = function (callback) {
                     $('#mag_calib_rest').hide();
                 });
 
-                GUI.timeout_add('button_reset', function () {
+                helper.timeout.add('button_reset', function () {
                     GUI.log(chrome.i18n.getMessage('initialSetupMagCalibEnded'));
                     self.removeClass('calibrating');
                     $('#mag_calib_running').hide();
@@ -206,8 +207,8 @@ TABS.setup.initialize = function (callback) {
             });
         }
 
-        GUI.interval_add('setup_data_pull_fast', get_fast_data, 33, true); // 30 fps
-        GUI.interval_add('setup_data_pull_slow', get_slow_data, 250, true); // 4 fps
+        helper.interval.add('setup_data_pull_fast', get_fast_data, 33, true); // 30 fps
+        helper.interval.add('setup_data_pull_slow', get_slow_data, 250, true); // 4 fps
 
         function updateArminFailure() {
             var flagNames = FC.getArmingFlags();
@@ -226,7 +227,7 @@ TABS.setup.initialize = function (callback) {
         /*
          * 1fps update rate will be fully enough
          */
-        GUI.interval_add('updateArminFailure', updateArminFailure, 500, true);
+        helper.interval.add('updateArminFailure', updateArminFailure, 500, true);
 
         GUI.content_ready(callback);
     }

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -175,6 +175,7 @@ TABS.setup.initialize = function (callback) {
                 MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
             }
 
+            //TODO ah man.... compare with update_live_status from serial_backend.js
             MSP.send_message(MSPCodes.MSP_ANALOG, false, false, function () {
                 bat_voltage_e.text(chrome.i18n.getMessage('initialSetupBatteryValue', [ANALOG.voltage]));
                 bat_mah_drawn_e.text(chrome.i18n.getMessage('initialSetupBatteryMahValue', [ANALOG.mAhdrawn]));

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -168,10 +168,6 @@ TABS.setup.initialize = function (callback) {
             heading_e = $('dd.heading');
 
         function get_slow_data() {
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-
             if (have_sensor(CONFIG.activeSensors, 'gps')) {
                 MSP.send_message(MSPCodes.MSP_RAW_GPS, false, false, function () {
                     var gpsFixType = chrome.i18n.getMessage('gpsFixNone');
@@ -197,7 +193,7 @@ TABS.setup.initialize = function (callback) {
             });
         }
 
-        helper.interval.add('setup_data_pull_fast', get_fast_data, 33, true); // 30 fps
+        helper.interval.add('setup_data_pull_fast', get_fast_data, 40, true); // 25 fps
         helper.interval.add('setup_data_pull_slow', get_slow_data, 250, true); // 4 fps
         helper.interval.add('gui_analog_update', function () {
                 bat_voltage_e.text(chrome.i18n.getMessage('initialSetupBatteryValue', [ANALOG.voltage]));

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -16,7 +16,6 @@ TABS.setup.initialize = function (callback) {
     var loadChainer = new MSPChainerClass();
 
     loadChainer.setChain([
-        mspHelper.loadStatus,
         mspHelper.loadMspIdent,
         mspHelper.loadBfConfig,
         mspHelper.loadMisc
@@ -169,8 +168,6 @@ TABS.setup.initialize = function (callback) {
             heading_e = $('dd.heading');
 
         function get_slow_data() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
                 MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
             }

--- a/tabs/transponder.js
+++ b/tabs/transponder.js
@@ -92,8 +92,6 @@ TABS.transponder.initialize = function (callback, scrollPosition) {
             });
         }
 
-        helper.task.statusPullStart();
-
         GUI.content_ready(callback);
     }
 };

--- a/tabs/transponder.js
+++ b/tabs/transponder.js
@@ -91,14 +91,8 @@ TABS.transponder.initialize = function (callback, scrollPosition) {
                 save_transponder_config();
             });
         }
-        // status data pulled via separate timer with static speed
-        helper.interval.add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
 
-            if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {
-                MSP.send_message(MSPCodes.MSP_SENSOR_STATUS);
-            }
-        }, 250, true);
+        helper.task.statusPullStart();
 
         GUI.content_ready(callback);
     }

--- a/tabs/transponder.js
+++ b/tabs/transponder.js
@@ -92,7 +92,7 @@ TABS.transponder.initialize = function (callback, scrollPosition) {
             });
         }
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
+        helper.interval.add('status_pull', function status_pull() {
             MSP.send_message(MSPCodes.MSP_STATUS);
 
             if (semver.gte(CONFIG.flightControllerVersion, "1.5.0")) {


### PR DESCRIPTION
Like usual, small refactoring ended up in fixing different kinds of things.
Bottom line is: after this update, Configurator have a common status poller initialized only once and not "per tab".

MSP_STATUS is called only on firmware versions that does not support MSP_STATUS_EX.
Also, MSP_STATUS has been marked as deprecated.

Status polling interval depends now on serial connection speed and gets lowered to 1.3Hz on baud rate 9600 and slower. Let's call it a first step closer to real GroundStation . 
The same goes for msp timeout. It is increased as bps goes down.

There is a quite big chance I messed something up and something is not working anymore. @oleost @digitalentity @stronnag @martinbudden @marbalon @skaman82 all kinds of testing are appreciated. Even quick click-through