### PR TITLE
Add support for the RX changes in MSP

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -464,7 +464,7 @@
     "RX_SERIAL": {
         "message": "Serial-based receiver (SPEKSAT, SBUS, SUMD)"
     },
-    "RX_PARALLEL_PWM": {
+    "RX_PWM": {
         "message": "PWM RX input (one wire per channel)"
     },
     "RX_MSP": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -458,17 +458,30 @@
         "message": "EEPROM <span style=\"color: #37a8db\">saved</span>"
     },
 
-    "featureRX_PPM": {
+    "RX_PPM": {
         "message": "PPM RX input"
     },
+    "RX_SERIAL": {
+        "message": "Serial-based receiver (SPEKSAT, SBUS, SUMD)"
+    },
+    "RX_PARALLEL_PWM": {
+        "message": "PWM RX input (one wire per channel)"
+    },
+    "RX_MSP": {
+        "message": "MSP RX input (control via MSP port)"
+    },
+    "RX_NRF24": {
+        "message": "RX SPI based receiver (NRF24L01, RFM22)"
+    },
+    "RX_NONE": {
+        "message": "No receiver"
+    },
+
     "featureVBAT": {
         "message": "Battery voltage monitoring"
     },
     "featureINFLIGHT_ACC_CAL": {
         "message": "In-flight level calibration"
-    },
-    "featureRX_SERIAL": {
-        "message": "Serial-based receiver (SPEKSAT, SBUS, SUMD)"
     },
     "featureMOTOR_STOP": {
         "message": "Don't spin the motors when armed"
@@ -502,12 +515,6 @@
     },
     "feature3D": {
         "message": "3D mode (for use with reversible ESCs)"
-    },
-    "featureRX_PARALLEL_PWM": {
-        "message": "PWM RX input (one wire per channel)"
-    },
-    "featureRX_MSP": {
-        "message": "MSP RX input (control via MSP port)"
     },
     "featureRSSI_ADC": {
         "message": "Analog RSSI input"
@@ -544,12 +551,6 @@
     },
     "featureTRANSPONDERTip": {
         "message": "Configure via the Race Transponder tab after enabling."
-    },
-    "featureRX_NRF24": {
-        "message": "RX SPI based receiver (NRF24L01, RFM22)"
-    },
-    "featureRX_NRF24Tip": {
-        "message": "Remember to set the RX SPI protocol after enabling."
     },
     "featureSOFTSPI": {
         "message": "CPU based SPI"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -470,7 +470,7 @@
     "RX_MSP": {
         "message": "MSP RX input (control via MSP port)"
     },
-    "RX_NRF24": {
+    "RX_SPI": {
         "message": "RX SPI based receiver (NRF24L01, RFM22)"
     },
     "RX_NONE": {
@@ -729,7 +729,7 @@
     "configurationSerialRX": {
         "message": "Serial Receiver Provider"
     },
-    "configurationNrf24Protocol": {
+    "configurationSPIProtocol": {
         "message": "RX SPI protocol"
     },
     "configurationEepromSaved": {

--- a/js/fc.js
+++ b/js/fc.js
@@ -355,8 +355,9 @@ var FC = {
             spektrum_sat_bind: 0,
             rx_min_usec: 0,
             rx_max_usec: 0,
-            nrf24rx_protocol: 0,
-            nrf24rx_id: 0
+            spirx_protocol: 0,
+            spirx_id: 0,
+            spirx_channel_count: 0,
         };
 
         POSITION_ESTIMATOR = {
@@ -627,7 +628,7 @@ var FC = {
         if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
             rxTypes.push(
                 {
-                    name: 'RX_NRF24',
+                    name: 'RX_SPI',
                     bit: 25,
                     value: 5,
                 },
@@ -681,7 +682,7 @@ var FC = {
 
         return data;
     },
-    getNrf24ProtocolTypes: function () {
+    getSPIProtocolTypes: function () {
         return [
             'V202 250Kbps',
             'V202 1Mbps',

--- a/js/fc.js
+++ b/js/fc.js
@@ -347,6 +347,7 @@ var FC = {
         };
 
         RX_CONFIG = {
+            receiver_type: 0,
             serialrx_provider: 0,
             maxcheck: 0,
             midrc: 0,
@@ -392,9 +393,7 @@ var FC = {
     },
     getFeatures: function () {
         var features = [
-            {bit: 0, group: 'rxMode', mode: 'group', name: 'RX_PPM'},
             {bit: 1, group: 'batteryVoltage', name: 'VBAT'},
-            {bit: 3, group: 'rxMode', mode: 'group', name: 'RX_SERIAL'},
             {bit: 4, group: 'esc', name: 'MOTOR_STOP'},
             {bit: 5, group: 'other', name: 'SERVO_TILT', showNameInTip: true},
             {bit: 6, group: 'other', name: 'SOFTSERIAL', haveTip: true, showNameInTip: true},
@@ -402,8 +401,6 @@ var FC = {
             {bit: 10, group: 'other', name: 'TELEMETRY', showNameInTip: true},
             {bit: 11, group: 'batteryCurrent', name: 'CURRENT_METER'},
             {bit: 12, group: 'other', name: '3D', showNameInTip: true},
-            {bit: 13, group: 'rxMode', mode: 'group', name: 'RX_PARALLEL_PWM'},
-            {bit: 14, group: 'rxMode', mode: 'group', name: 'RX_MSP'},
             {bit: 15, group: 'other', name: 'RSSI_ADC', haveTip: true, showNameInTip: true},
             {bit: 16, group: 'other', name: 'LED_STRIP', showNameInTip: true},
             {bit: 17, group: 'other', name: 'DISPLAY', showNameInTip: true},
@@ -444,7 +441,6 @@ var FC = {
 
         if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
             features.push(
-                {bit: 25, group: 'rxMode', mode: 'group', name: 'RX_NRF24', haveTip: true},
                 {bit: 26, group: 'other', name: 'SOFTSPI'}
             );
         }
@@ -603,6 +599,68 @@ var FC = {
             'Indian GAGAN',
             'Disabled'
         ];
+    },
+    getRxTypes: function() {
+        // Keep value field in sync with rxReceiverType_e in rx.h
+        var rxTypes = [
+            {
+                name: 'RX_SERIAL',
+                bit: 3,
+                value: 3,
+            },
+            {
+                name: 'RX_PPM',
+                bit: 0,
+                value: 1,
+            },
+            {
+                name: 'RX_PARALLEL_PWM',
+                bit: 13,
+                value: 2,
+            },
+            {
+                name: 'RX_MSP',
+                bit: 14,
+                value: 4,
+            },
+        ];
+        if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
+            rxTypes.push(
+                {
+                    name: 'RX_NRF24',
+                    bit: 25,
+                    value: 5,
+                },
+            );
+        }
+        if (semver.gt(CONFIG.flightControllerVersion, "1.7.3")) {
+            rxTypes.push(
+                {
+                    name: 'RX_NONE',
+                    value: 0,
+                },
+            );
+        }
+        return rxTypes;
+    },
+    isRxTypeEnabled: function(rxType) {
+        if (semver.gt(CONFIG.flightControllerVersion, "1.7.3")) {
+            return RX_CONFIG.receiver_type == rxType.value;
+        }
+        return bit_check(BF_CONFIG.features, rxType.bit);
+    },
+    setRxTypeEnabled: function(rxType) {
+        if (semver.gt(CONFIG.flightControllerVersion, "1.7.3")) {
+            RX_CONFIG.receiver_type = rxType.value;
+        } else {
+            // Clear other rx features before
+            var rxTypes = this.getRxTypes();
+            for (var ii = 0; ii < rxTypes.length; ii++) {
+                BF_CONFIG.features = bit_clear(BF_CONFIG.features, rxTypes[ii].bit);
+            }
+            // Set the feature for this rx type
+            BF_CONFIG.features = bit_set(BF_CONFIG.features, rxType.bit);
+        }
     },
     getSerialRxTypes: function () {
         var data = [

--- a/js/fc.js
+++ b/js/fc.js
@@ -611,37 +611,35 @@ var FC = {
             },
             {
                 name: 'RX_PPM',
-                bit: 0,
-                value: 1,
-            },
-            {
-                name: 'RX_PARALLEL_PWM',
                 bit: 13,
                 value: 2,
             },
             {
-                name: 'RX_MSP',
-                bit: 14,
-                value: 4,
+                name: 'RX_PWM',
+                bit: 0,
+                value: 1,
             },
         ];
+
         if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
-            rxTypes.push(
-                {
-                    name: 'RX_SPI',
-                    bit: 25,
-                    value: 5,
-                },
-            );
+            rxTypes.push({
+                name: 'RX_SPI',
+                bit: 25,
+                value: 5,
+            });
         }
-        if (semver.gt(CONFIG.flightControllerVersion, "1.7.3")) {
-            rxTypes.push(
-                {
-                    name: 'RX_NONE',
-                    value: 0,
-                },
-            );
-        }
+
+        rxTypes.push({
+            name: 'RX_MSP',
+            bit: 14,
+            value: 4,
+        });
+
+        rxTypes.push({
+            name: 'RX_NONE',
+            value: 0,
+        });
+
         return rxTypes;
     },
     isRxTypeEnabled: function(rxType) {
@@ -659,8 +657,10 @@ var FC = {
             for (var ii = 0; ii < rxTypes.length; ii++) {
                 BF_CONFIG.features = bit_clear(BF_CONFIG.features, rxTypes[ii].bit);
             }
-            // Set the feature for this rx type
-            BF_CONFIG.features = bit_set(BF_CONFIG.features, rxType.bit);
+            // Set the feature for this rx type (if any, RX_NONE is set by clearing all)
+            if (rxType.bit !== undefined) {
+                BF_CONFIG.features = bit_set(BF_CONFIG.features, rxType.bit);
+            }
         }
     },
     getSerialRxTypes: function () {

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -594,6 +594,10 @@ var mspHelper = (function (gui) {
                     RX_CONFIG.nrf24rx_id = data.getUint32(offset, true);
                     offset += 4;
                 }
+                if (semver.gt(CONFIG.flightControllerVersion, "1.7.3")) {
+                    RX_CONFIG.receiver_type = data.getUint8(offset);
+                    offset += 1;
+                }
                 break;
 
             case MSPCodes.MSP_FAILSAFE_CONFIG:
@@ -1169,6 +1173,10 @@ var mspHelper = (function (gui) {
                     buffer.push((RX_CONFIG.nrf24rx_id >> 8) & 0xFF);
                     buffer.push((RX_CONFIG.nrf24rx_id >> 16) & 0xFF);
                     buffer.push((RX_CONFIG.nrf24rx_id >> 24) & 0xFF);
+                }
+                if (semver.gt(CONFIG.flightControllerVersion, "1.7.3")) {
+                    // receiver type in RX_CONFIG rather than in BF_CONFIG.features
+                    buffer.push(RX_CONFIG.receiver_type);
                 }
                 break;
 

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -589,11 +589,11 @@ var mspHelper = (function (gui) {
                 offset += 2;
                 if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
                     offset += 4; // 4 null bytes for betaflight compatibility
-                    RX_CONFIG.nrf24rx_protocol = data.getUint8(offset);
+                    RX_CONFIG.spirx_protocol = data.getUint8(offset);
                     offset++;
-                    RX_CONFIG.nrf24rx_id = data.getUint32(offset, true);
+                    RX_CONFIG.spirx_id = data.getUint32(offset, true);
                     offset += 4;
-                    RX_CONFIG.nrf24rx_channel_count = data.getUint8(offset);
+                    RX_CONFIG.spirx_channel_count = data.getUint8(offset);
                     offset += 1;
                 }
                 if (semver.gt(CONFIG.flightControllerVersion, "1.7.3")) {
@@ -1172,14 +1172,10 @@ var mspHelper = (function (gui) {
                     buffer.push(0);
                     buffer.push(0);
                     buffer.push(0);
-                    buffer.push(RX_CONFIG.nrf24rx_protocol);
-                    // nrf24rx_id - 4 bytes
-                    buffer.push(RX_CONFIG.nrf24rx_id & 0xFF);
-                    buffer.push((RX_CONFIG.nrf24rx_id >> 8) & 0xFF);
-                    buffer.push((RX_CONFIG.nrf24rx_id >> 16) & 0xFF);
-                    buffer.push((RX_CONFIG.nrf24rx_id >> 24) & 0xFF);
-
-                    buffer.push(RX_CONFIG.nrf24rx_channel_count);
+                    buffer.push(RX_CONFIG.spirx_protocol);
+                    // spirx_id - 4 bytes
+                    buffer.push32(RX_CONFIG.spirx_id);
+                    buffer.push(RX_CONFIG.spirx_channel_count);
                 }
                 if (semver.gt(CONFIG.flightControllerVersion, "1.7.3")) {
                     // unused byte for fpvCamAngleDegrees, for compatiblity with betaflight

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -593,8 +593,12 @@ var mspHelper = (function (gui) {
                     offset++;
                     RX_CONFIG.nrf24rx_id = data.getUint32(offset, true);
                     offset += 4;
+                    RX_CONFIG.nrf24rx_channel_count = data.getUint8(offset);
+                    offset += 1;
                 }
                 if (semver.gt(CONFIG.flightControllerVersion, "1.7.3")) {
+                    // unused byte for fpvCamAngleDegrees, for compatiblity with betaflight
+                    offset += 1;
                     RX_CONFIG.receiver_type = data.getUint8(offset);
                     offset += 1;
                 }
@@ -1169,12 +1173,17 @@ var mspHelper = (function (gui) {
                     buffer.push(0);
                     buffer.push(0);
                     buffer.push(RX_CONFIG.nrf24rx_protocol);
+                    // nrf24rx_id - 4 bytes
                     buffer.push(RX_CONFIG.nrf24rx_id & 0xFF);
                     buffer.push((RX_CONFIG.nrf24rx_id >> 8) & 0xFF);
                     buffer.push((RX_CONFIG.nrf24rx_id >> 16) & 0xFF);
                     buffer.push((RX_CONFIG.nrf24rx_id >> 24) & 0xFF);
+
+                    buffer.push(RX_CONFIG.nrf24rx_channel_count);
                 }
                 if (semver.gt(CONFIG.flightControllerVersion, "1.7.3")) {
+                    // unused byte for fpvCamAngleDegrees, for compatiblity with betaflight
+                    buffer.push(0);
                     // receiver type in RX_CONFIG rather than in BF_CONFIG.features
                     buffer.push(RX_CONFIG.receiver_type);
                 }

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -133,9 +133,9 @@
                         <!-- list generated here -->
                     </select>
                 </div>
-                <div data-rx-type="RX_NRF24" class="spacer_box">
-                    <h3 data-i18n="configurationNrf24Protocol"></h3>
-                    <select id="nrf24-protocol" class="full-width" size="1">
+                <div data-rx-type="RX_SPI" class="spacer_box">
+                    <h3 data-i18n="configurationSPIProtocol"></h3>
+                    <select id="spi-protocol" class="full-width" size="1">
                         <!-- list generated here -->
                     </select>
                 </div>

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -119,10 +119,10 @@
                     <div class="spacer_box_title" data-i18n="configurationReceiver"></div>
                 </div>
                 <div class="spacer_box">
-                    <div class="features rxMode"></div>
-                    <!--feature list goes here-->
+                    <select id="rxType" class="full-width">
+                    </select>
                 </div>
-                <div class="spacer_box">
+                <div data-rx-type="RX_SERIAL" class="spacer_box">
                     <h3 data-i18n="configurationSerialRX"></h3>
                     <div class="note">
                         <div class="note_spacer">
@@ -133,7 +133,7 @@
                         <!-- list generated here -->
                     </select>
                 </div>
-                <div class="spacer_box">
+                <div data-rx-type="RX_NRF24" class="spacer_box">
                     <h3 data-i18n="configurationNrf24Protocol"></h3>
                     <select id="nrf24-protocol" class="full-width" size="1">
                         <!-- list generated here -->

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -635,14 +635,25 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             SENSOR_ALIGNMENT.align_acc = parseInt(orientation_acc_e.val());
             SENSOR_ALIGNMENT.align_mag = parseInt(orientation_mag_e.val());
 
+            var rxTypes = FC.getRxTypes();
+
+            function is_using_rx_type(name) {
+                for (var ii = 0; ii < rxTypes.length; ii++) {
+                    if (rxTypes[ii].name == name) {
+                        return FC.isRxTypeEnabled(rxTypes[ii]);
+                    }
+                }
+                return false;
+            }
+
             // track feature usage
-            if (FC.isFeatureEnabled('RX_SERIAL', features)) {
+            if (is_using_rx_type('RX_SERIAL')) {
                 googleAnalytics.sendEvent('Setting', 'SerialRxProvider', serialRxTypes[RX_CONFIG.serialrx_provider]);
             }
 
             // track feature usage
-            if (FC.isFeatureEnabled('RX_NRF24', features)) {
-                googleAnalytics.sendEvent('Setting', 'nrf24Protocol', FC.getNrf24ProtocolTypes()[RX_CONFIG.nrf24rx_protocol]);
+            if (is_using_rx_type('RX_SPI')) {
+                googleAnalytics.sendEvent('Setting', 'nrf24Protocol', FC.getSPIProtocolTypes()[RX_CONFIG.spirx_protocol]);
             }
 
             if (FC.isFeatureEnabled('GPS', features)) {

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -260,16 +260,16 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         //noinspection JSValidateTypes
         $('#content').scrollTop((scrollPosition) ? scrollPosition : 0);
 
-        var nrf24Protocol_e = $('#nrf24-protocol');
-        GUI.fillSelect(nrf24Protocol_e, FC.getNrf24ProtocolTypes());
+        var spiProtocol_e = $('#spi-protocol');
+        GUI.fillSelect(spiProtocol_e, FC.getSPIProtocolTypes());
 
-        nrf24Protocol_e.change(function () {
-            RX_CONFIG.nrf24rx_protocol = parseInt($(this).val());
-            RX_CONFIG.nrf24rx_id = 0;
+        spiProtocol_e.change(function () {
+            RX_CONFIG.spirx_protocol = parseInt($(this).val());
+            RX_CONFIG.spirx_id = 0;
         });
 
-        // select current nrf24 protocol
-        nrf24Protocol_e.val(RX_CONFIG.nrf24rx_protocol);
+        // select current spi protocol
+        spiProtocol_e.val(RX_CONFIG.spirx_protocol);
 
         // fill board alignment
         $('input[name="board_align_roll"]').val((BF_CONFIG.board_align_roll / 10.0).toFixed(1));

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -84,6 +84,40 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         // select current mixer configuration
         mixer_list_e.val(BF_CONFIG.mixerConfiguration).change();
 
+        // receiver configuration
+        var rxTypesSelect = $('#rxType');
+        var rxTypes = FC.getRxTypes();
+        for (var ii = 0; ii < rxTypes.length; ii++) {
+            var rxType = rxTypes[ii];
+            var option = $('<option value="' + rxType.name + '" >' + chrome.i18n.getMessage(rxType.name) + '</option>');
+            option.data('rx-type', rxType);
+            if (FC.isRxTypeEnabled(rxType)) {
+                option.prop('selected', true);
+            }
+            option.appendTo(rxTypesSelect);
+        }
+        var rxTypeOptions = $('[data-rx-type]');
+
+        var updateRxOptions = function(animated) {
+            var duration = animated ? 400 : 0;
+            rxTypeOptions.each(function (ii, obj) {
+                var $obj = $(obj);
+                var rxType = $obj.data('rx-type');
+                if (rxType && rxType != rxTypesSelect.val()) {
+                    $obj.slideUp(duration);
+                } else {
+                    $obj.slideDown(duration);
+                }
+            });
+        };
+        updateRxOptions(false);
+
+        rxTypesSelect.change(function () {
+            updateRxOptions(true);
+            var rxType = rxTypesSelect.find(':selected').data('rx-type');
+            FC.setRxTypeEnabled(rxType);
+        });
+
         // generate features
         var features = FC.getFeatures();
 


### PR DESCRIPTION
Implement a combobox selector for the receiver type, showing
just the options for the specific type (e.g. selecting serial
receiver reveals the combobox for the serial protocol).

On INAV > 1.7.3 read and write receiver type to RX_CONFIG rather
than to feature bits. Note that this will break the configurator
in builds with version = 1.7.4 before https://github.com/iNavFlight/inav/pull/1596/files
is applied.