### PR TITLE
Increase vbat resolution to 10mV

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -28,6 +28,7 @@ var CONFIG,
     ARMING_CONFIG,
     FC_CONFIG,
     MISC,
+    VOLTMETER_CONFIG,
     _3D,
     DATAFLASH,
     SDCARD,
@@ -215,8 +216,12 @@ var FC = {
         ANALOG = {
             voltage: 0,
             mAhdrawn: 0,
+            mWhdrawn: 0,
             rssi: 0,
-            amperage: 0
+            amperage: 0,
+            power: 0,
+            cell_count: 0,
+            battery_percentage: 0
         };
 
         ARMING_CONFIG = {
@@ -244,7 +249,24 @@ var FC = {
             vbatscale: 0,
             vbatmincellvoltage: 0,
             vbatmaxcellvoltage: 0,
-            vbatwarningcellvoltage: 0
+            vbatwarningcellvoltage: 0,
+            battery_capacity: 0,
+            battery_capacity_warning: 0,
+            battery_capacity_critical: 0,
+            battery_capacity_unit: 0
+        };
+
+        BATTERY_CONFIG = {
+            vbatscale: 0,
+            vbatmincellvoltage: 0,
+            vbatmaxcellvoltage: 0,
+            vbatwarningcellvoltage: 0,
+            current_offset: 0,
+            current_scale: 0,
+            capacity: 0,
+            capacity_warning: 0,
+            capacity_critical: 0,
+            capacity_unit: 0
         };
 
         ADVANCED_CONFIG = {

--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -153,6 +153,14 @@ var MSPCodes = {
     MSP_BF_BUILD_INFO:          69,  // build date as well as some space for future expansion
 
     // INAV specific codes
-    MSPV2_SETTING:          0x1003,
-    MSPV2_SET_SETTING:      0x1004,
+    MSPV2_SETTING:                      0x1003,
+    MSPV2_SET_SETTING:                  0x1004,
+    MSPV2_INAV_STATUS:                  0x2000,
+    MSPV2_INAV_OPTICAL_FLOW:            0x2001,
+    MSPV2_INAV_ANALOG:                  0x2002,
+    MSPV2_INAV_MISC:                    0x2003,
+    MSPV2_INAV_SET_MISC:                0x2004,
+    MSPV2_INAV_BATTERY_CONFIG:          0x2005,
+    MSPV2_INAV_SET_BATTERY_CONFIG:      0x2006
+
 };

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -235,6 +235,22 @@ var mspHelper = (function (gui) {
                 ANALOG.mAhdrawn = data.getUint16(1, true);
                 ANALOG.rssi = data.getUint16(3, true); // 0-1023
                 ANALOG.amperage = data.getInt16(5, true) / 100; // A
+                break;
+            case MSPCodes.MSPV2_INAV_ANALOG:
+                ANALOG.voltage = data.getUint16(offset, true) / 100.0;
+                offset += 2;
+                ANALOG.cell_count = data.getUint8(offset++);
+                ANALOG.battery_percentage = data.getUint8(offset++);
+                ANALOG.power = data.getUint16(offset, true);
+                offset += 2;
+                ANALOG.mAhdrawn = data.getUint16(offset, true);
+                offset += 2;
+                ANALOG.mWhdrawn = data.getUint16(offset, true);
+                offset += 2;
+                ANALOG.rssi = data.getUint16(offset, true); // 0-1023
+                offset += 2;
+                ANALOG.amperage = data.getInt16(offset, true) / 100; // A
+                offset += 2;
                 //noinspection JSValidateTypes
                 dataHandler.analog_last_received_timestamp = Date.now();
                 break;
@@ -298,6 +314,61 @@ var mspHelper = (function (gui) {
                 MISC.vbatmincellvoltage = data.getUint8(offset++) / 10; // 10-50
                 MISC.vbatmaxcellvoltage = data.getUint8(offset++) / 10; // 10-50
                 MISC.vbatwarningcellvoltage = data.getUint8(offset++) / 10; // 10-50
+                break;
+            case MSPCodes.MSPV2_INAV_MISC:
+                MISC.midrc = data.getInt16(offset, true);
+                offset += 2;
+                MISC.minthrottle = data.getUint16(offset, true); // 0-2000
+                offset += 2;
+                MISC.maxthrottle = data.getUint16(offset, true); // 0-2000
+                offset += 2;
+                MISC.mincommand = data.getUint16(offset, true); // 0-2000
+                offset += 2;
+                MISC.failsafe_throttle = data.getUint16(offset, true); // 1000-2000
+                offset += 2;
+                MISC.gps_type = data.getUint8(offset++);
+                MISC.sensors_baudrate = data.getUint8(offset++);
+                MISC.gps_ubx_sbas = data.getInt8(offset++);
+                MISC.rssi_channel = data.getUint8(offset++);
+                MISC.placeholder2 = data.getUint8(offset++);
+                MISC.mag_declination = data.getInt16(offset, 1) / 10; // -18000-18000
+                offset += 2;
+                MISC.vbatscale = data.getUint16(offset, true);
+                offset += 2;
+                MISC.vbatmincellvoltage = data.getUint16(offset, true) / 100;
+                offset += 2;
+                MISC.vbatmaxcellvoltage = data.getUint16(offset, true) / 100;
+                offset += 2;
+                MISC.vbatwarningcellvoltage = data.getUint16(offset, true) / 100;
+                offset += 2;
+                MISC.battery_capacity = data.getUint32(offset, true);
+                offset += 4;
+                MISC.battery_capacity_warning = data.getUint32(offset, true);
+                offset += 4;
+                MISC.battery_capacity_critical = data.getUint32(offset, true);
+                offset += 4;
+                MISC.battery_capacity_unit = data.getUint8(offset++);
+                break;
+            case MSPCodes.MSPV2_INAV_BATTERY_CONFIG:
+                BATTERY_CONFIG.vbatscale = data.getUint16(offset, true);
+                offset += 2;
+                BATTERY_CONFIG.vbatmincellvoltage = data.getUint16(offset, true) / 100;
+                offset += 2;
+                BATTERY_CONFIG.vbatmaxcellvoltage = data.getUint16(offset, true) / 100;
+                offset += 2;
+                BATTERY_CONFIG.vbatwarningcellvoltage = data.getUint16(offset, true) / 100;
+                offset += 2;
+                BATTERY_CONFIG.current_offset = data.getUint16(offset, true);
+                offset += 2;
+                BATTERY_CONFIG.current_scale = data.getUint16(offset, true);
+                offset += 2;
+                BATTERY_CONFIG.capacity = data.getUint32(offset, true);
+                offset += 4;
+                BATTERY_CONFIG.capacity_warning = data.getUint32(offset, true);
+                offset += 4;
+                BATTERY_CONFIG.capacity_critical = data.getUint32(offset, true);
+                offset += 4;
+                BATTERY_CONFIG.capacity_unit = data.getUint8(offset++);
                 break;
             case MSPCodes.MSP_3D:
                 _3D.deadband3d_low = data.getUint16(offset, true);
@@ -1294,6 +1365,62 @@ var mspHelper = (function (gui) {
                 buffer.push(Math.round(MISC.vbatmaxcellvoltage * 10));
                 buffer.push(Math.round(MISC.vbatwarningcellvoltage * 10));
                 break;
+            case MSPCodes.MSPV2_INAV_SET_MISC:
+                buffer.push(lowByte(MISC.midrc));
+                buffer.push(highByte(MISC.midrc));
+                buffer.push(lowByte(MISC.minthrottle));
+                buffer.push(highByte(MISC.minthrottle));
+                buffer.push(lowByte(MISC.maxthrottle));
+                buffer.push(highByte(MISC.maxthrottle));
+                buffer.push(lowByte(MISC.mincommand));
+                buffer.push(highByte(MISC.mincommand));
+                buffer.push(lowByte(MISC.failsafe_throttle));
+                buffer.push(highByte(MISC.failsafe_throttle));
+                buffer.push(MISC.gps_type);
+                buffer.push(MISC.sensors_baudrate);
+                buffer.push(MISC.gps_ubx_sbas);
+                buffer.push(MISC.multiwiicurrentoutput);
+                buffer.push(MISC.rssi_channel);
+                buffer.push(MISC.placeholder2);
+                buffer.push(lowByte(Math.round(MISC.mag_declination * 10)));
+                buffer.push(highByte(Math.round(MISC.mag_declination * 10)));
+                buffer.push(lowByte(MISC.vbatscale));
+                buffer.push(highByte(MISC.vbatscale));
+                buffer.push(lowByte(Math.round(MISC.vbatmincellvoltage * 100)));
+                buffer.push(highByte(Math.round(MISC.vbatmincellvoltage * 100)));
+                buffer.push(lowByte(Math.round(MISC.vbatmaxcellvoltage * 100)));
+                buffer.push(highByte(Math.round(MISC.vbatmaxcellvoltage * 100)));
+                buffer.push(lowByte(Math.round(MISC.vbatwarningcellvoltage * 100)));
+                buffer.push(highByte(Math.round(MISC.vbatwarningcellvoltage * 100)));
+                for (byte_index = 0; byte_index < 4; ++byte_index)
+                    buffer.push(specificByte(MISC.battery_capacity, byte_index));
+                for (byte_index = 0; byte_index < 4; ++byte_index)
+                    buffer.push(specificByte(MISC.battery_capacity_warning, byte_index));
+                for (byte_index = 0; byte_index < 4; ++byte_index)
+                    buffer.push(specificByte(MISC.battery_capacity_critical, byte_index));
+                buffer.push(MISC.battery_capacity_unit);
+                break;
+            case MSPCodes.MSPV2_INAV_SET_BATTERY_CONFIG:
+                buffer.push(lowByte(BATTERY_CONFIG.vbatscale));
+                buffer.push(highByte(BATTERY_CONFIG.vbatscale));
+                buffer.push(lowByte(Math.round(BATTERY_CONFIG.vbatmincellvoltage * 100)));
+                buffer.push(highByte(Math.round(BATTERY_CONFIG.vbatmincellvoltage * 100)));
+                buffer.push(lowByte(Math.round(BATTERY_CONFIG.vbatmaxcellvoltage * 100)));
+                buffer.push(highByte(Math.round(BATTERY_CONFIG.vbatmaxcellvoltage * 100)));
+                buffer.push(lowByte(Math.round(BATTERY_CONFIG.vbatwarningcellvoltage * 100)));
+                buffer.push(highByte(Math.round(BATTERY_CONFIG.vbatwarningcellvoltage * 100)));
+                buffer.push(lowByte(BATTERY_CONFIG.current_offset));
+                buffer.push(highByte(BATTERY_CONFIG.current_offset));
+                buffer.push(lowByte(BATTERY_CONFIG.current_scale));
+                buffer.push(highByte(BATTERY_CONFIG.current_scale));
+                for (byte_index = 0; byte_index < 4; ++byte_index)
+                    buffer.push(specificByte(BATTERY_CONFIG.capacity, byte_index));
+                for (byte_index = 0; byte_index < 4; ++byte_index)
+                    buffer.push(specificByte(BATTERY_CONFIG.capacity_warning, byte_index));
+                for (byte_index = 0; byte_index < 4; ++byte_index)
+                    buffer.push(specificByte(BATTERY_CONFIG.capacity_critical, byte_index));
+                buffer.push(BATTERY_CONFIG.capacity_unit);
+                break;
 
             case MSPCodes.MSP_SET_RX_CONFIG:
                 buffer.push(RX_CONFIG.serialrx_provider);
@@ -2219,6 +2346,14 @@ var mspHelper = (function (gui) {
         MSP.send_message(MSPCodes.MSP_MISC, false, false, callback);
     };
 
+    self.loadMiscV2 = function (callback) {
+        MSP.send_message(MSPCodes.MSPV2_INAV_MISC, false, false, callback);
+    };
+
+    self.loadBatteryConfig = function (callback) {
+	MSP.send_message(MSPCodes.MSPV2_BATTERY_CONFIG, false, false, callback);
+    };
+
     self.loadArmingConfig = function (callback) {
         MSP.send_message(MSPCodes.MSP_ARMING_CONFIG, false, false, callback);
     };
@@ -2329,6 +2464,14 @@ var mspHelper = (function (gui) {
 
     self.saveMisc = function (callback) {
         MSP.send_message(MSPCodes.MSP_SET_MISC, mspHelper.crunch(MSPCodes.MSP_SET_MISC), false, callback);
+    };
+
+    self.saveMiscV2 = function (callback) {
+        MSP.send_message(MSPCodes.MSPV2_INAV_SET_MISC, mspHelper.crunch(MSPCodes.MSPV2_INAV_SET_MISC), false, callback);
+    };
+
+    self.saveBatteryConfig = function (callback) {
+        MSP.send_message(MSPCodes.MSPV2_SET_BATTERY_CONFIG, mspHelper.crunch(MSPCodes.MSPV2_SET_BATTERY_CONFIG), false, callback);
     };
 
     self.save3dConfig = function (callback) {

--- a/main.css
+++ b/main.css
@@ -1669,7 +1669,7 @@ dialog {
     color: white;
     font-size: 10px;
     margin-top: 20px;
-    width: 90px;
+    width: 100px;
     float: right;
     margin-right: 20px;
     line-height: 12px;
@@ -1761,6 +1761,7 @@ dialog {
 .bottomStatusIcons {
     background-color: #272727;
     height: 31px;
+    margin-left: 5px;
     margin-top: 2px;
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -382,23 +382,23 @@
                     <!--list of generated features goes here-->
 
                     <div class="number">
-                        <input type="number" id="mincellvoltage" name="mincellvoltage" step="0.1" min="1" max="5" />
+                        <input type="number" id="mincellvoltage" name="mincellvoltage" step="0.01" min="1" max="5" />
                         <label for="mincellvoltage"><span data-i18n="configurationBatteryMinimum"></span></label>
                     </div>
                     <div class="number">
-                        <input type="number" id="maxcellvoltage" name="maxcellvoltage" step="0.1" min="1" max="5" />
+                        <input type="number" id="maxcellvoltage" name="maxcellvoltage" step="0.01" min="1" max="5" />
                         <label for="maxcellvoltage">
                             <span data-i18n="configurationBatteryMaximum"></span>
                         </label>
                     </div>
                     <div class="number">
-                        <input type="number" id="warningcellvoltage" name="warningcellvoltage" step="0.1" min="1" max="5" />
+                        <input type="number" id="warningcellvoltage" name="warningcellvoltage" step="0.01" min="1" max="5" />
                         <label for="warningcellvoltage">
                             <span data-i18n="configurationBatteryWarning"></span>
                         </label>
                     </div>
                     <div class="number">
-                        <input type="number" id="voltagescale" name="voltagescale" step="1" min="10" max="255" />
+                        <input type="number" id="voltagescale" name="voltagescale" step="1" min="10" max="65535" />
                         <label for="voltagescale">
                             <span data-i18n="configurationBatteryScale"></span>
                         </label>


### PR DESCRIPTION
Battery voltage resolution of 100mV is not enough for me. This patch increases the voltage resolution to 10mV.

- Voltage scaling/calibration resolution is increased 10 fold. Previous calibration value should be multiplied by 10.
- Increased battery voltage min/max/warning thresholds resolution to 10mV

This PR depends on https://github.com/iNavFlight/inav/pull/2668