### PR TITLE
Update launch settings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -762,79 +762,79 @@
         "message": "Fixed Wing Auto Launch Settings"
     },
     "configurationLaunchVelocity": {
-        "message": "Threshold Velocity"
+        "message": "Threshold Velocity [cm/s]"
     },
     "configurationLaunchVelocityHelp": {
         "message": "Forward velocity threshold for swing-launch detection [cm/s]"
     },
     "configurationLaunchAccel": {
-        "message": "Threshold Acceleration"
+        "message": "Threshold Acceleration [cm/s/s]"
     },
     "configurationLaunchAccelHelp": {
         "message": "Forward acceleration threshold for bungee launch of throw launch [cm/s/s], 1G = 981 cm/s/s"
     },
     "configurationLaunchMaxAngle": {
-        "message": "Max Throw Angle"
+        "message": "Max Throw Angle [&deg;]"
     },
     "configurationLaunchMaxAngleHelp": {
         "message": "Max throw angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg]"
     },
     "configurationLaunchDetectTime": {
-        "message": "Detect Time"
+        "message": "Detect Time [ms]"
     },
     "configurationLaunchDetectTimeHelp": {
         "message": "Time for which thresholds have to breached to consider launch happened [ms]"
     },
     "configurationLaunchThr": {
-        "message": "Launch Throttle"
+        "message": "Launch Throttle [uS]"
     },
     "configurationLaunchThrHelp": {
         "message": "Launch throttle - throttle to be set during launch sequence (pwm units)"
     },
     "configurationLaunchIdleThr": {
-        "message": "Idle Throttle"
+        "message": "Idle Throttle [uS]"
     },
     "configurationLaunchIdleThrHelp": {
         "message": "Idle throttle - throttle to be set before launch sequence is initiated. If set below minimum throttle it will force motor stop or at idle throttle (depending if the MOTOR_STOP is enabled). If set above minimum throttle it will force throttle to this value (if MOTOR_STOP is enabled it will be handled according to throttle stick position)"
     },
     "configurationLaunchMotorDelay": {
-        "message": "Motor Delay"
+        "message": "Motor Delay [ms]"
     },
     "configurationLaunchMotorDelayHelp": {
         "message": "Delay between detected launch and launch sequence start and throttling up (ms)"
     },
     "configurationLaunchSpinupTime": {
-        "message": "Motor Spinup Time"
+        "message": "Motor Spinup Time [ms]"
     },
     "configurationLaunchSpinupTimeHelp": {
         "message": "Time to bring power from minimum throttle to nav_fw_launch_thr - to avoid big stress on ESC and large torque from propeller"
     },
     "configurationLaunchMinTime": {
-        "message": "Minimum Launch Time"
+        "message": "Minimum Launch Time [ms]"
     },
     "configurationLaunchMinTimeHelp": {
         "message": "Allow launch mode to execute at least this time (ms) and ignore stick movements [0-60000]."
     },
     "configurationLaunchTimeout": {
-        "message": "Launch Timeout"
+        "message": "Launch Timeout [ms]"
     },
     "configurationLaunchTimeoutHelp": {
         "message": "Maximum time for launch sequence to be executed. After this time LAUNCH mode will be turned off and regular flight mode will take over (ms)"
     },
     "configurationLaunchEndTime": {
-        "message": "End Transition Time"
+        "message": "End Transition Time [ms]"
     },
     "configurationLaunchEndTimeHelp": {
         "message": "Smooth transition time at the end of the launch (ms). Default: 2000 [0-5000]. This is added to the Launch Timeout."
     },
     "configurationLaunchMaxAltitude": {
-        "message": "Maximum Altitude"
+        "message": "Maximum Altitude [cm]"
     },
     "configurationLaunchMaxAltitudeHelp": {
         "message": "Altitude at which LAUNCH mode will be turned off and regular flight mode will take over. [cm]"
     },
     "configurationLaunchClimbAngle": {
-        "message": "Climb Angle"
+        "message": "Climb Angle [&deg;]"
     },
     "configurationLaunchClimbAngleHelp": {
         "message": "Climb angle for launch sequence (degrees), is also restrained by global max_angle_inclination_pit"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -764,73 +764,79 @@
     "configurationLaunchVelocity": {
         "message": "Threshold Velocity"
     },
-    "configurationLaunchAccel": {
-        "message": "Threshold Acceleration"
-    },
-    "configurationLaunchMaxAngle": {
-        "message": "Max Tilt Angle"
-    },
-    "configurationLaunchDetectTime": {
-        "message": "Detect Time"
-    },
-    "configurationLaunchThr": {
-        "message": "Throttle"
-    },
-    "configurationLaunchIdleThr": {
-        "message": "Idle Throttle"
-    },
-    "configurationLaunchMotorDelay": {
-        "message": "Motor Delay"
-    },
-    "configurationLaunchSpinupTime": {
-        "message": "Motor Spinup Time"
-    },
-    "configurationLaunchMinTime": {
-        "message": "Min Time"
-    },
-    "configurationLaunchTimeout": {
-        "message": "Time Out"
-    },
-    "configurationLaunchMaxAltitude": {
-        "message": "Max Altitude"
-    },
-     "configurationLaunchClimbAngle": {
-        "message": "Climb Angle"
-    },
     "configurationLaunchVelocityHelp": {
         "message": "Forward velocity threshold for swing-launch detection [cm/s]"
+    },
+    "configurationLaunchAccel": {
+        "message": "Threshold Acceleration"
     },
     "configurationLaunchAccelHelp": {
         "message": "Forward acceleration threshold for bungee launch of throw launch [cm/s/s], 1G = 981 cm/s/s"
     },
+    "configurationLaunchMaxAngle": {
+        "message": "Max Throw Angle"
+    },
     "configurationLaunchMaxAngleHelp": {
-        "message": "Max tilt angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg]"
+        "message": "Max throw angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely [deg]"
+    },
+    "configurationLaunchDetectTime": {
+        "message": "Detect Time"
     },
     "configurationLaunchDetectTimeHelp": {
         "message": "Time for which thresholds have to breached to consider launch happened [ms]"
     },
+    "configurationLaunchThr": {
+        "message": "Launch Throttle"
+    },
     "configurationLaunchThrHelp": {
         "message": "Launch throttle - throttle to be set during launch sequence (pwm units)"
     },
+    "configurationLaunchIdleThr": {
+        "message": "Idle Throttle"
+    },
     "configurationLaunchIdleThrHelp": {
-        "message": "Launch idle throttle - throttle to be set before launch sequence is initiated. If set below minimum throttle it will force motor stop or at idle throttle (depending if the MOTOR_STOP is enabled). If set above minimum throttle it will force throttle to this value (if MOTOR_STOP is enabled it will be handled according to throttle stick position)"
+        "message": "Idle throttle - throttle to be set before launch sequence is initiated. If set below minimum throttle it will force motor stop or at idle throttle (depending if the MOTOR_STOP is enabled). If set above minimum throttle it will force throttle to this value (if MOTOR_STOP is enabled it will be handled according to throttle stick position)"
+    },
+    "configurationLaunchMotorDelay": {
+        "message": "Motor Delay"
     },
     "configurationLaunchMotorDelayHelp": {
         "message": "Delay between detected launch and launch sequence start and throttling up (ms)"
     },
+    "configurationLaunchSpinupTime": {
+        "message": "Motor Spinup Time"
+    },
     "configurationLaunchSpinupTimeHelp": {
         "message": "Time to bring power from minimum throttle to nav_fw_launch_thr - to avoid big stress on ESC and large torque from propeller"
+    },
+    "configurationLaunchMinTime": {
+        "message": "Minimum Launch Time"
     },
     "configurationLaunchMinTimeHelp": {
         "message": "Allow launch mode to execute at least this time (ms) and ignore stick movements [0-60000]."
     },
+    "configurationLaunchTimeout": {
+        "message": "Launch Timeout"
+    },
     "configurationLaunchTimeoutHelp": {
         "message": "Maximum time for launch sequence to be executed. After this time LAUNCH mode will be turned off and regular flight mode will take over (ms)"
+    },
+    "configurationLaunchEndTime": {
+        "message": "End Transition Time"
+    },
+    "configurationLaunchEndTimeHelp": {
+        "message": "Smooth transition time at the end of the launch (ms). Default: 2000 [0-5000]. This is added to the Launch Timeout."
+    },
+    "configurationLaunchMaxAltitude": {
+        "message": "Maximum Altitude"
     },
     "configurationLaunchMaxAltitudeHelp": {
         "message": "Altitude at which LAUNCH mode will be turned off and regular flight mode will take over. [cm]"
     },
-     "configurationLaunchClimbAngleHelp": {
+    "configurationLaunchClimbAngle": {
+        "message": "Climb Angle"
+    },
+    "configurationLaunchClimbAngleHelp": {
         "message": "Climb angle for launch sequence (degrees), is also restrained by global max_angle_inclination_pit"
     },
     "configuration3d": {

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -164,39 +164,11 @@
                 </div>
                 <div class="spacer_box settings">
                     <div class="number">
-                        <input type="number" id="launchVelocity" data-setting="nav_fw_launch_velocity" data-setting-multiplier="1" step="1" min="1000" max="2000" />
-                        <label for="launchVelocity">
-                            <span data-i18n="configurationLaunchVelocity"></span>
-                        </label>
-                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchVelocityHelp"></div>
-                    </div>
-                     <div class="number">
-                        <input type="number" id="launchAccel" data-setting="nav_fw_launch_accel" data-setting-multiplier="1" step="1" min="1000" max="2000" />
-                        <label for="launchAccel">
-                            <span data-i18n="configurationLaunchAccel"></span>
-                        </label>
-                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchAccelHelp"></div>
-                    </div>
-                    <div class="number">
                         <input type="number" id="launchMaxAngle" data-setting="nav_fw_launch_max_angle" data-setting-multiplier="1" step="1" min="5" max="180" />
                         <label for="launchMaxAngle">
                             <span data-i18n="configurationLaunchMaxAngle"></span>
                         </label>
                         <div class="helpicon cf_tip" data-i18n_title="configurationLaunchMaxAngleHelp"></div>
-                    </div>
-                    <div class="number">
-                        <input type="number" id="launchDetectTime" data-setting="nav_fw_launch_detect_time" data-setting-multiplier="1" step="1" min="10" max="1000" />
-                        <label for="launchDetectTime">
-                            <span data-i18n="configurationLaunchDetectTime"></span>
-                        </label>
-                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchDetectTimeHelp"></div>
-                    </div>
-                     <div class="number">
-                        <input type="number" id="launchThr" data-setting="nav_fw_launch_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
-                        <label for="launchThr">
-                            <span data-i18n="configurationLaunchThr"></span>
-                        </label>
-                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchThrHelp"></div>
                     </div>
                     <div class="number">
                         <input type="number" id="launchIdleThr" data-setting="nav_fw_launch_idle_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
@@ -206,11 +178,39 @@
                         <div class="helpicon cf_tip" data-i18n_title="configurationLaunchIdleThrHelp"></div>
                     </div>
                     <div class="number">
+                        <input type="number" id="launchVelocity" data-setting="nav_fw_launch_velocity" data-setting-multiplier="1" step="1" min="1000" max="2000" />
+                        <label for="launchVelocity">
+                            <span data-i18n="configurationLaunchVelocity"></span>
+                        </label>
+                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchVelocityHelp"></div>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="launchAccel" data-setting="nav_fw_launch_accel" data-setting-multiplier="1" step="1" min="1000" max="2000" />
+                        <label for="launchAccel">
+                            <span data-i18n="configurationLaunchAccel"></span>
+                        </label>
+                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchAccelHelp"></div>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="launchDetectTime" data-setting="nav_fw_launch_detect_time" data-setting-multiplier="1" step="1" min="10" max="1000" />
+                        <label for="launchDetectTime">
+                            <span data-i18n="configurationLaunchDetectTime"></span>
+                        </label>
+                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchDetectTimeHelp"></div>
+                    </div>
+                    <div class="number">
                         <input type="number" id="launchMotorDelay" data-setting="nav_fw_launch_motor_delay" data-setting-multiplier="1" step="1" min="0" max="5000" />
                         <label for="launchMotorDelay">
                             <span data-i18n="configurationLaunchMotorDelay"></span>
                         </label>
                         <div class="helpicon cf_tip" data-i18n_title="configurationLaunchMotorDelayHelp"></div>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="launchMinTime" data-setting="nav_fw_launch_min_time" data-setting-multiplier="1" step="1" min="0" max="60000" />
+                        <label for="launchMinTime">
+                            <span data-i18n="configurationLaunchMinTime"></span>
+                        </label>
+                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchMinTimeHelp"></div>
                     </div>
                     <div class="number">
                         <input type="number" id="launchSpinupTime" data-setting="nav_fw_launch_spinup_time" data-setting-multiplier="1" step="1" min="0" max="1000" />
@@ -219,12 +219,19 @@
                         </label>
                         <div class="helpicon cf_tip" data-i18n_title="configurationLaunchSpinupTimeHelp"></div>
                     </div>
-                    <div class="number">
-                        <input type="number" id="launchMinTime" data-setting="nav_fw_launch_min_time" data-setting-multiplier="1" step="1" min="0" max="60000" />
-                        <label for="launchMinTime">
-                            <span data-i18n="configurationLaunchMinTime"></span>
+                     <div class="number">
+                        <input type="number" id="launchThr" data-setting="nav_fw_launch_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
+                        <label for="launchThr">
+                            <span data-i18n="configurationLaunchThr"></span>
                         </label>
-                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchMinTimeHelp"></div>
+                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchThrHelp"></div>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="launchClimbAngle" data-setting="nav_fw_launch_climb_angle" data-setting-multiplier="1" step="1" min="0" max="60000" />
+                        <label for="launchClimbAngle">
+                            <span data-i18n="configurationLaunchClimbAngle"></span>
+                        </label>
+                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchClimbAngleHelp"></div>
                     </div>
                     <div class="number">
                         <input type="number" id="launchTimeout" data-setting="nav_fw_launch_timeout" data-setting-multiplier="1" step="1" min="0" max="60000" />
@@ -241,16 +248,14 @@
                         <div class="helpicon cf_tip" data-i18n_title="configurationLaunchMaxAltitudeHelp"></div>
                     </div>
                     <div class="number">
-                        <input type="number" id="launchClimbAngle" data-setting="nav_fw_launch_climb_angle" data-setting-multiplier="1" step="1" min="0" max="60000" />
-                        <label for="launchClimbAngle">
-                            <span data-i18n="configurationLaunchClimbAngle"></span>
+                        <input type="number" id="launchEndTime" data-setting="nav_fw_launch_end_time" data-setting-multiplier="1" step="1" min="0" max="5000" />
+                        <label for="launchEndTime">
+                            <span data-i18n="configurationLaunchEndTime"></span>
                         </label>
-                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchClimbAngleHelp"></div>
+                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchEndTimeHelp"></div>
                     </div>
                 </div>
-
             </div>
-
         </div>
 
         <div class="rightWrapper">

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -164,18 +164,18 @@
                 </div>
                 <div class="spacer_box settings">
                     <div class="number">
-                        <input type="number" id="launchMaxAngle" data-setting="nav_fw_launch_max_angle" data-setting-multiplier="1" step="1" min="5" max="180" />
-                        <label for="launchMaxAngle">
-                            <span data-i18n="configurationLaunchMaxAngle"></span>
-                        </label>
-                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchMaxAngleHelp"></div>
-                    </div>
-                    <div class="number">
                         <input type="number" id="launchIdleThr" data-setting="nav_fw_launch_idle_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
                         <label for="launchIdleThr">
                             <span data-i18n="configurationLaunchIdleThr"></span>
                         </label>
                         <div class="helpicon cf_tip" data-i18n_title="configurationLaunchIdleThrHelp"></div>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="launchMaxAngle" data-setting="nav_fw_launch_max_angle" data-setting-multiplier="1" step="1" min="5" max="180" />
+                        <label for="launchMaxAngle">
+                            <span data-i18n="configurationLaunchMaxAngle"></span>
+                        </label>
+                        <div class="helpicon cf_tip" data-i18n_title="configurationLaunchMaxAngleHelp"></div>
                     </div>
                     <div class="number">
                         <input type="number" id="launchVelocity" data-setting="nav_fw_launch_velocity" data-setting-multiplier="1" step="1" min="1000" max="2000" />


### PR DESCRIPTION
Updated the launch settings after feedback that some of the labels were not obvious to people who are used to the CLI commands (in particular max tilt angle). I have updated some labels to make these easier to identify for seasoned iNav pilots. While still keeping them easy to understand for new people.

The settings have been re-ordered in to:
1. Pre-launch
2. Detection
3. Launch
4. Post launch

![image](https://user-images.githubusercontent.com/17590174/99186781-983b0500-274a-11eb-878f-77da3c094159.png)
