### PR TITLE
Add a workaround for uploading fonts on F3 from macOS

### DIFF
--- a/js/msp.js
+++ b/js/msp.js
@@ -273,7 +273,7 @@ var MSP = {
         }
     },
 
-    send_message: function (code, data, callback_sent, callback_msp) {
+    send_message: function (code, data, callback_sent, callback_msp, protocolVersion) {
         var payloadLength = data && data.length ? data.length : 0;
         var length;
         var buffer;
@@ -281,7 +281,11 @@ var MSP = {
         var checksum;
         var ii;
 
-        switch (this.protocolVersion) {
+        if (!protocolVersion) {
+            protocolVersion = this.protocolVersion;
+        }
+
+        switch (protocolVersion) {
             case this.constants.PROTOCOL_V1:
                 // TODO: Error if code is < 255 and MSPv1 is requested
                 length = payloadLength + 6;
@@ -322,7 +326,7 @@ var MSP = {
                 view[length-1] = checksum;
                 break;
             default:
-                throw "Invalid MSP protocol version " + this.protocolVersion;
+                throw "Invalid MSP protocol version " + protocolVersion;
 
         }
 
@@ -354,12 +358,12 @@ var MSP = {
         }
         return crc;
     },
-    promise: function(code, data) {
+    promise: function(code, data, protocolVersion) {
         var self = this;
         return new Promise(function(resolve) {
             self.send_message(code, data, false, function(data) {
                 resolve(data);
-            });
+            }, protocolVersion);
         });
     },
     callbacks_cleanup: function () {

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -236,7 +236,9 @@ FONT.msp = {
 FONT.upload = function ($progress) {
     return Promise.mapSeries(FONT.data.characters, function (data, i) {
         $progress.val((i / FONT.data.characters.length) * 100);
-        return MSP.promise(MSPCodes.MSP_OSD_CHAR_WRITE, FONT.msp.encode(i));
+        // Force usage of V1 protocol to workaround the 64 byte write bug
+        // on F3 when the configurator is running on macOS
+        return MSP.promise(MSPCodes.MSP_OSD_CHAR_WRITE, FONT.msp.encode(i), MSP.constants.PROTOCOL_V1);
     })
         .then(function () {
             OSD.GUI.jbox.close();


### PR DESCRIPTION
Change MSP.send_message() and MSP.promise() to accept an optional
protocol version argument. If null or undefined, the default version
set for the MSP instance is used instead.

Use this additional argument in FONT.upload(), so we avoid generating
64 byte writes when uploading a font.