### PR TITLE
Hide platform type / flaps separator when there's no flaps checkbox

### DIFF
--- a/src/css/tabs/configuration.css
+++ b/src/css/tabs/configuration.css
@@ -93,7 +93,13 @@ hr {
 .tab-configuration .number:last-child,
 .tab-configuration .select:last-child,
 .tab-configuration .radio:last-child,
-.tab-configuration .checkbox:last-child {
+.tab-configuration .checkbox:last-child,
+.config-section .number.no-bottom-border,
+.config-section .select.no-bottom-border,
+.tab-configuration .number.no-bottom-border,
+.tab-configuration .select.no-bottom-border,
+.tab-configuration .radio.no-bottom-border,
+.tab-configuration .checkbox.no-bottom-border {
     border-bottom: none;
     padding-bottom: 0;
     margin-bottom: 0;

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -210,10 +210,14 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
             MIXER_CONFIG.platformType = parseInt($platformSelect.val(), 10);
             currentPlatform = helper.platform.getById(MIXER_CONFIG.platformType);
 
+            var $platformSelectParent = $platformSelect.parent('.select');
+
             if (currentPlatform.flapsPossible) {
                 $hasFlapsWrapper.removeClass('is-hidden');
+                $platformSelectParent.removeClass('no-bottom-border');
             } else {
                 $hasFlapsWrapper.addClass('is-hidden');
+                $platformSelectParent.addClass('no-bottom-border');
             }
 
             fillMixerPreset();


### PR DESCRIPTION
Just a small visual change

Before:

<img width="1139" alt="screen shot 2018-05-24 at 21 41 12" src="https://user-images.githubusercontent.com/41529/40512652-71c301a8-5f9b-11e8-86a4-186019ab0c53.png">


After:

<img width="1126" alt="screen shot 2018-05-24 at 21 43 13" src="https://user-images.githubusercontent.com/41529/40512690-81224410-5f9b-11e8-9e24-a5984a7050ef.png">

If the platform can have flaps, the border is shown on top of the flaps checkbox:

<img width="1130" alt="screen shot 2018-05-24 at 21 43 19" src="https://user-images.githubusercontent.com/41529/40512712-8e6ae5e6-5f9b-11e8-8f48-1a3011f5ca75.png">
