### PR TITLE
Make the attribution link in Missions tab open an external window

### DIFF
--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -339,6 +339,17 @@ TABS.mission_control.initialize = function (callback) {
             })
         });
 
+        // Set the attribute link to open on an external browser window, so
+        // it doesn't interfere with the configurator.
+        var interval;
+        interval = setInterval(function() {
+            var anchor = $('.ol-attribution a');
+            if (anchor.length) {
+                anchor.attr('target', '_blank');
+                clearInterval(interval);
+            }
+        }, 100);
+
         map.on('click', function (evt) {
             if (selectedMarker != null) {
                 try {


### PR DESCRIPTION
Otherwise it overrides the viewport of the configurator. The GPS
tab doesn't have this problem because it uses an intermediate
iframe to host the map.

Fixes #540