### PR TITLE
CSS fixes in the mixer tab

### DIFF
--- a/src/css/tabs/mixer.css
+++ b/src/css/tabs/mixer.css
@@ -10,6 +10,7 @@
 
 .mixer-table {
     width: 100%;
+    text-align: center;
 }
 
 .mixer-table thead {
@@ -17,6 +18,11 @@
 }
 
 .mixer-table input {
+    width: 80%;
+    margin: 0 5px;
+}
+
+.mixer-table .delete {
     width: 75px;
 }
 
@@ -74,4 +80,8 @@
 
 .output-table #function-row td {
     background-color: #ebe7e7;
+}
+
+.mixer_btn_add {
+    margin: 15px 0 10px;
 }

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -85,14 +85,14 @@
                                     <th data-i18n="controlAxisRoll"></th>
                                     <th data-i18n="controlAxisPitch"></th>
                                     <th data-i18n="controlAxisYaw"></th>
-                                    <th style="width: 75px"></th>
+                                    <th class="delete"></th>
                                 </tr>
                             </thead>
                             <tbody>
             
                             </tbody>
                         </table>
-                        <div class="btn default_btn narrow pull-right green" style="margin-bottom: 15px">
+                        <div class="btn default_btn narrow pull-right green mixer_btn_add">
                             <a href="#" data-role="role-motor-add" data-i18n="servoMixerAdd"></a>
                         </div>
                     </div>
@@ -111,14 +111,14 @@
                                     <th data-i18n="input"></th>
                                     <th data-i18n="weight"></th>
                                     <th data-i18n="speed"></th>
-                                    <th style="width: 75px"></th>
+                                    <th class="delete"></th>
                                 </tr>
                             </thead>
                             <tbody>
             
                             </tbody>
                         </table>
-                        <div class="btn default_btn narrow pull-right green" style="margin-bottom: 15px">
+                        <div class="btn default_btn narrow pull-right green mixer_btn_add">
                             <a href="#" data-role="role-servo-add" data-i18n="servoMixerAdd"></a>
                         </div>
                     </div>


### PR DESCRIPTION
Prevents tables from overflowing their containers with some window
widths.