### PR TITLE
Add nw and gulp as npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For local development, **node.js** build system is used.
 1. From project folder run `npm install`
 1. To build the JS and CSS files and start the configurator:
     - With NW.js: Run `npm start`.
-    - With Chrome: Run `./node_modules/gulp/bin/gulp.js`. Then open `chrome://extensions`, enable
+    - With Chrome: Run `npm run gulp`. Then open `chrome://extensions`, enable
     the `Developer mode`, click on the `Load unpacked extension...` button and select the `inav-configurator` directory.
 
 Other tasks are also defined in `gulpfile.js`. To run a task, use `./node_modules/gulp/bin/gulp.js task-name`. Available ones are:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "main.html",
   "default_locale": "en",
   "scripts": {
-    "start": "node node_modules/gulp/bin/gulp.js build && node node_modules/nw/bin/nw ."
+    "start": "node node_modules/gulp/bin/gulp.js build && node node_modules/nw/bin/nw .",
+    "gulp": "gulp",
+    "nw": "nw"
   },
   "window": {
     "title": "INAV Configurator",


### PR DESCRIPTION
This allows running them with `npm run gulp` and `npm run nw`
instead of having to type the whole path to the actual binaries.

Also, updated README to simplify the build instructions.