### PR TITLE
Add VTX Power Level Adjustment option

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1251,6 +1251,9 @@
     "adjustmentsFunction38": {
         "message": "Level D Adjustment"
     },
+    "adjustmentsFunction49":{
+        "message": "VTX Power Level Adjustment"
+    },
     "adjustmentsSave": {
         "message": "Save"
     },

--- a/tabs/adjustments.html
+++ b/tabs/adjustments.html
@@ -106,6 +106,7 @@
                         <option value="36" i18n="adjustmentsFunction36"></option>
                         <option value="37" i18n="adjustmentsFunction37"></option>
                         <option value="38" i18n="adjustmentsFunction38"></option>
+                        <option value="49" i18n="adjustmentsFunction49"></option>
                 </select></td>
                 <td class="adjustmentSlot"><select class="slot">
                         <option value="0" i18n="adjustmentsSlot0"></option>

--- a/tabs/adjustments.js
+++ b/tabs/adjustments.js
@@ -64,9 +64,11 @@ TABS.adjustments.initialize = function (callback) {
 
         // update list of selected functions
         var functionListOptions = $(functionList).find('option');
-        var availableFunctionCount = 32;
+        var availableFunctionCount = 40;
 
         var functionListOptions = $(functionListOptions).slice(0,availableFunctionCount);
+        // Remove item 32-39 from list. Need rework
+        functionListOptions.splice(32, 7);
         functionList.empty().append(functionListOptions);
 
         functionList.val(adjustmentRange.adjustmentFunction);


### PR DESCRIPTION
This PR add the option in Adjustments Tab for "VTX Power Level".
iNav feature PR [#4717](https://github.com/iNavFlight/inav/pull/4717)

As you can see in [line 70 adjustments.js](https://github.com/L4ky/inav-configurator/blob/5f521bc987544c43a1968344fcce44f0e02ae497/tabs/adjustments.js#L70)
i had to create this workaround to hide some entries that were not showing.

Definitely need rework in the future.

Bench tested.