### PR TITLE
Make channel mapping more user friendly

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -994,7 +994,30 @@ var FC = {
         }
     },
     getRcMapLetters: function () {
-        return ['A', 'E', 'R', 'T', '5', '6', '7', '8'];
+        if (semver.gte(CONFIG.flightControllerVersion, '1.9.1'))
+            return ['A', 'E', 'R', 'T'];
+        else
+            return ['A', 'E', 'R', 'T', '5', '6', '7', '8'];
+    },
+    isRcMapValid: function (val) {
+        var strBuffer = val.split(''),
+            duplicityBuffer = [];
+
+        if (val.length != FC.getRcMapLetters().length)
+            return false;
+
+        // check if characters inside are all valid, also check for duplicity
+        for (var i = 0; i < val.length; i++) {
+            if (FC.getRcMapLetters().indexOf(strBuffer[i]) < 0)
+                return false;
+
+            if (duplicityBuffer.indexOf(strBuffer[i]) < 0)
+                duplicityBuffer.push(strBuffer[i]);
+            else
+                return false;
+        }
+
+        return true;
     },
     getServoMixInputNames: function () {
         return [

--- a/tabs/receiver.html
+++ b/tabs/receiver.html
@@ -25,9 +25,9 @@
                     <input type="text" name="rcmap" spellcheck="false" /> 
                     <select class="hybrid_helper"
                         name="rcmap_helper">
-                        <option value="AETR5678">Default</option>
-                        <option value="AETR5678">Futaba / Hitec</option>
-                        <option value="TAER5678">JR / Spektrum / Graupner</option>
+                        <option value="AETR">Default</option>
+                        <option value="AETR">Futaba / Hitec</option>
+                        <option value="TAER">JR / Spektrum / Graupner</option>
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
The channel mapping input text becomes red when the mapping is not valid. Also includes support for simplified channel mapping (only 4 channels): https://github.com/iNavFlight/inav/pull/2947.