### PR TITLE
Make dist task finish before reporting it's done

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -199,8 +199,8 @@ gulp.task('dist-build', ['build'], function() {
         .pipe(gulp.dest(distDir));
 });
 
-gulp.task('dist', function() {
-    return runSequence('clean', 'dist-build');
+gulp.task('dist', function(done) {
+    return runSequence('clean', 'dist-build', done);
 });
 
 // Create app directories in ./apps


### PR DESCRIPTION
runSequence will return immediately, so tasks depending on
dist might fail the first time they're run. By explicitely passing
the callback, gulp will wait until runSequence runs both clean
and dist-build until it considers dist finished.