### PR TITLE
Remove the Multiwii current format option

### DIFF
--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -437,12 +437,6 @@
                             <span data-i18n="configurationBatteryCurrent"></span>
                         </label>
                     </div>
-                    <div class="checkbox">
-                        <input type="checkbox" id="multiwiicurrentoutput" name="multiwiicurrentoutput" class="toggle" />
-                        <label for="multiwiicurrentoutput">
-                            <span data-i18n="configurationBatteryMultiwiiCurrent"></span>
-                        </label>
-                    </div>
                 </div>
             </div>
 

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -341,7 +341,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         // fill current
         $('#currentscale').val(BF_CONFIG.currentscale);
         $('#currentoffset').val(BF_CONFIG.currentoffset);
-        $('#multiwiicurrentoutput').prop('checked', MISC.multiwiicurrentoutput);
 
         var escProtocols = FC.getEscProtocols();
         var servoRates = FC.getServoRates();
@@ -666,7 +665,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             BF_CONFIG.currentscale = parseInt($('#currentscale').val());
             BF_CONFIG.currentoffset = parseInt($('#currentoffset').val());
-            MISC.multiwiicurrentoutput = ~~$('#multiwiicurrentoutput').is(':checked'); // ~~ boolean to decimal conversion
 
             _3D.deadband3d_low = parseInt($('#3ddeadbandlow').val());
             _3D.deadband3d_high = parseInt($('#3ddeadbandhigh').val());


### PR DESCRIPTION
- Still can be set through the CLI for old versions supporting it
- Saving in the configuration tab won't alter the value