### PR TITLE
Add support for FEATURE_AIRMODE in the Configuration tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -566,6 +566,9 @@
     "featureOSD": {
         "message": "OSD"
     },
+    "featureAIRMODE": {
+        "message": "Permanently enable AIRMODE"
+    },
     "configurationFeatureEnabled": {
         "message": "Enabled"
     },

--- a/build/script.js
+++ b/build/script.js
@@ -11397,6 +11397,12 @@ var FC = {
             );
         }
 
+        if (semver.gte(CONFIG.flightControllerVersion, '1.7.3')) {
+            features.push(
+                {bit: 22, group: 'other', name: 'AIRMODE', haveTip: false, showNameInTip: false}
+            );
+        }
+
         return features.reverse();
     },
     isFeatureEnabled: function (featureName, features) {

--- a/js/fc.js
+++ b/js/fc.js
@@ -461,6 +461,12 @@ var FC = {
             );
         }
 
+        if (semver.gte(CONFIG.flightControllerVersion, '1.7.3')) {
+            features.push(
+                {bit: 22, group: 'other', name: 'AIRMODE', haveTip: false, showNameInTip: false}
+            );
+        }
+
         return features.reverse();
     },
     isFeatureEnabled: function (featureName, features) {


### PR DESCRIPTION
Setting the feature also hides the mode from the modes tab, since
the FC won't register the BOXID as an active one. FC support
detection is based on INAV version >= 1.7.3, since support for
the AIRMODE feature has been advertised by previous releases
but it's not really supported (it does nothing).

Support for INAV is at https://github.com/iNavFlight/inav/pull/1949

Fixes #154