### PR TITLE
Don't test for RX_NONE on INAV <= 1.7.3

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -642,10 +642,14 @@ var FC = {
             value: 4,
         });
 
-        rxTypes.push({
-            name: 'RX_NONE',
-            value: 0,
-        });
+        // Versions using feature bits don't allow not having an
+        // RX and fallback to RX_PPM.
+        if (semver.gt(CONFIG.flightControllerVersion, "1.7.3")) {
+            rxTypes.push({
+                name: 'RX_NONE',
+                value: 0,
+            });
+        }
 
         return rxTypes;
     },


### PR DESCRIPTION
Since in RX_NONE bit is undefined, bit_check() will always return
true. Fix is just removing RX_NONE from the available RX types
on versions using feature bits for RX, since they won't allow
not having a RX configured (FC will fall back to RX_PPM).

Fixes #287