### PR TITLE
Fix bug in throttle smoothing parameters settings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2561,10 +2561,10 @@
         "message": "How smoothly the autopilot adjusts the throttle level in response to pitch angle changes [0-9]."
     },
     "pitchToThrottleThreshold": {
-        "message": "Instantaneous pitch adjustment threshold [centidegrees]"
+        "message": "Instantaneous throttle adjustment threshold [centidegrees]"
     },
     "pitchToThrottleThresholdHelp": {
-        "message": "The autopilot will instantly adjust the throttle level according to pitch to throttle if the pitch angle is more this many centidegrees from the filtered value."
+        "message": "The autopilot will instantly adjust the throttle level without smoothing according to pitch to throttle if the pitch angle is more this many centidegrees from the filtered value."
     },
     "loiterRadius": {
         "message": "Loiter radius [cm]"

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -388,7 +388,7 @@
                     </div>
                     
                     <div class="number">
-                        <input id="pitchToThrottleSmoothing" type="number" data-simple-bind="nav_fw_pitch2thr_smoothing" data-setting-multiplier="1" step="0" min="0" max="9">
+                        <input id="pitchToThrottleSmoothing" type="number" data-setting="nav_fw_pitch2thr_smoothing" data-setting-multiplier="1" step="0" min="0" max="9">
                         <label for="pitchToThrottleSmoothing">
                             <span data-i18n="pitchToThrottleSmoothing"></span>
                         </label>
@@ -396,7 +396,7 @@
                     </div>
                     
                     <div class="number">
-                        <input id="pitchToThrottleThreshold" type="number" data-simple-bind="nav_fw_pitch2thr_threshold" data-setting-multiplier="1" step="1" min="0" max="900">
+                        <input id="pitchToThrottleThreshold" type="number" data-setting="nav_fw_pitch2thr_threshold" data-setting-multiplier="1" step="1" min="0" max="900">
                         <label for="pitchToThrottleThreshold">
                             <span data-i18n="pitchToThrottleThreshold"></span>
                         </label>


### PR DESCRIPTION
This fixes a bug introduced in #1127 that broke (well, it actually never worked) the link between the fields in the gui and the cli commands. Now works correctly. I also slightly changed the messages.