### PR TITLE
Added time zone settings to configuration tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3384,5 +3384,17 @@
     },
     "configurationCurrentMeterType": {
         "message": "Current Meter Type"
+    },
+    "configurationTzOffset": {
+        "message": "Time Zone Offset"
+    },
+    "configurationTzAutoDst": {
+        "message": "DST Region"
+    },
+    "configurationTzOffsetHelp": {
+        "message": "Time zone offset from UTC in hours, ranging from -12 to +14 with 15 minute increments. This is applied to the GPS time for logging and time-stamping of Blackbox logs."
+    },
+    "configurationTzAutoDstHelp": {
+        "message": "Automatically add Daylight Saving Time to the GPS time. If you live outside the available regions it is suggested to manage DST manually via Time Zone Offset."
     }
 }

--- a/js/fc.js
+++ b/js/fc.js
@@ -60,7 +60,8 @@ var CONFIG,
     BATTERY_CONFIG,
     OUTPUT_MAPPING,
     SETTINGS,
-    BRAKING_CONFIG;
+    BRAKING_CONFIG,
+    TZ_CONFIG;
 
 var FC = {
     MAX_SERVO_RATE: 125,
@@ -532,13 +533,18 @@ var FC = {
             boostSpeedThreshold: null,
             boostDisengageSpeed: null,
             bankAngle: null
-        }
+        };
 
         RXFAIL_CONFIG = [];
 
         OUTPUT_MAPPING = new OutputMappingCollection();
 
         SETTINGS = {};
+
+        TZ_CONFIG = {
+            tz_offset: 0,
+            tz_automatic_dst: 'OFF'
+        };
     },
     getOutputUsages: function() {
         return {
@@ -705,6 +711,13 @@ var FC = {
             'Japanese MSAS',
             'Indian GAGAN',
             'Disabled'
+        ];
+    },
+    getTzDstAreas: function () {
+        return [
+            'Disabled',
+            'EU',
+            'USA'
         ];
     },
     getSensorAlignments: function () {

--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -155,6 +155,8 @@ var MSPCodes = {
     MSP_BF_BUILD_INFO:          69,  // build date as well as some space for future expansion
 
     // INAV specific codes
+    MSP2_COMMON_TZ:                     0x1001,
+    MSP2_COMMON_SET_TZ:                 0x1002,
     MSPV2_SETTING:                      0x1003,
     MSPV2_SET_SETTING:                  0x1004,
 

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1444,6 +1444,16 @@ var mspHelper = (function (gui) {
             case MSPCodes.MSP2_INAV_SET_MC_BRAKING:
                 console.log('Braking config saved');
                 break;
+
+            case MSPCodes.MSP2_COMMON_TZ:
+                TZ_CONFIG.tz_offset = data.getInt16(0, true);
+                TZ_CONFIG.tz_automatic_dst = data.getUint8(2);
+                break;
+
+            case MSPCodes.MSP2_COMMON_SET_TZ:
+                console.log('Time Zone config saved');
+                break;
+
             case MSPCodes.MSP2_BLACKBOX_CONFIG:
                 BLACKBOX.supported = (data.getUint8(0) & 1) != 0;
                 BLACKBOX.blackboxDevice = data.getUint8(1);
@@ -2137,6 +2147,12 @@ var mspHelper = (function (gui) {
                 buffer.push(BRAKING_CONFIG.bankAngle);
                 break;
 
+            case MSPCodes.MSP2_COMMON_SET_TZ:
+                buffer.push(lowByte(TZ_CONFIG.tz_offset));
+                buffer.push(highByte(TZ_CONFIG.tz_offset));
+                buffer.push(TZ_CONFIG.tz_automatic_dst);
+                break;
+
             default:
                 return false;
         }
@@ -2161,17 +2177,17 @@ var mspHelper = (function (gui) {
     };
 
     self.sendBlackboxConfiguration = function (onDataCallback) {
-	var buffer = [];
-	var messageId = MSPCodes.MSP_SET_BLACKBOX_CONFIG;
-	buffer.push(BLACKBOX.blackboxDevice & 0xFF);
-	    messageId = MSPCodes.MSP2_SET_BLACKBOX_CONFIG;
-	    buffer.push(lowByte(BLACKBOX.blackboxRateNum));
-	    buffer.push(highByte(BLACKBOX.blackboxRateNum));
-	    buffer.push(lowByte(BLACKBOX.blackboxRateDenom));
-	    buffer.push(highByte(BLACKBOX.blackboxRateDenom));
+        var buffer = [];
+        var messageId = MSPCodes.MSP_SET_BLACKBOX_CONFIG;
+        buffer.push(BLACKBOX.blackboxDevice & 0xFF);
+        messageId = MSPCodes.MSP2_SET_BLACKBOX_CONFIG;
+        buffer.push(lowByte(BLACKBOX.blackboxRateNum));
+        buffer.push(highByte(BLACKBOX.blackboxRateNum));
+        buffer.push(lowByte(BLACKBOX.blackboxRateDenom));
+        buffer.push(highByte(BLACKBOX.blackboxRateDenom));
         //noinspection JSUnusedLocalSymbols
         MSP.send_message(messageId, buffer, false, function (response) {
-	    onDataCallback();
+            onDataCallback();
         });
     };
 
@@ -2737,7 +2753,7 @@ var mspHelper = (function (gui) {
     };
 
     self.loadBatteryConfig = function (callback) {
-	MSP.send_message(MSPCodes.MSPV2_BATTERY_CONFIG, false, false, callback);
+        MSP.send_message(MSPCodes.MSPV2_BATTERY_CONFIG, false, false, callback);
     };
 
     self.loadArmingConfig = function (callback) {
@@ -3169,6 +3185,14 @@ var mspHelper = (function (gui) {
         } else {
             callback();
         }
+    };
+
+    self.loadTzConfig = function(callback) {
+        MSP.send_message(MSPCodes.MSP2_COMMON_TZ, false, false, callback);
+    };
+
+    self.saveTzConfig = function(callback) {
+        MSP.send_message(MSPCodes.MSP2_COMMON_SET_TZ, mspHelper.crunch(MSPCodes.MSP2_COMMON_SET_TZ), false, callback);
     };
 
     return self;

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -137,6 +137,22 @@
                             <span data-i18n="configurationGPSubxSbas"></span>
                         </label>
                     </div>
+                    <div class="select">
+                        <select id="tz_dst_areas" class="tz_dst_areas">
+                            <!-- list generated here -->
+                        </select>
+                        <label for="tz_dst_areas">
+                            <span data-i18n="configurationTzAutoDst"></span>
+                        </label>
+                        <div class="helpicon cf_tip" data-i18n_title="configurationTzAutoDstHelp"></div>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="tz_offset" name="tz_offset" step="0.25" min="-12" max="14" />
+                        <label for="tz_offset">
+                            <span data-i18n="configurationTzOffset"></span>
+                        </label>
+                        <div class="helpicon cf_tip" data-i18n_title="configurationTzOffsetHelp"></div>
+                    </div>
                     <div class="number is-hidden">
                         <input type="number" id="mag_declination" name="mag_declination" step="0.1" min="-180" max="180" />
                         <label for="mag_declination">

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -39,6 +39,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         mspHelper.loadINAVPidConfig,
         mspHelper.loadSensorConfig,
         mspHelper.loadVTXConfig,
+        mspHelper.loadTzConfig,
         mspHelper.loadMixerConfig,
         loadCraftName,
         mspHelper.loadMiscV2
@@ -61,6 +62,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         mspHelper.saveINAVPidConfig,
         mspHelper.saveSensorConfig,
         mspHelper.saveVTXConfig,
+        mspHelper.saveTzConfig,
         saveCraftName,
         mspHelper.saveMiscV2,
         saveSettings,
@@ -255,6 +257,23 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         // code below is a temporary fix, which we will be able to remove in the future (hopefully)
         //noinspection JSValidateTypes
         $('#content').scrollTop((scrollPosition) ? scrollPosition : 0);
+
+        // Time Zone config
+        $('input[name="tz_offset"]').val((TZ_CONFIG.tz_offset / 60.0).toFixed(2));
+
+        var tzDstAreas = FC.getTzDstAreas();
+
+        var tz_dst_areas_e = $('#tz_dst_areas');
+        for (i = 0; i < tzDstAreas.length; i++) {
+            tz_dst_areas_e.append('<option value="' + i + '">' + tzDstAreas[i] + '</option>');
+        }
+
+        tz_dst_areas_e.change(function () {
+            TZ_CONFIG.tz_automatic_dst = parseInt($(this).val());
+        });
+
+        tz_dst_areas_e.val(TZ_CONFIG.tz_automatic_dst);
+
 
         // fill board alignment
         $('input[name="board_align_roll"]').val((BF_CONFIG.board_align_roll / 10.0).toFixed(1));
@@ -483,6 +502,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             SENSOR_ALIGNMENT.align_mag = parseInt(orientation_mag_e.val());
 
             craftName = $('input[name="craft_name"]').val();
+
+            TZ_CONFIG.tz_offset = Math.round(parseFloat($('#tz_offset').val()) * 60);
 
             if (FC.isFeatureEnabled('GPS', features)) {
                 googleAnalytics.sendEvent('Setting', 'GpsProtocol', gpsProtocols[MISC.gps_type]);


### PR DESCRIPTION
Pull request for issue #1052.

The time zone settings `tz_offset` and `tz_automatic_dst` have been added to the Configuration tab under GPS:

<img width="711" alt="image" src="https://user-images.githubusercontent.com/3070959/92617629-c66e1580-f2bf-11ea-92a7-b5d2a07b0fef.png">

`tz_offset` - Time zone offset from UTC in hours, ranging from -12h to +14h with 15 minute increments to cover all time zones.

Related pull request in inav is [#6115](https://github.com/iNavFlight/inav/pull/6115)

@Pairan - Can you verify this is what you requested?