### PR TITLE
Set default Airmode type to STICK_CENTER_ONCE for fixed wing

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -272,6 +272,10 @@ helper.defaultsDialog = (function() {
                 {
                     key: "imu_acc_ignore_rate",
                     value: 10
+                },
+                {
+                    key: "mc_airmode_type",
+                    value: "STICK_CENTER_ONCE"
                 }
             ],
             "features":[


### PR DESCRIPTION
Added default airmode type to be STICK_CENTER_ONCE, which makes more sense for fixed wing. This will need updating if a PR I'm currently working on for the INAV firmware goes through. Works with the current setup.