### PR TITLE
Hide midrc input box in INAV 2.0

### DIFF
--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -329,7 +329,7 @@
                             <span data-i18n="configurationThrottleMinimum"></span>
                         </label>
                     </div>
-                    <div class="number">
+                    <div class="number midthrottle_wrapper">
                         <input type="number" id="midthrottle" name="midthrottle" min="1200" max="1700" />
                         <label for="midthrottle">
                             <span data-i18n="configurationThrottleMid"></span>

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -396,7 +396,16 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
         // fill throttle
         $('#minthrottle').val(MISC.minthrottle);
-        $('#midthrottle').val(MISC.midrc);
+        // midrc was removed in 2.0, but the firmware still excepts
+        // the MSP frame with it for backwards compatibility, so we
+        // just hide it from the UI.
+        var midThrottleWrapper = $('.midthrottle_wrapper');
+        if (semver.lt(CONFIG.flightControllerVersion, '2.0.0')) {
+            $('#midthrottle').val(MISC.midrc);
+            midThrottleWrapper.show();
+        } else {
+            midThrottleWrapper.hide();
+        }
         $('#maxthrottle').val(MISC.maxthrottle);
         $('#mincommand').val(MISC.mincommand);
 


### PR DESCRIPTION
midrc was removed in 2.0, although the MSP message format was
kept for backwards compatibility. Hence, we just hide the field
on INAV >= 2.0.