### PR TITLE
Prevent map modes to be shown if firmware is < 2.0.0

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -743,11 +743,13 @@ OSD.constants = {
                 {
                     name: 'MAP_NORTH',
                     id: 43,
+                    min_version: '2.0.0',
                     positionable: false,
                 },
                 {
                     name: 'MAP_TAKEOFF',
                     id: 44,
+                    min_version: '2.0.0',
                     positionable: false,
                 },
             ],


### PR DESCRIPTION
Oversight from the initial map mode support