### PR TITLE
[FLASHER] Increase .hex file size limit to 100MB

### DIFF
--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -203,9 +203,9 @@ TABS.firmware_flasher.initialize = function (callback) {
                         var reader = new FileReader();
 
                         reader.onprogress = function (e) {
-                            if (e.total > 1048576) { // 1 MB
-                                // dont allow reading files bigger then 1 MB
-                                console.log('File limit (1 MB) exceeded, aborting');
+                            if (e.total > 104857600) { // 100 MB
+                                // dont allow reading files bigger then 100 MB
+                                console.log('File limit (100 MB) exceeded, aborting');
                                 reader.abort();
                             }
                         };


### PR DESCRIPTION
The previous 1MB limit is too low, we already have hex files bigger
than that.