### PR TITLE
Current consumption alarm in OSD

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2407,6 +2407,12 @@
     "osdAlarmMAX_NEG_ALTITUDE_HELP": {
         "message": "The altitude indicator will flash when altitude is negative and its absolute value is greater than this alarm. Useful when taking off from elevated places. Zero disables this alarm."
     },
+    "osdAlarmCURRENT": {
+        "message": "Current"
+    },
+    "osdAlarmCURRENT_HELP": {
+        "message": "The current draw element will start blinking when the consumption is greater than this value. Zero disables this alarm."
+    },
     "osdAlarmIMU_TEMPERATURE_MIN": {
         "message": "Minimum IMU temperature"
     },
@@ -2547,7 +2553,7 @@
     },
     "osdElement_3D_SPEED": {
         "message": "3D Speed"
-    },   
+    },
     "osdElement_3D_SPEED_HELP": {
         "message": "Shows 3D speed considering both horizontal and vertical speed."
     },

--- a/resources/settings.json
+++ b/resources/settings.json
@@ -1389,6 +1389,9 @@
   "osd_alt_alarm": {
     "type": "uint16_t"
   },
+  "osd_current_alarm": {
+    "type": "uint8_t"
+  },
   "osd_artificial_horizon_reverse_roll": {
     "type": "uint8_t",
     "table": {

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -402,6 +402,7 @@ OSD.initData = function () {
             max_altitude: null,
             dist: null,
             max_neg_altitude: null,
+            current: null,
             imu_temp_alarm_min: null,
             imu_temp_alarm_max: null,
             baro_temp_alarm_min: null,
@@ -499,6 +500,13 @@ OSD.constants = {
             unit: altitude_alarm_unit,
             to_display: altitude_alarm_to_display,
             from_display: altitude_alarm_from_display,
+        },
+        {
+            name: 'CURRENT',
+            field: 'current',
+            min_version: '2.2.0',
+            step: 1,
+            unit: 'A',
         },
         {
             name: 'IMU_TEMPERATURE_MIN',
@@ -1617,6 +1625,9 @@ OSD.msp = {
         result.push16(OSD.data.alarms.max_altitude);
         result.push16(OSD.data.alarms.dist);
         result.push16(OSD.data.alarms.max_neg_altitude);
+        if (semver.gte(CONFIG.flightControllerVersion, '2.2.0')) {
+            result.push8(OSD.data.alarms.current);
+        }
         if (semver.gte(CONFIG.flightControllerVersion, '2.1.0')) {
             result.push16(OSD.data.alarms.imu_temp_alarm_min);
             result.push16(OSD.data.alarms.imu_temp_alarm_max);
@@ -1634,6 +1645,9 @@ OSD.msp = {
         OSD.data.alarms.max_altitude = alarms.readU16();
         OSD.data.alarms.dist = alarms.readU16();
         OSD.data.alarms.max_neg_altitude = alarms.readU16();
+        if (semver.gte(CONFIG.flightControllerVersion, '2.2.0')) {
+            OSD.data.alarms.current = alarms.readU8();
+        }
         if (semver.gte(CONFIG.flightControllerVersion, '2.1.0')) {
             OSD.data.alarms.imu_temp_alarm_min = alarms.read16();
             OSD.data.alarms.imu_temp_alarm_max = alarms.read16();
@@ -1707,6 +1721,11 @@ OSD.msp = {
         result.push16(OSD.data.alarms.fly_minutes);
         result.push16(OSD.data.alarms.max_altitude);
         // These might be null, since there weren't supported
+        // until version 2.2
+        if (OSD.data.alarms.current !== null) {
+            result.push8(OSD.data.alarms.current);
+        }
+        // These might be null, since there weren't supported
         // until version 1.8
         if (OSD.data.alarms.dist !== null) {
             result.push16(OSD.data.alarms.dist);
@@ -1741,6 +1760,10 @@ OSD.msp = {
 
         d.alarms.dist = view.readU16();
         d.alarms.max_neg_altitude = view.readU16();
+
+        if (semver.gte(CONFIG.flightControllerVersion, '2.2.0')) {
+            d.alarms.current = view.readU8();
+        }
 
         d.items = [];
         // start at the offset from the other fields


### PR DESCRIPTION
Companion PR to iNavFlight/inav#4715.

I could use a check on the way I set up retrocompatibility: since this is an `uint8` I had to place it before the latest `uint16` additions to avoid moving the looped generic readings **(specifically [here][check-1] and [here][check-2])**.

[check-1]: https://github.com/iNavFlight/inav-configurator/compare/iNavFlight:150f6c9...nmaggioni:2f9ab94#diff-7db851820cf7a896309fa2ecbee7e185R1763
[check-2]: https://github.com/iNavFlight/inav-configurator/compare/iNavFlight:150f6c9...nmaggioni:2f9ab94#diff-7db851820cf7a896309fa2ecbee7e185R1723