### PR TITLE
Reword text and tooltip for auto_disarm_delay

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -679,10 +679,10 @@
         "message": "Magnetometer Declination [deg]"
     },
     "configurationAutoDisarmDelay": {
-        "message": "Disarm delay [Seconds]"
+        "message": "Seconds until disarm due to low THR"
     },
     "configurationAutoDisarmDelayHelp": {
-        "message": "Requires MOTOR_STOP feature"
+        "message": "Only used for stick arming (i.e. not using a switch)"
     },
     "configurationDisarmKillSwitch": {
         "message": "Disarm regardless of throttle value"


### PR DESCRIPTION
Make it clear that this setting disarms after THR has been low
for the given number of seconds and it's only used with stick
arming.