### PR TITLE
Fix disappearing Craft Name field

### DIFF
--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -18,6 +18,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 callback();
             });
         } else {
+            craftName = CONFIG.name;
             callback();
         }
     };
@@ -580,7 +581,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             $gyroLpfMessage.removeClass('ok-box');
             $gyroLpfMessage.removeClass('info-box');
             $gyroLpfMessage.removeClass('warning-box');
-            
+
             if (MIXER_CONFIG.platformType == PLATFORM_MULTIROTOR || MIXER_CONFIG.platformType == PLATFORM_TRICOPTER) {
                 console.log($gyroLpfMessage);
                 switch (parseInt(INAV_PID_CONFIG.gyroscopeLpf, 10)) {


### PR DESCRIPTION
The craft name is now being loaded from elsewhere before the Config tab is opened, a pre-existing value was ignored.