### PR TITLE
remove reference to slack for community

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ GitHub issue tracker is reserved for bugs and other technical problems. If you d
 everything, hardware is not working or have any other _support_ problem, please consult:
 
 * [rcgroups main thread](https://www.rcgroups.com/forums/showthread.php?2495732-Cleanflight-iNav-(navigation-rewrite)-project)
-* [Slack channel](https://inavflight.signup.team/)
 * [Telegram Group](https://t.me/INAVFlight)
 
 ## Issue trackers


### PR DESCRIPTION
Rather than #676 which fixed the URL; this PR removes the URL to slack