### PR TITLE
Add support for per-uart options for inversion and full/half duplex

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -880,10 +880,7 @@
         "message": "Until first arm"
     },
     "portsHelp": {
-        "message": "<strong>Note:</strong> not all combinations are valid.  When the flight controller firmware detects this the serial port configuration will be reset."
-    },
-    "portsMSPHelp": {
-        "message": "<strong>Note:</strong> Do <span style=\"color: red\">NOT</span> disable MSP on the first serial port unless you know what you are doing.  You may have to reflash and erase your configuration if you do."
+        "message": "<strong>Note:</strong> Not all combinations are valid. When the flight controller firmware detects a problem, it might change the serial port configuration."
     },
     "portsFirmwareUpgradeRequired": {
         "message": "Firmware upgrade <span style=\"color: red\">required</span>.  Serial port configurations of firmware &lt; 1.8.0 is not supported."
@@ -2602,8 +2599,62 @@
     "osdSettingMainVoltageDecimals": {
         "message": "Main Voltage Decimals"
     },
+    "portColumnIdentifier": {
+        "message": "Port"
+    },
+    "portColumnMSP": {
+        "message": "MSP"
+    },
+    "portColumnTelemetry": {
+        "message": "Telemetry"
+    },
+    "portColumnSerialRX": {
+        "message": "Serial RX"
+    },
     "portColumnSensors": {
         "message": "Sensors"
+    },
+    "portColumnPeripherals": {
+        "message": "Peripherals"
+    },
+    "portColumnOptions": {
+        "message": "Options"
+    },
+    "portOptionsTitle": {
+        "message":  "$1 Options"
+    },
+    "portOptionsSerialInversion": {
+        "message": "Serial Inversion:"
+    },
+    "portOptionAuto": {
+        "message": "Auto"
+    },
+    "portOptionNotInverted": {
+        "message": "Not Inverted"
+    },
+    "portOptionNotInvertedAbbr": {
+        "message": "NI"
+    },
+    "portOptionInverted": {
+        "message": "Inverted"
+    },
+    "portOptionInvertedAbbr": {
+        "message": "I"
+    },
+    "portOptionsFullHalfDuplex": {
+        "message": "Full/Half Duplex:"
+    },
+    "portOptionFullDuplex": {
+        "message": "Full Duplex"
+    },
+    "portOptionFullDuplexAbbr": {
+        "message": "FD"
+    },
+    "portOptionHalfDuplex": {
+        "message": "Half Duplex"
+    },
+    "portOptionHalfDuplexAbbr": {
+        "message": "HD"
     },
     "appUpdateNotificationHeader": {
         "message": "New Configurator version available."

--- a/src/css/tabs/ports.css
+++ b/src/css/tabs/ports.css
@@ -90,6 +90,29 @@
     border-right: 0px;
 }
 
+.tab-ports .functionsCell-options a {
+    background-color: #37a8db;
+    border-radius: 3px;
+    border: 1px solid #3394b5;
+    color: #fff;
+    padding: 1px 5px;
+}
+
+#tab-ports-options-modal .port-option {
+    margin: 15px 15px 0;
+}
+
+#tab-ports-options-modal .port-option span {
+    display: inline-block;
+    width: 150px;
+}
+
+#tab-ports-options-modal .port-option select {
+    font-size: 100%;
+    display: inline-block;
+    width: 100px;
+}
+
 @media only screen and (max-width: 1055px) , only screen and (max-device-width: 1055px) {
     .tab-ports table thead tr:first-child {
         font-size: 12px;

--- a/tabs/ports.html
+++ b/tabs/ports.html
@@ -9,18 +9,18 @@
             <div class="note spacebottom">
                 <div class="note_spacer">
                     <p data-i18n="portsHelp"></p>
-                    <p data-i18n="portsMSPHelp"></p>
                 </div>
             </div>
             <table class="ports spacebottom">
                 <thead>
                     <tr>
-                        <td>Identifier</td>
-                        <td>Data</td>
-                        <td>Telemetry</td>
-                        <td>RX</td>
+                        <td data-i18n="portColumnIdentifier"></td>
+                        <td data-i18n="portColumnMSP">MSP</td>
+                        <td data-i18n="portColumnTelemetry"></td>
+                        <td data-i18n="portColumnSerialRX"></td>
                         <td data-i18n="portColumnSensors"></td>
-                        <td class='peripherls-column'>Peripherals</td>
+                        <td data-i18n="portColumnPeripherals" class="peripherls-column"></td>
+                        <td data-i18n="portColumnOptions"></td>
                     </tr>
                 </thead>
                 <tbody>
@@ -49,20 +49,36 @@
                 <td class="identifierCell">
                     <p class="identifier"></p>
                 </td>
-                <td class="functionsCell-data"><select class="msp_baudrate">
+                <td class="functionsCell-msp">
+                    <input type="checkbox" value="MSP" class="togglemedium msp_enabled" />
+                    <select class="msp_baudrate">
                         <!-- list generated here -->
-                </select></td>
-                <td class="functionsCell-telemetry"><select class="telemetry_baudrate">
+                    </select>
+                </td>
+                <td class="functionsCell-telemetry">
+                    <select class="telemetry_baudrate">
                         <!-- list generated here -->
-                </select></td>
-                <td class="functionsCell-rx"></td>
-                <td class="functionsCell-sensors"><select class="sensors_baudrate">
+                    </select>
+                </td>
+                <td class="functionsCell-rx">
+                    <input type="checkbox" value="RX_SERIAL" class="togglemedium rx_serial_enabled" />
+                </td>
+                <td class="functionsCell-sensors">
+                    <select class="sensors_baudrate">
                         <!-- list generated here -->
-                </select></td>
-                <td class="functionsCell-peripherals"><select class="blackbox_baudrate">
+                    </select>
+                </td>
+                <td class="functionsCell-peripherals">
+                    <select class="peripheral_baudrate">
                         <!-- list generated here -->
-                </select></td>
+                    </select>
+                </td>
+                <td class="functionsCell-options">
+                    <a class="options" href="#"></a>
+                </td>
             </tr>
         </tbody>
     </table>
+</div>
+<div id="tab-ports-options-modal">
 </div>


### PR DESCRIPTION
- Removed note about not disabling MSP from the top port, just not
allow the user to do it.
- Add port options as a button in a new column
- Use a modal overlay to select the port options

Version checks test for > 2.0.0, since this should be merged only
for 2.1

Configurator PR at https://github.com/iNavFlight/inav/pull/3726

<img width="967" alt="screen shot 2018-08-09 at 21 57 28" src="https://user-images.githubusercontent.com/41529/43927090-4268a6f4-9c24-11e8-9dd6-5c3765bb1f0a.png">
<img width="1009" alt="screen shot 2018-08-09 at 21 57 36" src="https://user-images.githubusercontent.com/41529/43927091-42862e5e-9c24-11e8-883f-4886f2de3642.png">
<img width="960" alt="screen shot 2018-08-09 at 22 00 45" src="https://user-images.githubusercontent.com/41529/43927092-42a192ac-9c24-11e8-8b55-23a27b213782.png">
<img width="968" alt="screen shot 2018-08-09 at 22 27 49" src="https://user-images.githubusercontent.com/41529/43927093-42b9f2ca-9c24-11e8-910f-c8373281a379.png">
<img width="972" alt="screen shot 2018-08-09 at 22 27 56" src="https://user-images.githubusercontent.com/41529/43927094-42d4700a-9c24-11e8-9a11-dd0557a0e7b6.png">
