### PR TITLE
Fix double dispatch of MSP calls with the same code

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1495,7 +1495,10 @@ var mspHelper = (function (gui) {
                     dataHandler.callbacks.splice(i, 1);
 
                     // fire callback
-                    if (callback) callback({'command': dataHandler.code, 'data': data, 'length': dataHandler.message_length_expected});
+                    if (callback) {
+                        callback({'command': dataHandler.code, 'data': data, 'length': dataHandler.message_length_expected});
+                    }
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Current MSP handling groups callbacks by their MSP command
and when a response comes back it calls all the pending handlers
with the same response object.

This works fine when all MSP calls are either pure input or pure
output (e.g. the have a non-empty payload in just one direction).
However, we've had some calls that have a payload in both directions
for some time, like MSPV2_SETTING. For those MSP commands, the
response will depend on the request, so calling all handlers on
the first response received produces the wrong results. It's also
problematic on handlers that expect any kind of response, since the
DataView object is reused, but its offset was never reset which
would result in the second handler getting an empty response.

Change this strategy to call just the first pending handlers for
the MSP command received in the response. While this is still
a theoretical race condition (there's no guarantee a sequence of
the same command with different payloads will be replied in the
same order as they were issued to the FC), it's the best we can
do unless we add some kind of nonce/token system to each MSP
request, which would incur a significant overhead.