### PR TITLE
Fix incorrectly swapped bits for legacy RX

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -618,12 +618,12 @@ var FC = {
             },
             {
                 name: 'RX_PPM',
-                bit: 13,
+                bit: 0,
                 value: 2,
             },
             {
                 name: 'RX_PWM',
-                bit: 0,
+                bit: 13,
                 value: 1,
             },
         ];


### PR DESCRIPTION
Code for handling versions using feature bits for RX had the
feature bits for RX_PPM and RX_PWM swapped, causing incorrectly
displayed values.