### PR TITLE
Fix typo in MSPV2_INAV_MISC decoding

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -378,7 +378,7 @@ var mspHelper = (function (gui) {
                 offset += 4;
                 MISC.battery_capacity_critical = data.getUint32(offset, true);
                 offset += 4;
-                MISC.battery_capacity_unit = (data.getUint8(offset++) ? 'Wh' : 'mAh');
+                MISC.battery_capacity_unit = (data.getUint8(offset++) ? 'mWh' : 'mAh');
                 break;
             case MSPCodes.MSPV2_INAV_BATTERY_CONFIG:
                 BATTERY_CONFIG.vbatscale = data.getUint16(offset, true);


### PR DESCRIPTION
Not a big issue the only consequence is that after you select mWh as battery capacity unit the drop down menu will show a blank item selected. But it needs to be selected again before saving again otherwise the setting will go back to mAh.