### PR TITLE
Remove disarm_kill_switch from the configurator UI

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -684,12 +684,6 @@
     "configurationAutoDisarmDelayHelp": {
         "message": "Requires MOTOR_STOP feature"
     },
-    "configurationDisarmKillSwitch": {
-        "message": "Disarm regardless of throttle value"
-    },
-    "configurationDisarmKillSwitchHelp": {
-        "message": "When arming via radio channel"
-    },
     "configurationThrottleMinimum": {
         "message": "Minimum Throttle"
     },

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -271,14 +271,6 @@
                     <div class="features esc"></div>
                     <!--list of generated features goes here-->
 
-                    <div class="checkbox">
-                            <input type="checkbox" id="disarmkillswitch" name="disarmkillswitch" class="toggle" />
-                        <label for="disarmkillswitch">
-                            <span data-i18n="configurationDisarmKillSwitch"></span>
-                        </label>
-                        <div class="helpicon cf_tip" data-i18n_title="configurationDisarmKillSwitchHelp"></div>
-                    </div>
-
                     <div class="number disarmdelay" style="display: none; margin-bottom: 5px;">
                         <input type="number" id="autodisarmdelay" name="autodisarmdelay" min="0" max="60" />
                         <label for="autodisarmdelay">

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -310,7 +310,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
         //fill motor disarm params and FC loop time
         $('input[name="autodisarmdelay"]').val(ARMING_CONFIG.auto_disarm_delay);
-        $('input[name="disarmkillswitch"]').prop('checked', ARMING_CONFIG.disarm_kill_switch);
         $('div.disarm').show();
         if(bit_check(BF_CONFIG.features, 4)) {//MOTOR_STOP
             $('div.disarmdelay').show();
@@ -663,7 +662,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             MISC.mag_declination = parseFloat($('#mag_declination').val());
 
             ARMING_CONFIG.auto_disarm_delay = parseInt($('input[name="autodisarmdelay"]').val());
-            ARMING_CONFIG.disarm_kill_switch = ~~$('input[name="disarmkillswitch"]').is(':checked'); // ~~ boolean to decimal conversion
 
             MISC.minthrottle = parseInt($('#minthrottle').val());
             MISC.midrc = parseInt($('#midthrottle').val());


### PR DESCRIPTION
disarm_kill_switch can be a safety hazard if set to false without
understanding what it does and should be left on for most cases.
Also, it's too easy to change without knowing what it does.

This change just removes it from the UI, so it's still available via
CLI for advanced users.