### PR TITLE
Update defaults_dialog.js

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -230,6 +230,30 @@ helper.defaultsDialog = (function() {
                     value: 180
                 },
                 {
+                    key: "nav_fw_control_smoothness",
+                    value: 2
+                },
+                {
+                    key: "failsafe_procedure",
+                    value: "RTH"
+                },
+                {
+                    key: "nav_rth_allow_landing",
+                    value: "NEVER"
+                },
+                {
+                    key: "nav_rth_altitude",
+                    value: 5000
+                },
+                {
+                    key: "failsafe_mission",
+                    value: "OFF"
+                },
+                {
+                    key: "nav_wp_radius",
+                    value: 3000
+                },
+                {
                     key: "platform_type",
                     value: "AIRPLANE"
                 },

--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -234,12 +234,8 @@ helper.defaultsDialog = (function() {
                     value: 2
                 },
                 {
-                    key: "failsafe_procedure",
-                    value: "RTH"
-                },
-                {
                     key: "nav_rth_allow_landing",
-                    value: "NEVER"
+                    value: "FS_ONLY"
                 },
                 {
                     key: "nav_rth_altitude",


### PR DESCRIPTION
Added some of the defaults suggested in issue https://github.com/iNavFlight/inav-configurator/issues/1028

I omitted disabling permanent airmode as the reason for disabling it has been fixed in 2.6 https://github.com/iNavFlight/inav/pull/5711
I omitted enabling motors as servos by default for safety
I omitted setting RTH to turn first, as most prefer climb first, as shown in a poll on INAV Fixed Wing Group