### PR TITLE
Removed mc_ from airmode settings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3511,17 +3511,17 @@
     "iTermMechanics": {
         "message": "I-term mechanics"
     },
-    "mc_airmode_type": {
+    "airmode_type": {
         "message": "Airmode handling type"
     },
-    "mc_airmode_type_help": {
-        "message": "Defines the Airmode state handling type for Multirotors. <br />Default STICK_CENTER is the classical approach in which Airmode is always active if enabled, but when the throttle is low and ROLL/PITCH/YAW sticks are centered, Iterms is not allowed to grow (ANTI_WINDUP). <br />STICK_CENTER_ONCE works like STICK_CENTER, but only until the first time THROTTLE is not low and ROLL/PITCH/YAW sticks are moved. After that, ANTI_WINDUP is deactivated until next arm. Useful for airplanes. <br />THROTTLE_THRESHOLD is the Airmode behavior known from Betaflight. In this mode, Airmode is active as soon THROTTLE position is above <i>mc_airmode_threshold</i> and stays active until disarm. ANTI_WINDUP is never triggered. For small Multirotors (up to 7-inch propellers) it is suggested to switch to THROTTLE_THRESHOLD since it keeps full stabilization no matter what pilot does with the sticks. Airplanes default to STICK_CENTER mode."
+    "airmode_type_help": {
+        "message": "Defines the Airmode state handling type. <br />Default STICK_CENTER is the classical approach in which Airmode is always active if enabled, but when the throttle is low and ROLL/PITCH/YAW sticks are centered, Iterms is not allowed to grow (ANTI_WINDUP). <br />STICK_CENTER_ONCE works like STICK_CENTER, but only until the first time THROTTLE is not low and ROLL/PITCH/YAW sticks are moved. After that, ANTI_WINDUP is deactivated until next arm. Useful for airplanes. <br />THROTTLE_THRESHOLD is the Airmode behavior known from Betaflight. In this mode, Airmode is active as soon THROTTLE position is above <i>airmode_throttle_threshold</i> and stays active until disarm. ANTI_WINDUP is never triggered. For small Multirotors (up to 7-inch propellers) it is suggested to switch to THROTTLE_THRESHOLD since it keeps full stabilization no matter what pilot does with the sticks. Airplanes default to STICK_CENTER_ONCE mode."
     },
-    "mc_airmode_threshold": {
+    "airmode_throttle_threshold": {
         "message": "Airmode Throttle threshold"
     },
-    "mc_airmode_threshold_help": {
-        "message": "Defines airmode THROTTLE activation threshold when mc_airmode_type THROTTLE_THRESHOLD is used"
+    "airmode_throttle_threshold_help": {
+        "message": "Defines airmode THROTTLE activation threshold when airmode_type THROTTLE_THRESHOLD is used"
     },
     "gps_map_center": {
         "message": "Center"

--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -85,7 +85,7 @@ helper.defaultsDialog = (function() {
                 Mechanics
                 */
                 {
-                    key: "mc_airmode_type",
+                    key: "airmode_type",
                     value: "THROTTLE_THRESHOLD"
                 },
                 {
@@ -272,6 +272,10 @@ helper.defaultsDialog = (function() {
                 {
                     key: "imu_acc_ignore_rate",
                     value: 10
+                },
+                {
+                    key: "airmode_type",
+                    value: "STICK_CENTER_ONCE"
                 }
             ],
             "features":[

--- a/js/preset_definitions.js
+++ b/js/preset_definitions.js
@@ -174,7 +174,7 @@ presets.presets = [
                 value: 70
             },
             {
-                key: "mc_airmode_type",
+                key: "airmode_type",
                 value: "THROTTLE_THRESHOLD"
             },
             {
@@ -324,7 +324,7 @@ presets.presets = [
                 value: 70
             },
             {
-                key: "mc_airmode_type",
+                key: "airmode_type",
                 value: "THROTTLE_THRESHOLD"
             },
             {
@@ -482,7 +482,7 @@ presets.presets = [
                 value: 70
             },
             {
-                key: "mc_airmode_type",
+                key: "airmode_type",
                 value: "THROTTLE_THRESHOLD"
             },
             {
@@ -645,7 +645,7 @@ presets.presets = [
                 value: 70
             },
             {
-                key: "mc_airmode_type",
+                key: "airmode_type",
                 value: "THROTTLE_THRESHOLD"
             },
             {
@@ -815,7 +815,7 @@ presets.presets = [
                 value: 70
             },
             {
-                key: "mc_airmode_type",
+                key: "airmode_type",
                 value: "THROTTLE_THRESHOLD"
             },
             {
@@ -973,7 +973,7 @@ presets.presets = [
                 value: 70
             },
             {
-                key: "mc_airmode_type",
+                key: "airmode_type",
                 value: "THROTTLE_THRESHOLD"
             },
             {
@@ -1131,7 +1131,7 @@ presets.presets = [
                 value: 70
             },
             {
-                key: "mc_airmode_type",
+                key: "airmode_type",
                 value: "THROTTLE_THRESHOLD"
             },
             {

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -481,17 +481,17 @@
                 <table class="settings-table settings-table--filtering">
                     <tbody>
                         <tr>
-                            <th data-i18n="mc_airmode_type"></th>
+                            <th data-i18n="airmode_type"></th>
                             <td>
-                                <select data-setting="mc_airmode_type" />
-                                <div class="helpicon cf_tip" data-i18n_title="mc_airmode_type_help"></div>
+                                <select data-setting="airmode_type" />
+                                <div class="helpicon cf_tip" data-i18n_title="airmode_type_help"></div>
                             </td>
                         </tr>
                         <tr>
-                            <th data-i18n="mc_airmode_threshold"></th>
+                            <th data-i18n="airmode_throttle_threshold"></th>
                             <td>
-                                <select data-setting="mc_airmode_threshold" />
-                                <div class="helpicon cf_tip" data-i18n_title="mc_airmode_threshold_help"></div>
+                                <select data-setting="airmode_throttle_threshold" />
+                                <div class="helpicon cf_tip" data-i18n_title="airmode_throttle_threshold_help"></div>
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
This change is to partner PR https://github.com/iNavFlight/inav/pull/6578 in the INAV firmware. It removes the mc_ prefix from the airmode CLI variables, as they are confusing, as there are now options that can also apply to fixed wing.

This change covers the default dialog, presets, and PID/Mechanics pages. I could not find any other instances of mc_airmode_x in the configurator.