### PR TITLE
Port of Copy to clipboard and Load from file in CLI tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1480,6 +1480,24 @@
     "cliClearOutputHistoryBtn": {
         "message": "Clear output history"
     },
+    "cliCopyToClipboardBtn": {
+        "message": "Copy to clipboard"
+    },
+    "cliCopySuccessful": {
+        "message": "Copied!"
+    },
+    "cliLoadFromFileBtn": {
+        "message": "Load from file"
+    },
+    "cliConfirmSnippetDialogTitle": {
+        "message": "Review loaded commands"
+    },
+    "cliConfirmSnippetNote": {
+        "message": "<strong>Note</strong>: You can review and edit commands before execution."
+    },
+    "cliConfirmSnippetBtn": {
+        "message": "Execute"
+    },
 
     "loggingNote": {
         "message": "Data will be logged in this tab <span style=\"color: red\">only</span>, leaving the tab will <span style=\"color: red\">cancel</span> logging and application will return to its normal <strong>\"configurator\"</strong> state.<br /> You are free to select the global update period, data will be written into the log file every <strong>1</strong> second for performance reasons."

--- a/src/css/tabs/cli.css
+++ b/src/css/tabs/cli.css
@@ -50,12 +50,29 @@
     resize: none;
 }
 
+.jBox-container textarea#preview {
+    background-color: rgba(0, 0, 0, 0.75);
+    width: 100%;
+    resize: none;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    font-family: monospace;
+    color: white;
+    padding: 5px;
+    margin-bottom: 5px;
+}
+
 .tab-cli #content-watermark {
     z-index: 0;
 }
 
 .tab-cli .window .wrapper {
     white-space: pre-wrap;
+}
+
+.tab-cli .window .error_message {
+    color: red;
+    font-weight: bold;
 }
 
 .tab-cli .save {

--- a/tabs/cli.html
+++ b/tabs/cli.html
@@ -16,7 +16,22 @@
     <div class="content_toolbar">
         <div class="btn save_btn pull-right">
             <a class="save" href="#" i18n="cliSaveToFileBtn"></a>
+            <a class="load" href="#" i18n="cliLoadFromFileBtn"></a>
             <a class="clear" href="#" i18n="cliClearOutputHistoryBtn"></a>
+            <a class="copy" href="#" i18n="cliCopyToClipboardBtn"></a>
+        </div>
+    </div>
+
+    <!-- Snippet preview dialog -->
+    <div id="snippetpreviewcontent" style="display: none">
+        <div class="note">
+            <div class="note_spacer">
+                <p i18n="cliConfirmSnippetNote"></p>
+            </div>
+        </div>
+        <textarea id="preview" cols="120" rows="20"></textarea>
+        <div class="default_btn">
+            <a class="confirm" href="#" i18n="cliConfirmSnippetBtn"></a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Port of BF's _Copy to clipboard_ and _Load from file_ functions for the CLI tab. When loading commands from a file a dialog lets the user check and edit anything that will be sent. While I was at it I've also ported coloring for batch mode errors.

The function `sendLinesWithDelay` is used by both the usual user interaction and the file loading process, thus avoiding code duplication and making future messing with the delays easier.