### PR TITLE
[TABS] Generate the documentation link dynamically via JS

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -55,7 +55,9 @@
     "configMigrationSuccessful": {
         "message": "Configuration migration complete, migrations applied: $1"
     },
-
+    "documentation": {
+        "message": "Documentation"
+    },
     "tabFirmwareFlasher": {
         "message": "Firmware Flasher"
     },

--- a/js/gui.js
+++ b/js/gui.js
@@ -164,12 +164,13 @@ GUI_control.prototype.content_ready = function (callback) {
          $(elem).removeClass('togglemedium');
     });
 
-    if (CONFIGURATOR.connectionValid) {
-        // Build link to in-use CF version documentation
-        var documentationButton = $('div#content #button-documentation');
-        documentationButton.html("Documentation for INAV");
-        documentationButton.attr("href","https://github.com/iNavFlight/inav/wiki");
-    }
+    // Insert a documentation button next to the tab title
+    const tabTitle = $('div#content .tab_title');
+    const documentationDiv = $('<div>').addClass('cf_doc_version_bt');
+    $('<a>').attr('href', 'https://github.com/iNavFlight/inav/wiki')
+        .attr('target', '_blank').attr('id', 'button-documentation')
+        .html(chrome.i18n.getMessage('documentation')).appendTo(documentationDiv);
+    documentationDiv.insertAfter(tabTitle);
 
     // loading tooltip
     jQuery(document).ready(function($) {

--- a/tabs/adjustments.html
+++ b/tabs/adjustments.html
@@ -1,9 +1,6 @@
 <div class="tab-adjustments toolbar_fixed_bottom">
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabAdjustments"></div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
         <div class="note spacebottom">
             <div class="note_spacer">
                 <p i18n="adjustmentsHelp"></p>

--- a/tabs/auxiliary.html
+++ b/tabs/auxiliary.html
@@ -1,9 +1,6 @@
 <div class="tab-auxiliary toolbar_fixed_bottom">
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabAuxiliary">tabAuxiliary</div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
         <div class="note spacebottom">
             <div class="note_spacer">
                 <p i18n="auxiliaryHelp"></p>

--- a/tabs/calibration.html
+++ b/tabs/calibration.html
@@ -3,9 +3,6 @@
         <!-- should be the first DIV on each tab -->
         <div class="cf_column full spacerbottom">
             <div class="tab_title" data-i18n="tabCalibration">Calibration</div>
-            <div class="cf_doc_version_bt">
-                <a id="button-documentation" href="" target="_blank"></a>
-            </div>
             <div class="cf_column threefourth_left">
                 <div class="spacer_right">
                     <div class="gui_box grey">

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -1,9 +1,6 @@
 <div class="tab-configuration toolbar_fixed_bottom">
     <div class="content_wrapper">
         <div class="tab_title" data-i18n="tabConfiguration">Configuration</div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
         <div class="note" style="margin-bottom: 20px;">
             <div class="note_spacer">
                 <p data-i18n="configurationFeaturesHelp"></p>

--- a/tabs/failsafe.html
+++ b/tabs/failsafe.html
@@ -1,9 +1,6 @@
 <div class="tab-failsafe toolbar_fixed_bottom">
     <div class="content_wrapper">
         <div class="tab_title">Failsafe</div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
         <div class="gui_box grey">
             <div class="gui_box_titlebar">
                 <div class="spacer_box_title" data-i18n="failsafeStageTwoSettingsTitle"></div>

--- a/tabs/gps.html
+++ b/tabs/gps.html
@@ -1,11 +1,6 @@
 <div class="tab-gps">
     <div class="content_wrapper">
         <div class="tab_title" data-i18n="tabGPS">GPS</div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
-
-
         <div class="cf_column fourth">
             <div class="spacer_right">
                 <div class="gui_box grey">

--- a/tabs/led_strip.html
+++ b/tabs/led_strip.html
@@ -1,9 +1,6 @@
 <div class="tab-led-strip toolbar_fixed_bottom">
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabLedStrip"></div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
         <div class="note spacebottom">
             <div class="note_spacer">
                 <p i18n="ledStripHelp"></p>

--- a/tabs/logging.html
+++ b/tabs/logging.html
@@ -1,9 +1,6 @@
 <div class="tab-logging toolbar_fixed_bottom">
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabLogging"></div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
         <div class="note">
             <div class="note_spacer">
                 <p i18n="loggingNote"></p>

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -1,9 +1,6 @@
 <div class="tab-mission-control">
     <div style="padding-top: 20px;padding-left: 20px; padding-right: 20px;position: relative;">
         <div class="tab_title" data-i18n="tabMissionControl">Mission planer</div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
     </div>
     <div class="content_wrapper">
         <div class="cf_column fourth" id="missionControls">

--- a/tabs/onboard_logging.html
+++ b/tabs/onboard_logging.html
@@ -2,9 +2,6 @@
 <div class="tab-onboard_logging toolbar_fixed_bottom">
     <div class="content_wrapper">
         <div class="tab_title" data-i18n="tabOnboardLogging"></div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
         <div class="require-blackbox-unsupported">
             
             <div class="gui_box grey require-blackbox-config-supported">

--- a/tabs/osd.html
+++ b/tabs/osd.html
@@ -3,9 +3,6 @@
         <h1 class="tab_title">
             OSD
         </h1>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="" target="_blank"></a>
-        </div>
         <div class="unsupported hide">
             <p class="note">Your flight controller isn't responding to OSD commands. This probably means that it does not have an integrated OSD.</p>
             <p class="note">Note that some flight controllers have an onboard <a href="https://www.youtube.com/watch?v=ikKH_6SQ-Tk" target="_blank">MinimOSD</a> that can be flashed and configured with <a href="https://github.com/ShikOfTheRa/scarab-osd/releases/latest" target="_blank">scarab-osd</a>, however the MinimOSD cannot be configured through this interface.</p>

--- a/tabs/ports.html
+++ b/tabs/ports.html
@@ -2,9 +2,6 @@
 <div class="tab-ports toolbar_fixed_bottom">
     <div class="content_wrapper">
         <div class="tab_title" data-i18n="tabPorts">Ports</div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
         <div class="require-support">
             <div class="note spacebottom">
                 <div class="note_spacer">

--- a/tabs/receiver.html
+++ b/tabs/receiver.html
@@ -2,9 +2,6 @@
 <div class="tab-receiver toolbar_fixed_bottom">
     <div class="content_wrapper">
         <div class="tab_title" data-i18n="tabReceiver"></div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
         <div class="note" style="margin-bottom: 20px;">
             <div class="note_spacer">
                 <p data-i18n="receiverHelp"></p>

--- a/tabs/sensors.html
+++ b/tabs/sensors.html
@@ -1,10 +1,6 @@
 <div class="tab-sensors">
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabRawSensorData">tabRawSensorData</div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
-
         <div class="note" style="margin-bottom: 10px;">
             <div class="note_spacer">
                 <p i18n="sensorsInfo">Keep in mind that using fast update periods and rendering multiple graphs at

--- a/tabs/setup.html
+++ b/tabs/setup.html
@@ -3,9 +3,6 @@
         <!-- should be the first DIV on each tab -->
         <div class="cf_column full spacerbottom">
             <div class="tab_title" data-i18n="tabSetup">Setup</div>
-            <div class="cf_doc_version_bt">
-                <a id="button-documentation" href="" target="_blank"></a>
-            </div>
             <div class="cf_column fourth buttonarea">
                 <div class="spacer_right">
                     <div class="default_btn">

--- a/tabs/transponder.html
+++ b/tabs/transponder.html
@@ -1,10 +1,6 @@
 <div class="tab-transponder toolbar_fixed_bottom">
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabTransponder">Transponder</div>
-        <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/iNavFlight/inav/releases" target="_blank"></a>
-        </div>
-        
         <div class="require-transponder-unsupported note">
             <div class="note_spacer">
                 <p i18n="transponderNotSupported"></p>


### PR DESCRIPTION
This way we don't need to repeat the same 3 lines of HTML in every
tab. Also fixes the missing link in the mission planner tab when
the FC wasn't connected.