### PR TITLE
Enhance port discovery and port option storage/restoring

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2342,6 +2342,9 @@
     "w_z_gos_p_help": {
         "message": "When this value is set to <strong>0</strong>, GPS is not used for altitude computation"
     },
+    "portManual": {
+        "message": "Manual Selection"
+    },
     "wirelessModeSwitch": {
         "message": "Wireless mode"
     },

--- a/js/serial.js
+++ b/js/serial.js
@@ -199,6 +199,9 @@ var serial = {
             callback(devices);
         });
     },
+    allowsOtherDevices: function () {
+        return !chrome.serial._disallows_other_devices;
+    },
     getInfo: function (callback) {
         chrome.serial.getInfo(this.connectionId, callback);
     },

--- a/main.css
+++ b/main.css
@@ -185,6 +185,11 @@ input[type="number"]::-webkit-inner-spin-button {
     margin-left: 5px;
 }
 
+.disabled .switchery {
+    opacity: 0.5 !important;
+    pointer-events: none;
+}
+
 .portsinput__top-element--inline span {
     color: #ddd;
 }

--- a/src/css/dropdown-lists/css/style_lists.css
+++ b/src/css/dropdown-lists/css/style_lists.css
@@ -140,8 +140,12 @@
   text-shadow: 0 1px black;
   /* Fallback for IE 8 */
   background: #444;
-  
 }
+
+.dropdown-dark .dropdown-select.disabled {
+  opacity: 0.5;
+}
+
 .dropdown-dark .dropdown-select:focus {
   color: #fff;
 }


### PR DESCRIPTION
- Detect when a port is backed by BLE and force wireless mode
- Detect port types that don't use the BPS and disable the input
- Disable manual port selection for runtimes that don't support it
- Save bps/wireless mode per port instead of globally
