### PR TITLE
Add end time to launch settings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -791,6 +791,9 @@
     "configurationLaunchTimeout": {
         "message": "Time Out"
     },
+    "configurationLaunchEndTime": {
+        "message": "Transition Time"
+    },
     "configurationLaunchMaxAltitude": {
         "message": "Max Altitude"
     },
@@ -826,6 +829,9 @@
     },
     "configurationLaunchTimeoutHelp": {
         "message": "Maximum time for launch sequence to be executed. After this time LAUNCH mode will be turned off and regular flight mode will take over (ms)"
+    },
+    "configurationLaunchEndTimeHelp": {
+        "message": "Smooth transition time at the end of the launch (ms). Default: 2000 [0-5000]."
     },
     "configurationLaunchMaxAltitudeHelp": {
         "message": "Altitude at which LAUNCH mode will be turned off and regular flight mode will take over. [cm]"

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -234,6 +234,13 @@
                         <div class="helpicon cf_tip" data-i18n_title="configurationLaunchTimeoutHelp"></div>
                     </div>
                     <div class="number">
+                        <input type="number" id="launchEndTime" data-setting="nav_fw_launch_end_time" data-setting-multiplier="1" step="1" min="0" max="5000" />
+                        <label for="launchEndTime">
+                            <span data-i18n="configurationLaunchEndTime"></span>
+                        </label>
+                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchEndTimeHelp"></div>
+                    </div>
+                    <div class="number">
                         <input type="number" id="launchMaxAltitude" data-setting="nav_fw_launch_max_altitude" data-setting-multiplier="1" step="1" min="0" max="60000" />
                         <label for="launchMaxAltitude">
                             <span data-i18n="configurationLaunchMaxAltitude"></span>


### PR DESCRIPTION
Added the setting for the smooth exit of launch mode, as a request from @dragnea

![image](https://user-images.githubusercontent.com/17590174/99186036-79863f80-2745-11eb-8953-51f224012c2a.png)
