### PR TITLE
Add version to osd

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -772,6 +772,11 @@ OSD.constants = {
                     id: 106,
                     min_version: '2.3.0',
                     preview: FONT.symbol(SYM.RPM) + '983',
+                },
+                {
+                    name: 'VERSION',
+                    id: 119,
+                    preview: 'INAV: 2.7.0'
                 }
             ]
         },

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -776,7 +776,7 @@ OSD.constants = {
                 {
                     name: 'VERSION',
                     id: 119,
-                    preview: 'INAV: 2.7.0'
+                    preview: 'INAV 2.7.0'
                 }
             ]
         },


### PR DESCRIPTION
Added an option to add the firmware version number to the OSD.

Fixes https://github.com/iNavFlight/inav/issues/6328

PR For firmware component: https://github.com/iNavFlight/inav/pull/6344

![image](https://user-images.githubusercontent.com/17590174/100277754-97308180-2f5b-11eb-970f-8e44d21fa8a0.png)

![image](https://user-images.githubusercontent.com/17590174/100277769-9f88bc80-2f5b-11eb-8746-a072bfa1ee8e.png)