### PR TITLE
Make the OSD preview fixed in the viewport

### DIFF
--- a/tabs/osd.html
+++ b/tabs/osd.html
@@ -28,7 +28,7 @@
                 </div>
             </div>
             <div class="cf_column twothird">
-                <div class="gui_box grey preview" style="float: left;">
+                <div class="gui_box grey preview" style="float: left; position: fixed;">
                     <div class="gui_box_titlebar image">
                         <div class="spacer_box_title">
                           Preview <span>(drag to change position)</span>


### PR DESCRIPTION
Allows seeing the preview when scrolling down to see all available
OSD elements.

Attached screenshot for reference.

<img width="1019" alt="screen shot 2017-10-06 at 15 32 42" src="https://user-images.githubusercontent.com/41529/31282845-b2ffe73a-aaab-11e7-8024-fda504063a17.png">
