### PR TITLE
Load SENSOR_CONFIG before loading the calibration UI

### DIFF
--- a/tabs/calibration.js
+++ b/tabs/calibration.js
@@ -55,6 +55,7 @@ TABS.calibration.initialize = function (callback) {
     if (semver.gte(CONFIG.flightControllerVersion, "1.8.1")) {
         loadChainer.setChain([
             mspHelper.loadStatus,
+            mspHelper.loadSensorConfig,
             mspHelper.loadCalibrationData
         ]);
         loadChainer.setExitPoint(loadHtml);


### PR DESCRIPTION
Otherwise the mag is not properly detected and the compass
calibration button is grayed out.

It worked if you loaded the "Configuration" or "OSD" tabs first, since those tabs load the `SENSOR_CONFIG` global.