### PR TITLE
Fix disabled calibrate mag button

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1957,6 +1957,10 @@ var mspHelper = (function (gui) {
         MSP.send_message(MSPCodes.MSP_BF_CONFIG, false, false, callback);
     };
 
+    self.quaryFcStatus = function (callback) {
+        MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false, callback);
+    };
+
     self.loadMisc = function (callback) {
         MSP.send_message(MSPCodes.MSP_MISC, false, false, callback);
     };

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1957,7 +1957,7 @@ var mspHelper = (function (gui) {
         MSP.send_message(MSPCodes.MSP_BF_CONFIG, false, false, callback);
     };
 
-    self.quaryFcStatus = function (callback) {
+    self.queryFcStatus = function (callback) {
         MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false, callback);
     };
 

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -17,7 +17,8 @@ TABS.setup.initialize = function (callback) {
 
     loadChainer.setChain([
         mspHelper.loadBfConfig,
-        mspHelper.loadMisc
+        mspHelper.loadMisc,
+        mspHelper.quaryFcStatus
     ]);
     loadChainer.setExitPoint(load_html);
     loadChainer.execute();

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -18,7 +18,7 @@ TABS.setup.initialize = function (callback) {
     loadChainer.setChain([
         mspHelper.loadBfConfig,
         mspHelper.loadMisc,
-        mspHelper.quaryFcStatus
+        mspHelper.queryFcStatus
     ]);
     loadChainer.setExitPoint(load_html);
     loadChainer.execute();


### PR DESCRIPTION
Looks like we have a possible race condition in Setup tab code between `periodicStatusUpdater` and `TABS.setup.initialize`. 

On connect `CONFIG.activeSensors` is zero. If `TABS.setup.initialize` calls `process_html` before `periodicStatusUpdater` polls for sensor status "Calibrate magnetometer" button will be disabled.

This PR queries for `MSP_STATUS_EX` message explicitly.

Should resolve #245, #162