### PR TITLE
Fix tab name in outputs disabled warning

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1965,7 +1965,7 @@
         "message" : "Servo has to support refresh rate. Change only if you know that servo supports it. Too high refresh rate might damage servos!"
     },
     "logPwmOutputDisabled": {
-        "message" : "PWM output is disabled. Motors and servos will not work. Use <u>Configuration</u> tab to enable!"
+        "message" : "PWM output is disabled. Motors and servos will not work. Use <u>Outputs</u> tab to enable!"
     },
     "configurationGyroSyncTitle": {
         "message" : "Synchronize looptime with gyroscope"


### PR DESCRIPTION
Relevant section has been moved to the "Outputs" tab.