### PR TITLE
Show µs in mixer when "ONE" input is selected

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2966,6 +2966,9 @@
     "input": {
         "message": "Input"
     },
+    "fixedValue": {
+        "message": "Fixed Value (µs)"
+    },
     "weight": {
         "message": "Weight (%)"
     },

--- a/js/fc.js
+++ b/js/fc.js
@@ -1082,7 +1082,7 @@ var FC = {
         ];
     },
     getServoMixInputName: function (input) {
-        return getServoMixInputNames()[input];
+        return this.getServoMixInputNames()[input];
     },
     getModeId: function (name) {
         for (var i = 0; i < AUX_CONFIG.length; i++) {
@@ -1095,7 +1095,7 @@ var FC = {
         return bit_check(CONFIG.mode[Math.trunc(i / 32)], i % 32);
     },
     isModeEnabled: function (name) {
-        return FC.isModeBitSet(FC.getModeId(name));
+        return this.isModeBitSet(this.getModeId(name));
     },
     getLogicOperators: function () {
         return {
@@ -1181,7 +1181,7 @@ var FC = {
                     0: "ARM timer [s]",
                     1: "Home distance [m]",
                     2: "Trip distance [m]",
-                    3: "RSSI", 
+                    3: "RSSI",
                     4: "Vbat [deci-Volt] [1V = 10]",
                     5: "Cell voltage [deci-Volt] [1V = 10]",
                     6: "Current [centi-Amp] [1A = 100]",

--- a/src/css/tabs/mixer.css
+++ b/src/css/tabs/mixer.css
@@ -85,3 +85,7 @@
 .mixer_btn_add {
     margin: 15px 0 10px;
 }
+
+.mixer-fixed-value-col {
+    display: none;
+}

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -61,12 +61,12 @@
 
                 </tr>
                 <tr id="function-row">
-                    
+
                 </tr>
             </table>
         </div>
 
-        <!-- middle roew -->
+        <!-- middle row -->
         <div class="clear-both"></div>
         <!-- bottom row -->
         <div class="motor-mixer gui_box grey">
@@ -86,7 +86,7 @@
                         </tr>
                     </thead>
                     <tbody>
-    
+
                     </tbody>
                 </table>
                 <div class="btn default_btn narrow pull-right green mixer_btn_add">
@@ -104,6 +104,7 @@
                         <tr>
                             <th style="width: 75px" data-i18n="servo"></th>
                             <th data-i18n="input"></th>
+                            <th data-i18n="fixedValue" class="mixer-fixed-value-col"></th>
                             <th data-i18n="weight"></th>
                             <th data-i18n="speed"></th>
                             <th data-i18n="active"></th>
@@ -111,7 +112,7 @@
                         </tr>
                     </thead>
                     <tbody>
-    
+
                     </tbody>
                 </table>
                 <div class="btn default_btn narrow pull-left mixer_btn_add">

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -100,6 +100,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
                     <tr>\
                     <td><input type="number" class="mix-rule-servo" step="1" min="0" max="15" /></td>\
                     <td><select class="mix-rule-input"></select></td>\
+                    <td class="mixer-fixed-value-col"><input type="number" class="mix-rule-fixed-value" min="875" max="2125" disabled /></td> \
                     <td><input type="number" class="mix-rule-rate" step="1" min="-125" max="125" /></td>\
                     <td><input type="number" class="mix-rule-speed" step="1" min="0" max="255" /></td>\
                     <td><select class="mix-rule-condition"></td>\
@@ -119,9 +120,10 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
                 });
 
                 GUI.fillSelect($row.find(".mix-rule-input"), FC.getServoMixInputNames(), servoRule.getInput());
-                
+
                 $row.find(".mix-rule-input").val(servoRule.getInput()).change(function () {
                     servoRule.setInput($(this).val());
+                    updateFixedValueVisibility($row, $(this));
                 });
 
                 $row.find(".mix-rule-servo").val(servoRule.getTarget()).change(function () {
@@ -130,15 +132,19 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
 
                 $row.find(".mix-rule-rate").val(servoRule.getRate()).change(function () {
                     servoRule.setRate($(this).val());
+                    $row.find(".mix-rule-fixed-value").val(mapServoWeightToFixedValue($(this).val()));
                 });
+
+                $row.find(".mix-rule-fixed-value").val(mapServoWeightToFixedValue($row.find(".mix-rule-rate").val()));
 
                 $row.find(".mix-rule-speed").val(servoRule.getSpeed()).change(function () {
                     servoRule.setSpeed($(this).val());
                 });
-                
-                $row.find("[data-role='role-servo-delete']").attr("data-index", servoRuleIndex);
-            }
 
+                $row.find("[data-role='role-servo-delete']").attr("data-index", servoRuleIndex);
+
+                updateFixedValueVisibility($row, $row.find(".mix-rule-input"));
+            }
         }
 
         let rate_inputs = $('.mix-rule-rate');
@@ -146,6 +152,36 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         rate_inputs.attr("max", 1000);
 
         localize();
+    }
+
+    function updateFixedValueVisibility(row, $mixRuleInput) {
+
+        // Show the fixed value input box if "ONE" input was selected for this servo
+        const $fixedValueCalcInput = row.find(".mix-rule-fixed-value");
+        if (FC.getServoMixInputNames()[$mixRuleInput.val()] === 'ONE') {
+            $fixedValueCalcInput.show();
+            row.find(".mix-rule-speed").prop('disabled', true);
+        } else {
+            $fixedValueCalcInput.hide();
+            row.find(".mix-rule-speed").prop('disabled', false);
+        }
+
+        // Show the Fixed Value column if at least one servo has the "ONE" input assigned
+        const $fixedValueCol = $("#servo-mix-table").find(".mixer-fixed-value-col");
+        const rules = SERVO_RULES.get();
+        for (let servoRuleIndex in rules) {
+            if (rules.hasOwnProperty(servoRuleIndex)) {
+                if (FC.getServoMixInputNames()[rules[servoRuleIndex].getInput()] === 'ONE') {
+                    $fixedValueCol.show();
+                    return;
+                }
+            }
+        }
+        $fixedValueCol.hide();
+    }
+
+    function mapServoWeightToFixedValue(weight) {
+        return (parseInt(weight) + 100) * 1000 / 200 + 1000;
     }
 
     function renderMotorMixRules() {
@@ -281,7 +317,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         $mixerPreset.change(function () {
             const presetId = parseInt($mixerPreset.val(), 10);
             currentMixerPreset = helper.mixer.getById(presetId);
-            
+
             MIXER_CONFIG.appliedMixerPreset = presetId;
 
             $('.mixerPreview img').attr('src', './resources/motor_order/'
@@ -357,7 +393,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         $("[data-role='role-logic-conditions-open']").click(function () {
             LOGIC_CONDITIONS.open();
         });
-        
+
         $('#save-button').click(saveAndReboot);
 
         renderServoMixRules();
@@ -369,11 +405,11 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         LOGIC_CONDITIONS.init($('#logic-wrapper'));
 
         localize();
-        
+
         if (semver.gte(CONFIG.flightControllerVersion, "2.3.0")) {
             helper.mspBalancedInterval.add('logic_conditions_pull', 350, 1, getLogicConditionsStatus);
         }
-        
+
         GUI.content_ready(callback);
     }
 


### PR DESCRIPTION
Configurator-only alternative to iNavFlight/inav#4835 and #795.

![picos_small](https://user-images.githubusercontent.com/3594528/72208881-ad029880-34a8-11ea-8fb1-b90e1d270c07.png)
