### PR TITLE
Use async URL loading for the JSON setting definitions

### DIFF
--- a/tabs/profiles.js
+++ b/tabs/profiles.js
@@ -531,7 +531,9 @@ TABS.profiles.initialize = function (callback, scrollPosition) {
             var settings = presets.settings.get(currentPreset.type);
             Object.keys(settings).forEach(function(key, ii) {
                 var value = settings[key];
-                promises[key] = MSP.promise(MSPCodes.MSPV2_SET_SETTING, mspHelper.encodeSetting(key, value));
+                promises[key] = mspHelper.encodeSetting(key, value).then(function(data) {
+                    return MSP.promise(MSPCodes.MSPV2_SET_SETTING, data);
+                });
             });
         }
         Promise.props(promises).then(function () {


### PR DESCRIPTION
Chrome disallows synchronous URL loading, so all functions requiring
the JSON definitions for the settings over MSPv2 need to be async.
This required rewriting MSPHelper._getSetting() and all its callers
using promises.

Fixes #284