### PR TITLE
Moved Crsf LQ Format help message to Settings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2897,7 +2897,7 @@
         "message": "RX Link Quality %"
     },
     "osdElement_CRSF_LQ_HELP": {
-        "message": "STYLE1 shows LQ% as used by TBS hardware. STYLE2 shows RF Profile Modes (2=150Hz, 1=50Hz, 0=4Hz update rates) and LQ % [0..100%]. Tracer shows RFMode 1 and LQ [0..100%]."
+        "message": "Use Crossfire LQ Format setting to select format type."
     },
     "osdElement_CRSF_SNR_DB": {
         "message": "RX Uplink SNR in dB"
@@ -3033,6 +3033,9 @@
     },
     "osdSettingMainVoltageDecimals": {
         "message": "Main voltage decimals"
+    },
+    "osdSettingCRSF_LQ_FORMAT_HELP": {
+        "message": "TYPE1 shows LQ% as used by TBS hardware. TYPE2 shows RF Profile Modes (2=150Hz, 1=50Hz, 0=4Hz update rates) and LQ % [0..100%]. Tracer shows RFMode 1 (1=250Hz) and LQ % [0..100%]."
     },
     "uploadingCharacters": {
         "message": "Uploading..."

--- a/tabs/osd.html
+++ b/tabs/osd.html
@@ -80,6 +80,7 @@
                                 <label>
                                     <select class="update_preview" data-setting="osd_right_sidebar_scroll" data-live="true"></select> Right Sidebar Scroll
                                 </label>
+                                <div class="helpicon cf_tip" data-i18n_title="osdSettingCRSF_LQ_FORMAT_HELP"></div>
                                 <label>
                                     <select class="update_preview" data-setting="osd_crsf_lq_format" data-live="true"></select> Crossfire LQ Format
                                 </label>


### PR DESCRIPTION
Moves LQ help message to Settings and updates setting value names in message to match Inav. The word "Style" was used instead of "Type"

Thanks!

![image](https://user-images.githubusercontent.com/45466510/99196445-692c8f80-275a-11eb-939e-327ae6fd4445.png)
