### PR TITLE
backend of pidSumLimit

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -252,7 +252,8 @@ var FC = {
             yawPLimit: null,
             axisAccelerationLimitRollPitch: null,
             axisAccelerationLimitYaw: null,
-            dtermSetpointWeight: null
+            dtermSetpointWeight: null,
+            pidSumLimit: null
         };
 
         INAV_PID_CONFIG = {

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -846,6 +846,7 @@ var mspHelper = (function (gui) {
 
                 if (semver.gte(CONFIG.flightControllerVersion, "1.6.0")) {
                     PID_ADVANCED.dtermSetpointWeight = data.getUint8(9);
+                    PID_ADVANCED.pidSumLimit = data.getUint16(10, true);
                 }
 
                 PID_ADVANCED.axisAccelerationLimitRollPitch = data.getUint16(13, true);
@@ -1262,12 +1263,14 @@ var mspHelper = (function (gui) {
 
                 if (semver.gte(CONFIG.flightControllerVersion, "1.6.0")) {
                     buffer.push(PID_ADVANCED.dtermSetpointWeight);
+                    buffer.push(lowByte(PID_ADVANCED.pidSumLimit));
+                    buffer.push(highByte(PID_ADVANCED.pidSumLimit));
                 } else {
                     buffer.push(0);
+                    buffer.push(0); // reserved
+                    buffer.push(0); // reserved
                 }
 
-                buffer.push(0); // reserved
-                buffer.push(0); // reserved
                 buffer.push(0); //BF: currentProfile->pidProfile.itermThrottleGain
 
                 buffer.push(lowByte(PID_ADVANCED.axisAccelerationLimitRollPitch));


### PR DESCRIPTION
@digitalentity fix that should preserve pidSumLimit in configurator and not zero it.
I'm unable to test, do not have an FC on me. Please test and check if PID_ADVANCED variable is initiated with value from FC and it is not zeroed after saving (any profile or PID Tuning change)