### PR TITLE
Fix the code to select the previously set font

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -2089,10 +2089,15 @@ TABS.osd.initialize = function (callback) {
 
         // load the last selected font when we change tabs
         chrome.storage.local.get('osd_font', function (result) {
-            if (result.osd_font != undefined)
-                $('.fontbuttons button[data-font-file="' + result.osd_font + '"]').click()
-            else
+            if (result.osd_font != undefined) {
+                previous_font_button = $('.fontbuttons button[data-font-file="' + result.osd_font + '"]');
+                if (previous_font_button.attr('data-font-file') == undefined) previous_font_button = undefined;
+            }
+
+            if (previous_font_button == undefined)
                 $fontPicker.first().click();
+            else
+                previous_font_button.click();
         });
 
         $('button.load_font_file').click(function () {


### PR DESCRIPTION
It prevented the OSD tab from loading if the previously selected font wasn't existing anymore.