### PR TITLE
Mention release-only-linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ in the configurator. If new files are added, they must be included in `gulpfile.
 in the `./dist/` directory.
 - **release**: Create NW.js apps for each supported platform (win32, osx64 and linux64) in the `./apps`
 directory. Running this task on macOS or Linux requires Wine, since it's needed to set the icon
-for the Windows app.
+for the Windows app. If you don't have Wine installed you can create a release by running the **release-only-linux** task.
 
 ## Authors
 


### PR DESCRIPTION
Found release-only-linux to avoid breaking the build because of missing Wine. Should be mentioned here.