### PR TITLE
Remove double initialization of helper.defaultsDialog

### DIFF
--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -340,7 +340,6 @@ function onConnect() {
     }, 100);
 
     helper.interval.add('global_data_refresh', helper.periodicStatusUpdater.run, helper.periodicStatusUpdater.getUpdateInterval(serial.bitrate), false);
-    helper.defaultsDialog.init();
 }
 
 function onClosed(result) {


### PR DESCRIPTION
helper.defaultsDialog.init() was called from both onConnect()
and onValidFirmware(). Thanks to @dzikuvx for pointing out that
just the last call was enough.