### PR TITLE
Add FW_LAUNCH feature to configurator

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -573,6 +573,9 @@
     "featureAIRMODE": {
         "message": "Permanently enable AIRMODE"
     },
+    "featureFW_LAUNCH": {
+        "message": "Permanently enable Launch Mode for Fixed Wing"
+    },
     "configurationFeatureEnabled": {
         "message": "Enabled"
     },

--- a/js/fc.js
+++ b/js/fc.js
@@ -498,6 +498,12 @@ var FC = {
             );
         }
 
+        if (semver.gte(CONFIG.flightControllerVersion, '1.8.1')) {
+            features.push(
+                {bit: 30, group: 'other', name: 'FW_LAUNCH', haveTip: false, showNameInTip: false}
+            );
+        }
+
         return features.reverse();
     },
     isFeatureEnabled: function (featureName, features) {


### PR DESCRIPTION
Adds configurator support to https://github.com/iNavFlight/inav/pull/2731

Is there a way I can check for "Fixed Wing" and display the option only if "Fixed Wing" is set on the FC?