### PR TITLE
Add MSPHelper.getRTC() and MSPHelper.setRTC()

### DIFF
--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -122,6 +122,9 @@ var MSPCodes = {
     MSP_SERVO_MIX_RULES:    241,
     MSP_SET_SERVO_MIX_RULE: 242,
 
+    MSP_RTC:                246,
+    MSP_SET_RTC:            247,
+
     MSP_EEPROM_WRITE:       250,
 
     MSP_DEBUGMSG:           253,


### PR DESCRIPTION
Functions for getting and setting the RTC. Not used for now, but
can be manually called from the debug console for testing RTC
related changes.