### PR TITLE
Add rth home altitude to advanced tuning #1094

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2464,6 +2464,12 @@
     "rthAltitudeHelp": {
         "message": "Used in Extra, Fixed and 'At Least' RTH altitude modes"
     },
+    "rthHomeAltitude": {
+        "message": "RTH Home altitude [cm]"
+    },
+    "rthHomeAltitudeHelp": {
+        "message": "Used when not landing at the home point. Upon arriving at home, the plane will loiter and change altitude to the RTH Home Altitude. Default is 0, which is feature disabled."
+    },
     "landDescentRate": {
         "message": "Landing vertical speed [cm/s]"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2464,7 +2464,7 @@
     "rthAltitudeHelp": {
         "message": "Used in Extra, Fixed and 'At Least' RTH altitude modes"
     },
-    "rthHomeAltitude": {
+    "rthHomeAltitudeLabel": {
         "message": "RTH Home altitude [cm]"
     },
     "rthHomeAltitudeHelp": {

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -76,6 +76,14 @@
                         </label>
                         <div class="helpicon cf_tip" data-i18n_title="rthAltitudeHelp"></div>
                     </div>
+                    
+                     <div class="number">
+                        <input type="number" id="rthHomeAltitude" data-setting="nav_rth_home_altitude" data-setting-multiplier="1" step="1" min="0" max="65000" />
+                        <label for="rthHomeAltitude">
+                            <span data-i18n="rthHomeAltitudeLabel"></span>
+                        </label>
+                        <div class="helpicon cf_tip" data-i18n_title="rthHomeAltitudeHelp"></div>
+                    </div>
 
                     <div class="checkbox">
                         <input type="checkbox" id="rth-climb-first" class="toggle" />


### PR DESCRIPTION
Added RTH Home Altitude to the Advanced Tuning tab. Implemented using the settings framework.
Fixes #1094 

![RTH Home Alt](https://user-images.githubusercontent.com/17590174/97731977-bdceda00-1acd-11eb-8e41-e141bb1c0fd1.png)
