### PR TITLE
[RX-MSP] Fix double binding on click for the enable button

### DIFF
--- a/tabs/receiver_msp.js
+++ b/tabs/receiver_msp.js
@@ -128,7 +128,7 @@ function localizeAxisNames() {
 }
 
 $(document).ready(function() {
-    $(".button-enable").click(function() {
+    $("a.button-enable").click(function() {
         var
             shrinkHeight = $(".warning").height();
         


### PR DESCRIPTION
The click handler was registered to both the div and the anchor,
causing it to fire twice and shrink the window twice. Make sure
we only bind to the anchor.