### PR TITLE
Fixed GPS map zoom issue

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3180,5 +3180,8 @@
     },
     "mc_airmode_threshold_help": {
         "message": "Defines airmode THROTTLE activation threshold when mc_airmode_type THROTTLE_THRESHOLD is used"
+    },
+    "gps_map_center": {
+        "message": "Center"
     }
 }

--- a/src/css/tabs/gps.css
+++ b/src/css/tabs/gps.css
@@ -50,6 +50,24 @@
     float: left;
 }
 
+.map-button {
+  z-index:1;
+  position: absolute;
+  background-color: #37A8DB;
+  color: white;
+  padding: 5px;
+  left: 10px;
+  bottom: 10px;
+  border-style: solid;
+  border-width: 2px;
+  border-color: #E4E4E4;
+  border-radius: 2px;
+  opacity: 0.8;
+}
+.map-button:hover {
+  opacity: 1;
+}
+
 .tab-gps #loadmap .controls {
     width: 100%;
     float: left;
@@ -99,6 +117,7 @@
     height: 400px;
     width: 100%;
     float: left;
+    position: relative;
 }
 
 /*noinspection ALL*/

--- a/tabs/gps.html
+++ b/tabs/gps.html
@@ -91,7 +91,9 @@
                     <div class="spacer_box_title" data-i18n="gpsMapHead"></div>
                 </div>
                 <div id="loadmap">
-                    <div id="gps-map"></div>
+                    <div id="gps-map">
+                      <button class="map-button" id="center_button" data-i18n="gps_map_center"></button>
+                    </div>
                 </div>
         </div>
 

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -27,7 +27,7 @@ TABS.gps.initialize = function (callback) {
             center: ol.proj.fromLonLat([0, 0]),
             zoom: 15
         });
-        
+
         let mapLayer;
 
         if (globalSettings.mapProviderType == 'bing') {
@@ -40,10 +40,17 @@ TABS.gps.initialize = function (callback) {
         	mapLayer = new ol.source.TileWMS({
         		url: globalSettings.proxyURL,
                 params: {'LAYERS':globalSettings.proxyLayer}
-             })               
+             })
         } else {
             mapLayer = new ol.source.OSM();
         }
+
+        $("#center_button").click(function(){
+          let lat = GPS_DATA.lat / 10000000;
+          let lon = GPS_DATA.lon / 10000000;
+          let center = ol.proj.fromLonLat([lon, lat]);
+          mapView.setCenter(center);
+        });
 
         mapHandler = new ol.Map({
             target: document.getElementById('gps-map'),
@@ -82,7 +89,7 @@ TABS.gps.initialize = function (callback) {
             } else if (GPS_DATA.fix >= 1) {
                 gpsFixType = chrome.i18n.getMessage('gpsFix2D');
             }
-            
+
             $('.GPS_info td.fix').html(gpsFixType);
             $('.GPS_info td.alt').text(GPS_DATA.alt + ' m');
             $('.GPS_info td.lat').text(lat.toFixed(4) + ' deg');
@@ -107,6 +114,8 @@ TABS.gps.initialize = function (callback) {
             //Update map
             if (GPS_DATA.fix >= 2) {
 
+                let center = ol.proj.fromLonLat([lon, lat]);
+
                 if (!cursorInitialized) {
                     cursorInitialized = true;
 
@@ -118,29 +127,30 @@ TABS.gps.initialize = function (callback) {
                             src: '../images/icons/cf_icon_position.png'
                         }))
                     });
-            
+
                     let currentPositionLayer;
                     iconGeometry = new ol.geom.Point(ol.proj.fromLonLat([0, 0]));
                     iconFeature = new ol.Feature({
                         geometry: iconGeometry
                     });
-            
+
                     iconFeature.setStyle(iconStyle);
-            
+
                     let vectorSource = new ol.source.Vector({
                         features: [iconFeature]
                     });
                     currentPositionLayer = new ol.layer.Vector({
                         source: vectorSource
                     });
-            
+
                     mapHandler.addLayer(currentPositionLayer);
+                    
+                    mapView.setCenter(center);
+                    mapView.setZoom(14);
                 }
 
-                let center = ol.proj.fromLonLat([lon, lat]);
-                mapView.setCenter(center);
-                mapView.setZoom(14);
                 iconGeometry.setCoordinates(center);
+
             }
         }
 


### PR DESCRIPTION
On map of GPS tab i've added a button to center the map position to current position of the UAV and i've removed the zoom and the centering on every GPS data update.
So i've fixed issue #702 
Now clicking on + and - regolate the map zoom without center the map, while clicking on center button place the drone position to the center of the view.

![Screenshot](https://user-images.githubusercontent.com/40276199/60169423-f211f680-9806-11e9-867e-e4813adf29ab.png)

