### PR TITLE
Fix preview of RTC OSD indicator

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -471,7 +471,7 @@ OSD.constants = {
                     name: 'RTC_TIME',
                     id: 29,
                     min_version: '1.7.4',
-                    preview: FONT.symbol(SYM.CLOCK) + ' 13:37'
+                    preview: FONT.symbol(SYM.CLOCK) + '13:37'
                 },
             ]
         },


### PR DESCRIPTION
There was an extra space between the clock symbol and the hour