### PR TITLE
Upgrade nw.js version used for development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "inav-configurator",
-  "version": "1.9.3",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4030,9 +4030,9 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nw": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/nw/-/nw-0.25.4.tgz",
-      "integrity": "sha512-ZVyi9JYlIMltM7mb7oC7KI8cVNTlHPkTjt/kzKmnuSaIOTCjExglk8ST8sZxVdy5ncwYIqjF2aSymq7OMxvPOA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/nw/-/nw-0.30.0.tgz",
+      "integrity": "sha512-wOqViJ/j0HVFwHYPYT7YrPpNrSWBEonLeGh0/QRy/nPfTSBrox1LUacjKklJ6ldfozV8zsFBqhLUlBUaVbuPjg==",
       "requires": {
         "chalk": "1.1.3",
         "decompress": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jquery": "2.1.4",
     "jquery-ui-npm": "1.12.0",
     "marked": "^0.3.17",
-    "nw": "^0.25.4-sdk",
+    "nw": "^0.30.0-sdk",
     "nw-builder": "^3.4.1",
     "openlayers": "^4.6.4",
     "run-sequence": "^2.2.0",


### PR DESCRIPTION
Since builds are shipping with 0.29 right now, developing with
0.25 is a pain because it can't use the stored settings from
0.29+. This is not a problem for user builds, since nw.js automatically
upgrades the configuration to the newer format.