### PR TITLE
[OSD]: Workaround for F3 64 byte write bug on macOS

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -290,9 +290,11 @@ FONT.upload = function (callback) {
             if (callback) {
                 callback(idx, count, (idx / count) * 100);
             }
-            // Force usage of V1 protocol to workaround the 64 byte write bug
+            // Force usage of V1/V2 protocol to workaround the 64 byte write bug
             // on F3 when the configurator is running on macOS
-            return MSP.promise(MSPCodes.MSP_OSD_CHAR_WRITE, FONT.msp.encode(next, MSP.constants.PROTOCOL_V1));
+            var proto = next <= 255 ? MSP.constants.PROTOCOL_V1 : MSP.constants.PROTOCOL_V2;
+            var data = FONT.msp.encode(next);
+            return MSP.promise(MSPCodes.MSP_OSD_CHAR_WRITE, data, proto);
         });
     }, Promise.resolve()).then(function() {
         OSD.GUI.jbox.close();


### PR DESCRIPTION
Upload fonts with address <= 255 using MSPv1, use MSPv2 for fonts
with address > 255. This ensures we never send a payload with one
of the problematic lengths.