### PR TITLE
Add support for changing the craft name

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -735,6 +735,15 @@
     "configurationSPIProtocol": {
         "message": "RX SPI protocol"
     },
+    "configurationPersonalization": {
+        "message": "Personalization"
+    },
+    "configurationCraftName": {
+        "message": "Craft Name"
+    },
+    "configurationCraftNameHelp": {
+        "message": "Craft name. Can be displayed by OSD and by compatible RC systems."
+    },
     "configurationEepromSaved": {
         "message": "EEPROM <span style=\"color: #37a8db\">saved</span>"
     },

--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -10,6 +10,9 @@ var MSPCodes = {
     MSP_INAV_PID:               6,
     MSP_SET_INAV_PID:           7,
 
+    MSP_NAME:                   10,
+    MSP_SET_NAME:               11,
+
     MSP_NAV_POSHOLD:            12,
     MSP_SET_NAV_POSHOLD:        13,
     MSP_CALIBRATION_DATA:       14,

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1115,6 +1115,11 @@ var mspHelper = (function (gui) {
             case MSPCodes.MSP_OSD_CHAR_WRITE:
                 console.log('OSD char uploaded');
                 break;
+            case MSPCodes.MSP_NAME:
+                break;
+            case MSPCodes.MSP_SET_NAME:
+                console.log("Craft name set");
+                break;
             case MSPCodes.MSPV2_SETTING:
                 break;
             case MSPCodes.MSPV2_SET_SETTING:
@@ -2517,6 +2522,39 @@ var mspHelper = (function (gui) {
     self.loadServoMixRules = function (callback) {
         MSP.send_message(MSPCodes.MSP_SERVO_MIX_RULES, false, false, callback);
     }
+    
+    self.getCraftName = function(callback) {
+        if (semver.gt(CONFIG.flightControllerVersion, "1.8.0")) {
+            MSP.send_message(MSPCodes.MSP_NAME, false, false, function(resp) {
+                var name = "";
+                for (var ii = 0; ii < resp.data.byteLength; ii++) {
+                    var c = resp.data.readU8();
+                    if (c != 0) {
+                        name += String.fromCharCode(c);
+                    }
+                }
+                if (callback) {
+                    callback(name);
+                }
+            });
+        } else if (callback) {
+            callback(null);
+        }
+    };
+
+    self.setCraftName = function(name, callback) {
+        if (semver.gt(CONFIG.flightControllerVersion, "1.8.0")) {
+            var data = [];
+            name = name || "";
+            for (var ii = 0; ii < name.length; ii++) {
+                data.push(name.charCodeAt(ii));
+            }
+            MSP.send_message(MSPCodes.MSP_SET_NAME, data, false, callback);
+        } else if (callback) {
+            callback();
+        }
+    };
+
 
     return self;
 })(GUI);

--- a/src/css/tabs/configuration.css
+++ b/src/css/tabs/configuration.css
@@ -20,9 +20,8 @@
     font-weight: bold;
 }
 
-.config-section .number input,
-.tab-configuration .number input {
-    width: 65px;
+.config-section input,
+.tab-configuration input {
     padding-left: 3px;
     height: 20px;
     line-height: 20px;
@@ -34,8 +33,17 @@
     font-weight: normal;
 }
 
-.tab-configuration .number .disabled {
+.config-section .number input,
+.tab-configuration .number input {
     width: 65px;
+}
+
+.config-section .string input,
+.tab-configuration .string input {
+    width: 130px;
+}
+
+.tab-configuration .disabled {
     background-color: #ececec;
 }
 
@@ -224,6 +232,10 @@ hr {
 
 .config-section .radio label {
     left: 2em;
+}
+
+.config-section .string label {
+    left: 175px;
 }
 
 .config-section .radio input {

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -212,6 +212,21 @@
                 </div>
             </div>
 
+            <div class="config-section gui_box grey config-personalization">
+                <div class="gui_box_titlebar">
+                    <div class="spacer_box_title" data-i18n="configurationPersonalization"></div>
+                </div>
+                <div class="spacer_box">
+                    <div class="string">
+                        <input maxlength="16" id="craft_name" name="craft_name" />
+                        <label for="craft_name">
+                            <span data-i18n="configurationCraftName"></span>
+                        </label>
+                        <div class="helpicon cf_tip" data-i18n_title="configurationCraftNameHelp"></div>
+                    </div>
+                </div>
+            </div>
+
         </div>
 
         <!--Right column begins here-->

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -10,6 +10,18 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         googleAnalytics.sendAppView('Configuration');
     }
 
+    var craftName = null;
+    var loadCraftName = function(callback) {
+        mspHelper.getCraftName(function(name) {
+            craftName = name;
+            callback();
+        });
+    };
+
+    var saveCraftName = function(callback) {
+        mspHelper.setCraftName(craftName, callback);
+    };
+
     var loadChainer = new MSPChainerClass();
 
     loadChainer.setChain([
@@ -22,7 +34,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         mspHelper.loadSensorAlignment,
         mspHelper.loadAdvancedConfig,
         mspHelper.loadINAVPidConfig,
-        mspHelper.loadSensorConfig
+        mspHelper.loadSensorConfig,
+        loadCraftName
     ]);
     loadChainer.setExitPoint(load_html);
     loadChainer.execute();
@@ -41,6 +54,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         mspHelper.saveAdvancedConfig,
         mspHelper.saveINAVPidConfig,
         mspHelper.saveSensorConfig,
+        saveCraftName,
         mspHelper.saveToEeprom
     ]);
     saveChainer.setExitPoint(reboot);
@@ -597,6 +611,14 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             });
         });
 
+        // Craft name
+        if (craftName != null) {
+            $('.config-personalization').show();
+            $('input[name="craft_name"]').val(craftName);
+        } else {
+            // craft name not supported by the firmware
+            $('.config-personalization').hide();
+        }
 
         $('a.save').click(function () {
             // gather data that doesn't have automatic change event bound
@@ -634,6 +656,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             SENSOR_ALIGNMENT.align_gyro = parseInt(orientation_gyro_e.val());
             SENSOR_ALIGNMENT.align_acc = parseInt(orientation_acc_e.val());
             SENSOR_ALIGNMENT.align_mag = parseInt(orientation_mag_e.val());
+
+            craftName = $('input[name="craft_name"]').val();
 
             var rxTypes = FC.getRxTypes();
 


### PR DESCRIPTION
Uses MSP_NAME/MSP_SET_NAME to get and set it. A new section was
added to the Configuration tab which includes an input for the name.
Also, some CSS changes to allow wider fields for string inputs.

iNav PR at https://github.com/iNavFlight/inav/pull/2488