### PR TITLE
Cleanup and default to VCP board

### DIFF
--- a/js/boards.js
+++ b/js/boards.js
@@ -2,10 +2,6 @@
 
 var BOARD_DEFINITIONS = [
     {
-        name: "CC3D",
-        identifier: "CC3D",
-        vcp: true
-    }, {
         name: "ChebuzzF3",
         identifier: "CHF3",
         vcp: false
@@ -33,64 +29,29 @@ var BOARD_DEFINITIONS = [
         identifier: "103R",
         vcp: false
     }, {
-        name: "Sparky",
-        identifier: "SPKY",
-        vcp: true
-    }, {
-        name: "STM32F3Discovery",
-        identifier: "SDF3",
-        vcp: true
-    }, {
-        name: "Colibri Race",
-        identifier: "CLBR",
-        vcp: true
-    }, {
         name: "SP Racing F3",
         identifier: "SRF3",
         vcp: false
-    }, {
-        name: "SP Racing F3 Mini",
-        identifier: "SRFM",
-        vcp: true
-    }, {
-        name: "MotoLab",
-        identifier: "MOTO",
-        vcp: true
-    }, {
-        name: "Omnibus",
-        identifier: "OMNI",
-        vcp: true
-    }, {
-        name: "Airbot F4",
-        identifier: "ABF4",
-        vcp: true
-    }, {
-        name: "Revolution",
-        identifier: "REVO",
-        vcp: true
-    }, {
-        name: "Omnibus F4",
-        identifier: "OBF4",
-        vcp: true
-    }, {
-        name: "Omnibus F4 Pro",
-        identifier: "OBSD",
-        vcp: true
     }
 ];
 
 var DEFAULT_BOARD_DEFINITION = {
     name: "Unknown",
     identifier: "????",
-    vcp: false
+    vcp: true
 };
 
 var BOARD = {
 };
 
-BOARD.find_board_definition = function (identifier) {
-    for (var i = 0; i < BOARD_DEFINITIONS.length; i++) {
-        var candidate = BOARD_DEFINITIONS[i];
+BOARD.hasVcp = function (identifier) {
+    let board = BOARD.findDefinition(identifier);
+    return !!board.vcp;
+}
+
+BOARD.findDefinition = function (identifier) {
+    for (let i = 0; i < BOARD_DEFINITIONS.length; i++) {
+        let candidate = BOARD_DEFINITIONS[i];
         
         if (candidate.identifier == identifier) {
             return candidate;

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -22,7 +22,7 @@ $(document).ready(function () {
 
     GUI.handleReconnect = function ($tabElement) {
 
-        if (BOARD.find_board_definition(CONFIG.boardIdentifier).vcp) { // VCP-based flight controls may crash old drivers, we catch and reconnect
+        if (BOARD.hasVcp(CONFIG.boardIdentifier)) { // VCP-based flight controls may crash old drivers, we catch and reconnect
 
             /*
              Disconnect

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -3,8 +3,6 @@
 TABS.ports = {};
 
 TABS.ports.initialize = function (callback) {
-    var board_definition = {};
-
 
     var functionRules = [
          {name: 'MSP',                  groups: ['data', 'msp'], maxPorts: 2},
@@ -134,8 +132,6 @@ TABS.ports.initialize = function (callback) {
 
         function on_configuration_loaded_handler() {
             $('#content').load("./tabs/ports.html", on_tab_loaded_handler);
-
-            board_definition = BOARD.find_board_definition(CONFIG.boardIdentifier);
         }
     }
 


### PR DESCRIPTION
Configurator to successfully reconnect has to know it this is VCP or not board.
Until now, we assumed that board is no-VCP and decided so only if board identifier was defined.

Now, we assume board has VCP and switch back to no-VCP when board is known. Currently new boards are designed with VCP and we know about the old ones like SPRF3 and similar.