### PR TITLE
Update Slack auto-invite link

### DIFF
--- a/tabs/landing.html
+++ b/tabs/landing.html
@@ -8,7 +8,7 @@
         </div>
         <div class="community">
             <ul class="communityTelegramSupport"><a href="https://t.me/INAVFlight" target="_blank"><i class="fa fa-telegram" aria-hidden="true"></i><span i18n="communityTelegramSupport"></span></a></ul>
-            <ul class="communitySlackSupport"><a href="https://inavflight.signup.team/" target="_blank"><i class="fa fa-slack" aria-hidden="true"></i><span i18n="communitySlackSupport"></span></a></ul>
+            <ul class="communitySlackSupport"><a href="https://publicslack.com/slacks/inavflight/invites/new" target="_blank"><i class="fa fa-slack" aria-hidden="true"></i><span i18n="communitySlackSupport"></span></a></ul>
             <ul class="communityRCGroupsSupport"><a href="https://www.rcgroups.com/forums/showthread.php?2495732-Cleanflight-iNav-%28navigation-rewrite%29-project" target="_blank"><i class="fa fa-users" aria-hidden="true"></i><span i18n="communityRCGroupsSupport"></span></a></ul>
         </div>
         <div class="content_mid">


### PR DESCRIPTION
Replace signup.team, which has been down for some time, with
publicslack.com