### PR TITLE
Disable "Load Firmware [Online]" button while downloading it

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1477,6 +1477,9 @@
     "firmwareFlasherButtonLoadOnline": {
         "message": "Load Firmware [Online]"
     },
+    "firmwareFlasherButtonLoading": {
+        "message": "Loading..."
+    },
     "firmwareFlasherFlashFirmware": {
         "message": "Flash Firmware"
     },

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -338,7 +338,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             var summary = $('select[name="firmware_version"] option:selected').data('summary');
             if (summary) { // undefined while list is loading or while running offline
-                $("a.load_remote_file").text(chrome.i18n.getMessage('firmwareFlasherButtonLoading')).addClass('disabled');
+                $(".load_remote_file").text(chrome.i18n.getMessage('firmwareFlasherButtonLoading')).addClass('disabled');
                 $.get(summary.url, function (data) {
                     enable_load_online_button();
                     process_hex(data, summary);

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -27,6 +27,10 @@ TABS.firmware_flasher.initialize = function (callback) {
         // translate to user-selected language
         localize();
 
+        function enable_load_online_button() {
+            $("a.load_remote_file").text(chrome.i18n.getMessage('firmwareFlasherButtonLoadOnline')).removeClass('disabled');
+        }
+
         function parse_hex(str, callback) {
             // parsing hex in different thread
             var worker = new Worker('./build/hex_parser.js');
@@ -255,7 +259,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                 $("a.load_remote_file").addClass('disabled');
             }
             else {
-                $("a.load_remote_file").removeClass('disabled');
+                enable_load_online_button();
             }
         });
 
@@ -329,11 +333,14 @@ TABS.firmware_flasher.initialize = function (callback) {
             function failed_to_load() {
                 $('span.progressLabel').text(chrome.i18n.getMessage('firmwareFlasherFailedToLoadOnlineFirmware'));
                 $('a.flash_firmware').addClass('disabled');
+                enable_load_online_button();
             }
 
             var summary = $('select[name="firmware_version"] option:selected').data('summary');
             if (summary) { // undefined while list is loading or while running offline
+                $("a.load_remote_file").text(chrome.i18n.getMessage('firmwareFlasherButtonLoading')).addClass('disabled');
                 $.get(summary.url, function (data) {
+                    enable_load_online_button();
                     process_hex(data, summary);
                 }).fail(failed_to_load);
             } else {

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -28,7 +28,7 @@ TABS.firmware_flasher.initialize = function (callback) {
         localize();
 
         function enable_load_online_button() {
-            $("a.load_remote_file").text(chrome.i18n.getMessage('firmwareFlasherButtonLoadOnline')).removeClass('disabled');
+            $(".load_remote_file").text(chrome.i18n.getMessage('firmwareFlasherButtonLoadOnline')).removeClass('disabled');
         }
 
         function parse_hex(str, callback) {


### PR DESCRIPTION
Provides feedback to the user to let he know that the configurator
didn't hang up


<img width="1097" alt="screen shot 2017-10-06 at 15 46 47" src="https://user-images.githubusercontent.com/41529/31283473-a528f21c-aaad-11e7-9f0e-aa1a891f8b46.png">
