### PR TITLE
Standardize preset definitions

### DIFF
--- a/js/preset_definitions.js
+++ b/js/preset_definitions.js
@@ -43,8 +43,8 @@ presets.settings = {
  */
 presets.presets = [
     {
-        name: '3-inch Multirotor Preset',
-        description: "INAV Quad X configuration, 3-inch propellers. F4/F7 CPU.",
+        name: 'Generic 3" Quadcopter',
+        description: "Quad X, 3\" propellers. F4/F7 CPU.",
         features: ["DSHOT600", "4k mode", "Matrix Filter", "Improved mechanics", "Optimized filtering", "Optimized rates"],
         applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
         settingsMSP: [],
@@ -213,186 +213,8 @@ presets.presets = [
         type: 'multirotor'
     },
     {
-        name: 'MegaBee Cinewoop',
-        description: "iFlight MegaBee Preset",
-        features: ["DSHOT600", "4k mode", "Matrix Filter", "Improved mechanics", "Optimized filtering", "Optimized rates"],
-        applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
-        settingsMSP: [],
-        settings: [
-            {
-                key: "platform_type",
-                value: "MULTIROTOR"
-            },
-            {
-                key: "motor_pwm_protocol",
-                value: "DSHOT600"
-            },
-            {
-                key: "gyro_hardware_lpf",
-                value: "256HZ"
-            },
-            {
-                key: "looptime",
-                value: 250
-            },
-            {
-                key: "gyro_lpf_hz",
-                value: 130
-            },
-            {
-                key: "gyro_lpf_type",
-                value: "PT1"
-            },
-            {
-                key: "gyro_stage2_lowpass_hz",
-                value: 180
-            },
-            {
-                key: "gyro_stage2_lowpass_type",
-                value: "PT1"
-            },
-            {
-                key: "gyro_notch1_hz",
-                value: 200
-            },
-            {
-                key: "gyro_notch1_cutoff",
-                value: 175
-            },
-            {
-                key: "dterm_lpf_hz",
-                value: 100
-            },
-            {
-                key: "dterm_lpf_type",
-                value: "PT1"
-            },
-            {
-                key: "dterm_lpf2_hz",
-                value: 150
-            },
-            {
-                key: "dterm_lpf2_type",
-                value: "PT1"
-            },
-            {
-                key: "use_dterm_fir_filter",
-                value: "OFF"
-            },
-            {
-                key: "mc_iterm_relax_type",
-                value: "GYRO"
-            },
-            {
-                key: "mc_iterm_relax",
-                value: "RP"
-            },
-            {
-                key: "d_boost_factor",
-                value: 1.5
-            },
-            {
-                key: "d_boost_max_at_acceleration",
-                value: 5000.000
-            },
-            {
-                key: "d_boost_gyro_delta_lpf_hz",
-                value: 80
-            },
-            {
-                key: "antigravity_gain",
-                value: 2
-            },
-            {
-                key: "antigravity_accelerator",
-                value: 5
-            },
-            {
-                key: "rc_yaw_expo",
-                value: 70
-            },
-            {
-                key: "rc_expo",
-                value: 70
-            },
-            {
-                key: "roll_rate",
-                value: 70
-            },
-            {
-                key: "pitch_rate",
-                value: 70
-            },
-            {
-                key: "yaw_rate",
-                value: 60
-            },
-            {
-                key: "mc_p_pitch",
-                value: 34
-            },
-            {
-                key: "mc_i_pitch",
-                value: 55
-            },
-            {
-                key: "mc_d_pitch",
-                value: 35
-            },
-            {
-                key: "mc_p_roll",
-                value: 32
-            },
-            {
-                key: "mc_i_roll",
-                value: 45
-            },
-            {
-                key: "mc_d_roll",
-                value: 33
-            },
-            {
-                key: "mc_p_yaw",
-                value: 65
-            },
-            {
-                key: "mc_i_yaw",
-                value: 70
-            },
-            {
-                key: "mc_airmode_type",
-                value: "THROTTLE_THRESHOLD"
-            },
-            {
-                key: "dynamic_gyro_notch_enabled",
-                value: "ON"
-            },
-            {
-                key: "dynamic_gyro_notch_q",
-                value: 180
-            },
-            {
-                key: "dynamic_gyro_notch_min_hz",
-                value: 150
-            },
-            {
-                key: "min_check",
-                value: 1050
-            },
-            {
-                key: "throttle_idle",
-                value: 12
-            },
-            {
-                key: "dterm_setpoint_weight",
-                value: 0.400
-            }
-        ],
-        type: 'multirotor'
-    },
-    {
-        name: '5-inch Multirotor Preset',
-        description: "INAV Quad X configuration, 5-inch propellers. F4/F7 CPU. GPS and Magnetometer are optional",
+        name: 'Generic 5" Quadcopter',
+        description: "Quad X, 5\" propellers. F4/F7 CPU.",
         features: ["DSHOT600", "2k mode", "Matrix Filter", "Improved mechanics", "Optimized filtering", "Optimized rates"],
         applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
         settingsMSP: [],
@@ -553,348 +375,8 @@ presets.presets = [
         type: 'multirotor'
     },
     {
-        name: '5-inch, 2208 2450KV motors',
-        description: "Overpowered freestyle kwad. 5-inch, 3 bladed propellers like HQProp S4, Nepal N1, 2208 2450KV motors, 4S, DSHOT600 ESC protocol. Optimized for smooth, freestyle or acrobatic flight.",
-        features: ["DSHOT600", "4k mode", "Matrix Filter", "Improved mechanics", "Optimized filtering", "Optimized rates"],
-        applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
-        settingsMSP: [],
-        settings: [
-            {
-                key: "platform_type",
-                value: "MULTIROTOR"
-            },
-            {
-                key: "motor_pwm_protocol",
-                value: "DSHOT600"
-            },
-            {
-                key: "gyro_hardware_lpf",
-                value: "256HZ"
-            },
-            {
-                key: "looptime",
-                value: 250
-            },
-            {
-                key: "gyro_lpf_hz",
-                value: 115
-            },
-            {
-                key: "gyro_lpf_type",
-                value: "PT1"
-            },
-            {
-                key: "gyro_stage2_lowpass_hz",
-                value: 0
-            },
-            {
-                key: "gyro_stage2_lowpass_type",
-                value: "PT1"
-            },
-            {
-                key: "dterm_lpf_hz",
-                value: 110
-            },
-            {
-                key: "dterm_lpf_type",
-                value: "PT1"
-            },
-            {
-                key: "dterm_lpf2_hz",
-                value: 170
-            },
-            {
-                key: "dterm_lpf2_type",
-                value: "PT1"
-            },
-            {
-                key: "use_dterm_fir_filter",
-                value: "OFF"
-            },
-            {
-                key: "mc_iterm_relax_type",
-                value: "SETPOINT"
-            },
-            {
-                key: "mc_iterm_relax",
-                value: "RP"
-            },
-            {
-                key: "d_boost_factor",
-                value: 1.5
-            },
-            {
-                key: "d_boost_max_at_acceleration",
-                value: 7500.000
-            },
-            {
-                key: "d_boost_gyro_delta_lpf_hz",
-                value: 80
-            },
-            {
-                key: "antigravity_gain",
-                value: 2
-            },
-            {
-                key: "antigravity_accelerator",
-                value: 5
-            },
-            {
-                key: "rc_yaw_expo",
-                value: 70
-            },
-            {
-                key: "rc_expo",
-                value: 70
-            },
-            {
-                key: "roll_rate",
-                value: 85
-            },
-            {
-                key: "pitch_rate",
-                value: 85
-            },
-            {
-                key: "yaw_rate",
-                value: 75
-            },
-            {
-                key: "mc_p_pitch",
-                value: 26
-            },
-            {
-                key: "mc_i_pitch",
-                value: 60
-            },
-            {
-                key: "mc_d_pitch",
-                value: 28
-            },
-            {
-                key: "mc_p_roll",
-                value: 22
-            },
-            {
-                key: "mc_i_roll",
-                value: 50
-            },
-            {
-                key: "mc_d_roll",
-                value: 24
-            },
-            {
-                key: "mc_p_yaw",
-                value: 44
-            },
-            {
-                key: "mc_i_yaw",
-                value: 70
-            },
-            {
-                key: "mc_airmode_type",
-                value: "THROTTLE_THRESHOLD"
-            },
-            {
-                key: "dynamic_gyro_notch_enabled",
-                value: "ON"
-            },
-            {
-                key: "dynamic_gyro_notch_q",
-                value: 200
-            },
-            {
-                key: "dynamic_gyro_notch_min_hz",
-                value: 140
-            },
-            {
-                key: "min_check",
-                value: 1050
-            },
-            {
-                key: "throttle_idle",
-                value: 12
-            },
-            {
-                key: "dterm_setpoint_weight",
-                value: 0.850
-            }
-        ],
-        type: 'multirotor'
-    },
-    {
-        name: '6-inch, 2207 1700KV motors',
-        description: "6-inch, 3 bladed propellers, 2207 1700KV motors, 4S, DSHOT600 ESC protocol. Optimized for smooth, freestyle or acrobatic flight with GPS or not.",
-        features: ["DSHOT600", "2k mode", "Matrix Filter", "Improved mechanics", "Optimized filtering", "Optimized rates"],
-        applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
-        settingsMSP: [],
-        settings: [
-            {
-                key: "platform_type",
-                value: "MULTIROTOR"
-            },
-            {
-                key: "motor_pwm_protocol",
-                value: "DSHOT600"
-            },
-            {
-                key: "gyro_hardware_lpf",
-                value: "256HZ"
-            },
-            {
-                key: "looptime",
-                value: 500
-            },
-            {
-                key: "gyro_lpf_hz",
-                value: 100
-            },
-            {
-                key: "gyro_lpf_type",
-                value: "PT1"
-            },
-            {
-                key: "gyro_stage2_lowpass_hz",
-                value: 250
-            },
-            {
-                key: "gyro_stage2_lowpass_type",
-                value: "PT1"
-            },
-            {
-                key: "dterm_lpf_hz",
-                value: 90
-            },
-            {
-                key: "dterm_lpf_type",
-                value: "PT1"
-            },
-            {
-                key: "dterm_lpf2_hz",
-                value: 200
-            },
-            {
-                key: "dterm_lpf2_type",
-                value: "PT1"
-            },
-            {
-                key: "use_dterm_fir_filter",
-                value: "OFF"
-            },
-            {
-                key: "mc_iterm_relax_type",
-                value: "SETPOINT"
-            },
-            {
-                key: "mc_iterm_relax",
-                value: "RP"
-            },
-            {
-                key: "d_boost_factor",
-                value: 1.5
-            },
-            {
-                key: "d_boost_max_at_acceleration",
-                value: 5500.000
-            },
-            {
-                key: "d_boost_gyro_delta_lpf_hz",
-                value: 70
-            },
-            {
-                key: "antigravity_gain",
-                value: 2
-            },
-            {
-                key: "antigravity_accelerator",
-                value: 5
-            },
-            {
-                key: "rc_yaw_expo",
-                value: 70
-            },
-            {
-                key: "rc_expo",
-                value: 70
-            },
-            {
-                key: "roll_rate",
-                value: 70
-            },
-            {
-                key: "pitch_rate",
-                value: 70
-            },
-            {
-                key: "yaw_rate",
-                value: 60
-            },
-            {
-                key: "mc_p_pitch",
-                value: 37
-            },
-            {
-                key: "mc_i_pitch",
-                value: 70
-            },
-            {
-                key: "mc_d_pitch",
-                value: 22
-            },
-            {
-                key: "mc_p_roll",
-                value: 31
-            },
-            {
-                key: "mc_i_roll",
-                value: 50
-            },
-            {
-                key: "mc_d_roll",
-                value: 21
-            },
-            {
-                key: "mc_p_yaw",
-                value: 50
-            },
-            {
-                key: "mc_i_yaw",
-                value: 70
-            },
-            {
-                key: "mc_airmode_type",
-                value: "THROTTLE_THRESHOLD"
-            },
-            {
-                key: "dynamic_gyro_notch_enabled",
-                value: "ON"
-            },
-            {
-                key: "dynamic_gyro_notch_q",
-                value: 175
-            },
-            {
-                key: "dynamic_gyro_notch_min_hz",
-                value: 110
-            },
-            {
-                key: "min_check",
-                value: 1050
-            },
-            {
-                key: "throttle_idle",
-                value: 12
-            },
-            {
-                key: "dterm_setpoint_weight",
-                value: 0.700
-            }
-        ],
-        type: 'multirotor'
-    },
-    {
-        name: '7-inch Multirotor Preset',
-        description: "General configuration for 7-inch propellers. Adjusted rates and filtering.",
+        name: 'Generic 7" Quadcopter',
+        description: "Quad X, 7\" propellers. F4/F7 CPU.",
         features: ["DSHOT600", "2k mode", "Matrix Filter", "Improved mechanics", "Optimized filtering", "Optimized rates"],
         applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
         settingsMSP: [],
@@ -1063,8 +545,8 @@ presets.presets = [
         type: 'multirotor'
     },
     {
-        name: '10-inch Multirotor Preset',
-        description: "450-600 class general purpose multirotor with 10-inch 2-bladed propellers.",
+        name: 'Generic 10" Multirotor',
+        description: "General purpose 450-600 class multirotor with 10\", 2-bladed propellers.",
         features: [
             "DSHOT600",
             "400dps rates",
@@ -1242,8 +724,526 @@ presets.presets = [
         type: 'multirotor'
     },
     {
-        name: "Airplane General",
-        description: "General setup for airplanes",
+        name: '3" Cinewhoop',
+        description: "Based on the iFlight MegaBee Cinewhoop.",
+        features: ["DSHOT600", "4k mode", "Matrix Filter", "Improved mechanics", "Optimized filtering", "Optimized rates"],
+        applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
+        settingsMSP: [],
+        settings: [
+            {
+                key: "platform_type",
+                value: "MULTIROTOR"
+            },
+            {
+                key: "motor_pwm_protocol",
+                value: "DSHOT600"
+            },
+            {
+                key: "gyro_hardware_lpf",
+                value: "256HZ"
+            },
+            {
+                key: "looptime",
+                value: 250
+            },
+            {
+                key: "gyro_lpf_hz",
+                value: 130
+            },
+            {
+                key: "gyro_lpf_type",
+                value: "PT1"
+            },
+            {
+                key: "gyro_stage2_lowpass_hz",
+                value: 180
+            },
+            {
+                key: "gyro_stage2_lowpass_type",
+                value: "PT1"
+            },
+            {
+                key: "gyro_notch1_hz",
+                value: 200
+            },
+            {
+                key: "gyro_notch1_cutoff",
+                value: 175
+            },
+            {
+                key: "dterm_lpf_hz",
+                value: 100
+            },
+            {
+                key: "dterm_lpf_type",
+                value: "PT1"
+            },
+            {
+                key: "dterm_lpf2_hz",
+                value: 150
+            },
+            {
+                key: "dterm_lpf2_type",
+                value: "PT1"
+            },
+            {
+                key: "use_dterm_fir_filter",
+                value: "OFF"
+            },
+            {
+                key: "mc_iterm_relax_type",
+                value: "GYRO"
+            },
+            {
+                key: "mc_iterm_relax",
+                value: "RP"
+            },
+            {
+                key: "d_boost_factor",
+                value: 1.5
+            },
+            {
+                key: "d_boost_max_at_acceleration",
+                value: 5000.000
+            },
+            {
+                key: "d_boost_gyro_delta_lpf_hz",
+                value: 80
+            },
+            {
+                key: "antigravity_gain",
+                value: 2
+            },
+            {
+                key: "antigravity_accelerator",
+                value: 5
+            },
+            {
+                key: "rc_yaw_expo",
+                value: 70
+            },
+            {
+                key: "rc_expo",
+                value: 70
+            },
+            {
+                key: "roll_rate",
+                value: 70
+            },
+            {
+                key: "pitch_rate",
+                value: 70
+            },
+            {
+                key: "yaw_rate",
+                value: 60
+            },
+            {
+                key: "mc_p_pitch",
+                value: 34
+            },
+            {
+                key: "mc_i_pitch",
+                value: 55
+            },
+            {
+                key: "mc_d_pitch",
+                value: 35
+            },
+            {
+                key: "mc_p_roll",
+                value: 32
+            },
+            {
+                key: "mc_i_roll",
+                value: 45
+            },
+            {
+                key: "mc_d_roll",
+                value: 33
+            },
+            {
+                key: "mc_p_yaw",
+                value: 65
+            },
+            {
+                key: "mc_i_yaw",
+                value: 70
+            },
+            {
+                key: "mc_airmode_type",
+                value: "THROTTLE_THRESHOLD"
+            },
+            {
+                key: "dynamic_gyro_notch_enabled",
+                value: "ON"
+            },
+            {
+                key: "dynamic_gyro_notch_q",
+                value: 180
+            },
+            {
+                key: "dynamic_gyro_notch_min_hz",
+                value: 150
+            },
+            {
+                key: "min_check",
+                value: 1050
+            },
+            {
+                key: "throttle_idle",
+                value: 12
+            },
+            {
+                key: "dterm_setpoint_weight",
+                value: 0.400
+            }
+        ],
+        type: 'multirotor'
+    },
+    {
+        name: '5" Freestyle Quadcopter, 2208 2450kV motors',
+        description: "Overpowered freestyle quad. 5\", 3 bladed propellers like HQProp S4, Nepal N1, 2208 2450KV motors, 4S, DSHOT600 ESC protocol.<br>Optimized for smooth, freestyle or acrobatic flight.",
+        features: ["DSHOT600", "4k mode", "Matrix Filter", "Improved mechanics", "Optimized filtering", "Optimized rates"],
+        applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
+        settingsMSP: [],
+        settings: [
+            {
+                key: "platform_type",
+                value: "MULTIROTOR"
+            },
+            {
+                key: "motor_pwm_protocol",
+                value: "DSHOT600"
+            },
+            {
+                key: "gyro_hardware_lpf",
+                value: "256HZ"
+            },
+            {
+                key: "looptime",
+                value: 250
+            },
+            {
+                key: "gyro_lpf_hz",
+                value: 115
+            },
+            {
+                key: "gyro_lpf_type",
+                value: "PT1"
+            },
+            {
+                key: "gyro_stage2_lowpass_hz",
+                value: 0
+            },
+            {
+                key: "gyro_stage2_lowpass_type",
+                value: "PT1"
+            },
+            {
+                key: "dterm_lpf_hz",
+                value: 110
+            },
+            {
+                key: "dterm_lpf_type",
+                value: "PT1"
+            },
+            {
+                key: "dterm_lpf2_hz",
+                value: 170
+            },
+            {
+                key: "dterm_lpf2_type",
+                value: "PT1"
+            },
+            {
+                key: "use_dterm_fir_filter",
+                value: "OFF"
+            },
+            {
+                key: "mc_iterm_relax_type",
+                value: "SETPOINT"
+            },
+            {
+                key: "mc_iterm_relax",
+                value: "RP"
+            },
+            {
+                key: "d_boost_factor",
+                value: 1.5
+            },
+            {
+                key: "d_boost_max_at_acceleration",
+                value: 7500.000
+            },
+            {
+                key: "d_boost_gyro_delta_lpf_hz",
+                value: 80
+            },
+            {
+                key: "antigravity_gain",
+                value: 2
+            },
+            {
+                key: "antigravity_accelerator",
+                value: 5
+            },
+            {
+                key: "rc_yaw_expo",
+                value: 70
+            },
+            {
+                key: "rc_expo",
+                value: 70
+            },
+            {
+                key: "roll_rate",
+                value: 85
+            },
+            {
+                key: "pitch_rate",
+                value: 85
+            },
+            {
+                key: "yaw_rate",
+                value: 75
+            },
+            {
+                key: "mc_p_pitch",
+                value: 26
+            },
+            {
+                key: "mc_i_pitch",
+                value: 60
+            },
+            {
+                key: "mc_d_pitch",
+                value: 28
+            },
+            {
+                key: "mc_p_roll",
+                value: 22
+            },
+            {
+                key: "mc_i_roll",
+                value: 50
+            },
+            {
+                key: "mc_d_roll",
+                value: 24
+            },
+            {
+                key: "mc_p_yaw",
+                value: 44
+            },
+            {
+                key: "mc_i_yaw",
+                value: 70
+            },
+            {
+                key: "mc_airmode_type",
+                value: "THROTTLE_THRESHOLD"
+            },
+            {
+                key: "dynamic_gyro_notch_enabled",
+                value: "ON"
+            },
+            {
+                key: "dynamic_gyro_notch_q",
+                value: 200
+            },
+            {
+                key: "dynamic_gyro_notch_min_hz",
+                value: 140
+            },
+            {
+                key: "min_check",
+                value: 1050
+            },
+            {
+                key: "throttle_idle",
+                value: 12
+            },
+            {
+                key: "dterm_setpoint_weight",
+                value: 0.850
+            }
+        ],
+        type: 'multirotor'
+    },
+    {
+        name: '6" Freestyle Quadcopter, 2207 1700kV motors',
+        description: "6\", 3 bladed propellers, 2207 1700kV motors, 4S, DSHOT600 ESC protocol.<br>Optimized for smooth, freestyle or acrobatic flight with GPS or not.",
+        features: ["DSHOT600", "2k mode", "Matrix Filter", "Improved mechanics", "Optimized filtering", "Optimized rates"],
+        applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
+        settingsMSP: [],
+        settings: [
+            {
+                key: "platform_type",
+                value: "MULTIROTOR"
+            },
+            {
+                key: "motor_pwm_protocol",
+                value: "DSHOT600"
+            },
+            {
+                key: "gyro_hardware_lpf",
+                value: "256HZ"
+            },
+            {
+                key: "looptime",
+                value: 500
+            },
+            {
+                key: "gyro_lpf_hz",
+                value: 100
+            },
+            {
+                key: "gyro_lpf_type",
+                value: "PT1"
+            },
+            {
+                key: "gyro_stage2_lowpass_hz",
+                value: 250
+            },
+            {
+                key: "gyro_stage2_lowpass_type",
+                value: "PT1"
+            },
+            {
+                key: "dterm_lpf_hz",
+                value: 90
+            },
+            {
+                key: "dterm_lpf_type",
+                value: "PT1"
+            },
+            {
+                key: "dterm_lpf2_hz",
+                value: 200
+            },
+            {
+                key: "dterm_lpf2_type",
+                value: "PT1"
+            },
+            {
+                key: "use_dterm_fir_filter",
+                value: "OFF"
+            },
+            {
+                key: "mc_iterm_relax_type",
+                value: "SETPOINT"
+            },
+            {
+                key: "mc_iterm_relax",
+                value: "RP"
+            },
+            {
+                key: "d_boost_factor",
+                value: 1.5
+            },
+            {
+                key: "d_boost_max_at_acceleration",
+                value: 5500.000
+            },
+            {
+                key: "d_boost_gyro_delta_lpf_hz",
+                value: 70
+            },
+            {
+                key: "antigravity_gain",
+                value: 2
+            },
+            {
+                key: "antigravity_accelerator",
+                value: 5
+            },
+            {
+                key: "rc_yaw_expo",
+                value: 70
+            },
+            {
+                key: "rc_expo",
+                value: 70
+            },
+            {
+                key: "roll_rate",
+                value: 70
+            },
+            {
+                key: "pitch_rate",
+                value: 70
+            },
+            {
+                key: "yaw_rate",
+                value: 60
+            },
+            {
+                key: "mc_p_pitch",
+                value: 37
+            },
+            {
+                key: "mc_i_pitch",
+                value: 70
+            },
+            {
+                key: "mc_d_pitch",
+                value: 22
+            },
+            {
+                key: "mc_p_roll",
+                value: 31
+            },
+            {
+                key: "mc_i_roll",
+                value: 50
+            },
+            {
+                key: "mc_d_roll",
+                value: 21
+            },
+            {
+                key: "mc_p_yaw",
+                value: 50
+            },
+            {
+                key: "mc_i_yaw",
+                value: 70
+            },
+            {
+                key: "mc_airmode_type",
+                value: "THROTTLE_THRESHOLD"
+            },
+            {
+                key: "dynamic_gyro_notch_enabled",
+                value: "ON"
+            },
+            {
+                key: "dynamic_gyro_notch_q",
+                value: 175
+            },
+            {
+                key: "dynamic_gyro_notch_min_hz",
+                value: 110
+            },
+            {
+                key: "min_check",
+                value: 1050
+            },
+            {
+                key: "throttle_idle",
+                value: 12
+            },
+            {
+                key: "dterm_setpoint_weight",
+                value: 0.700
+            }
+        ],
+        type: 'multirotor'
+    },
+    {
+        name: "Generic Airplane",
+        description: "General setup for airplanes.",
         features: [
             "Adjusted gyro filtering",
             "Adjusted PIDs",
@@ -1273,9 +1273,8 @@ presets.presets = [
         type: 'airplane'
     },
     {
-        name: "Flying wing Z84",
-        description: "Small flying wing on multirotor racer parts<br>" +
-            "<span>300g-500g weight, 3S-4S battery</span>",
+        name: "Flying Wing Z84",
+        description: "Small flying wing on multirotor racer parts. 3S/4S battery, AUW under 500g.",
         features: [
             "Adjusted gyro filtering",
             "Adjusted PIDs",
@@ -1331,7 +1330,7 @@ presets.presets = [
     },
     {
         name: "Flying Wing S800 Sky Shadow",
-        description: "Flying wing on multirotor racer parts with 3S/4S battery and FPV equipment",
+        description: "Flying wing on multirotor racer parts. 3S/4S battery and FPV equipment. AUW under 1000g.",
         features: [
             "Adjusted gyro filtering",
             "Adjusted PIDs",
@@ -1388,7 +1387,7 @@ presets.presets = [
     },
     {
         name: "Ritewing Mini Drak",
-        description: "Amazig looking and flying airplane with 8x6 propeller, 2216 1400KV motor, powered with 4S LiPo. AUW above 1200g",
+        description: "8x6 propeller, 2216 1400kV motor, 4S LiPo. AUW above 1200g.",
         features: [
             "Adjusted gyro filtering",
             "Adjusted PIDs",
@@ -1444,8 +1443,8 @@ presets.presets = [
         type: 'flyingwing'
     },
     {
-        name: "ZOHD Dart 250G",
-        description: "Small and light flying wing that can be build below 250g and as such be fully legal in many countries",
+        name: "ZOHD Dart 250g",
+        description: "3x5x3 propeller, 1406 2600kV motor, 3S LiPo. 570mm wingspan, AUW potentially under 250g on 2S.",
         features: [
             "Adjusted gyro filtering",
             "Adjusted PIDs",
@@ -1501,8 +1500,8 @@ presets.presets = [
         type: 'flyingwing'
     },
     {
-        name: "Mini AR Wing",
-        description: "Small, 600mm wingspan, FPV flying wing",
+        name: "SonicModell Mini AR Wing",
+        description: "5x4.5 propeller, 1805 2400kV motor, 3S LiPo. 600mm wingspan, AUW under 400g.",
         features: [
             "Adjusted gyro filtering",
             "Adjusted PIDs",


### PR DESCRIPTION
Standardize presets definitions wording (targeted specs and components) and sort them by category:

1. Generic quads by prop dimension
2. Generic multirotors
3. Model/Brand-specific multirotors
4. Generic airplanes
5. Model/Brand-specific airplanes