### PR TITLE
Fix decoding MSPv2 message codes with high byte != 0

### DIFF
--- a/js/msp.js
+++ b/js/msp.js
@@ -165,7 +165,7 @@ var MSP = {
                     this.state = this.decoder_states.CODE_V2_HIGH;
                     break;
                 case this.decoder_states.CODE_V2_HIGH:
-                    this.message_length_expected |= data[i] << 8;
+                    this.code |= data[i] << 8;
                     this.state = this.decoder_states.PAYLOAD_LENGTH_V2_LOW;
                     break;
                 case this.decoder_states.PAYLOAD_LENGTH_JUMBO_LOW:


### PR DESCRIPTION
OR the high byte of the MSPv2 code with the "code" variable rather
than with this.message_length_expected. This wasn't caught earlier
because it would work for MSPv2 commands with the high byte set to
zero anyway.