### PR TITLE
Add support for OSD alarms for distance and negative altitude

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2098,6 +2098,18 @@
     "osdUnitUKTip": {
         "message": "Use metric units except for the speed, which is displayed in miles per hour."
     },
+    "osdAlarmRSSI": {
+        "message": "RSSI"
+    },
+    "osdAlarmBATT_CAP": {
+        "message": "Used Battery"
+    },
+    "osdAlarmFLY_MINUTES": {
+        "message": "Fly Time"
+    },
+    "osdAlarmMAX_ALTITUDE": {
+        "message": "Maximum Altitude"
+    },
     "osdGroupGeneral": {
         "message": "General"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2104,6 +2104,9 @@
     "osdAlarmBATT_CAP": {
         "message": "Used Battery"
     },
+    "osdAlarmBATT_CAP_HELP": {
+        "message": "The battery capacity used indicator (mah drawn) will flash when the total consumed mah are greater than this value. Requires a current sensor. Zero disables this alarm."
+    },
     "osdAlarmFLY_MINUTES": {
         "message": "Fly Time"
     },
@@ -2113,8 +2116,14 @@
     "osdAlarmDIST": {
         "message": "Distance"
     },
+    "osdAlarmDIST_HELP": {
+        "message": "The distance to home indicator will flash when the distance is greater than this value. Zero disables this alarm."
+    },
     "osdAlarmMAX_NEG_ALTITUDE": {
         "message": "Negative Altitude"
+    },
+    "osdAlarmMAX_NEG_ALTITUDE_HELP": {
+        "message": "The altitude indicator will flash when altitude is negative and its absolute value is greater than this alarm. Useful when taking off from elevated places. Zero disables this alarm."
     },
     "osdGroupGeneral": {
         "message": "General"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2108,7 +2108,13 @@
         "message": "Fly Time"
     },
     "osdAlarmMAX_ALTITUDE": {
-        "message": "Maximum Altitude"
+        "message": "Altitude"
+    },
+    "osdAlarmDIST": {
+        "message": "Distance"
+    },
+    "osdAlarmMAX_NEG_ALTITUDE": {
+        "message": "Negative Altitude"
     },
     "osdGroupGeneral": {
         "message": "General"

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -1021,7 +1021,24 @@ TABS.osd.initialize = function (callback) {
                                     updateOsdView();
                                 });
                         });
-                        var $input = $('<label/>').append(alarmInput);
+                        var $input = $('<label/>');
+                        var help = chrome.i18n.getMessage('osdAlarm' + alarm.name + '_HELP');
+                        if (help) {
+                            $('<div class="helpicon cf_tip"></div>')
+                            .css('margin-top', '1px')
+                            .attr('title', help)
+                            .appendTo($input)
+                            .jBox('Tooltip', {
+                                delayOpen: 100,
+                                delayClose: 100,
+                                position: {
+                                    x: 'right',
+                                    y: 'center'
+                                },
+                                outside: 'x'
+                            });
+                        }
+                        $input.append(alarmInput);
                         $alarms.append($input);
                     }
 


### PR DESCRIPTION
Alarms are always in SI units. Conversion is performed by the configurator.

INAV PR at https://github.com/iNavFlight/inav/pull/2296