### PR TITLE
Don't hardcode the logo text width

### DIFF
--- a/main.css
+++ b/main.css
@@ -131,7 +131,6 @@ input[type="number"]::-webkit-inner-spin-button {
 .logo_text {
     position: absolute;
     height: 20px;
-    width: 125px;
     left: 0;
     top: 65px;
     color: #949494;
@@ -140,6 +139,7 @@ input[type="number"]::-webkit-inner-spin-button {
 
 .logo_text .version {
     float: right;
+    margin-left: 1em;
 }
 
 #port-picker {


### PR DESCRIPTION
Otherwise it doesn't display correctly when the version is longer
than X.Y.Z. Add some left margin to the version instead.