### PR TITLE
Wait longer for reconnect

### DIFF
--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -46,7 +46,7 @@ $(document).ready(function () {
                     }, 500);
                 }
 
-            }, 5000);
+            }, 7000);
         } else {
 
             helper.timeout.add('waiting_for_bootup', function waiting_for_bootup() {


### PR DESCRIPTION
If board will fail to init and OS detect VCP port, autoreconnect will fail and board will be stuck.
Looks like now booting takes slightly more time and 5s was not enough. Boost to 7s seems to be solving the problem