### PR TITLE
Allow RSSI channel only on channels >= 5

### DIFF
--- a/tabs/receiver.js
+++ b/tabs/receiver.js
@@ -172,8 +172,8 @@ TABS.receiver.initialize = function (callback) {
         // rssi
         var rssi_channel_e = $('select[name="rssi_channel"]');
         rssi_channel_e.append('<option value="0">Disabled</option>');
-        for (var i = 1; i < RC.active_channels + 1; i++) {
-            rssi_channel_e.append('<option value="' + i + '">' + i + '</option>');
+        for (var i = 5; i < RC.active_channels + 1; i++) {
+            rssi_channel_e.append('<option value="' + i + '">CH' + i + '</option>');
         }
 
         $('select[name="rssi_channel"]').val(MISC.rssi_channel);


### PR DESCRIPTION
Also, show CH# (e.g. CH7) rather than just the bare number in the
combobox, makes it more obvious that you're selecting an actual
channel number rather than an AUX channel number.