### PR TITLE
Ignore OSD items unknown by the FC in the OSD tab

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -500,6 +500,11 @@ OSD.get_item = function(item_id) {
 };
 
 OSD.is_item_displayed = function(item, group) {
+    if (!OSD.data.items[item.id]) {
+        // FC has no data about this item, so
+        // it doesn't support it.
+        return false;
+    }
     if (FC.getOsdDisabledFields().indexOf(item.name) != -1) {
         return false;
     }


### PR DESCRIPTION
Otherwise configuring the OSD of an INAV version older than the
configurator will cause errors.