### PR TITLE
fix missing blackbox animation

### DIFF
--- a/js/gui.js
+++ b/js/gui.js
@@ -193,7 +193,7 @@ GUI_control.prototype.content_ready = function (callback) {
     });
 
     const duration = content.data('empty') ? 0 : 400;
-    $('#content .data-loading').fadeOut(duration, function() {
+    $('#content .data-loading:first').fadeOut(duration, function() {
         $(this).remove();
     });
     if (callback) {


### PR DESCRIPTION
.data-loading is for loading tab and blackbox erase,
but when tab loading finished it removes all .data-loading elements

#5937