### PR TITLE
Don't stop the promise chain in loadOutputMapping() in < 2.0

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -2599,7 +2599,7 @@ var mspHelper = (function (gui) {
             MSP.send_message(MSPCodes.MSPV2_INAV_OUTPUT_MAPPING, false, false, callback);
         else {
             OUTPUT_MAPPING.flush();
-            return false;
+            callback();
         }
     };
 


### PR DESCRIPTION
Affects the mixer and servos tab. This way they show a couple of
warnings ("no servos" and "upgrade the FC firmware" respectively)
rather than hanging the configurator.

Fixes https://github.com/iNavFlight/inav/issues/3462