### PR TITLE
Set MOTOR_STOP and AIRMODE features in all FW presets

### DIFF
--- a/build/script.js
+++ b/build/script.js
@@ -21444,6 +21444,15 @@ presets.model = (function () {
 
             }
         }
+        if (mixerType == 'airplane' || mixerType == 'flyingwing') {
+            // Always set MOTOR_STOP and feature AIRMODE for fixed wing
+            window.BF_CONFIG.features |= 1 << 4; // MOTOR_STOP
+            if (semver.gt(CONFIG.flightControllerVersion, '1.7.2')) {
+                // Note that feature_AIRMODE is only supported on
+                // INAV > 1.7.2.
+                window.BF_CONFIG.features |= 1 << 22; // AIRMODE
+            }
+        }
     };
 
     self.extractPresetNames = function (presets) {

--- a/tabs/profiles.js
+++ b/tabs/profiles.js
@@ -406,6 +406,15 @@ presets.model = (function () {
 
             }
         }
+        if (mixerType == 'airplane' || mixerType == 'flyingwing') {
+            // Always set MOTOR_STOP and feature AIRMODE for fixed wing
+            window.BF_CONFIG.features |= 1 << 4; // MOTOR_STOP
+            if (semver.gt(CONFIG.flightControllerVersion, '1.7.2')) {
+                // Note that feature_AIRMODE is only supported on
+                // INAV > 1.7.2.
+                window.BF_CONFIG.features |= 1 << 22; // AIRMODE
+            }
+        }
     };
 
     self.extractPresetNames = function (presets) {


### PR DESCRIPTION
AIRMODE will only be set if INAV version is > 1.7.2, since it
does nothing in previous versions even when the feature is
advertised.