### PR TITLE
Increased FW loiter radius

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -259,7 +259,7 @@ helper.defaultsDialog = (function() {
                 },
                 {
                     key: "nav_wp_radius",
-                    value: 3000
+                    value: 7500
                 },
                 {
                     key: "platform_type",


### PR DESCRIPTION
We are seeing a lot of issues with crashes due to partially too tight a loiter radius. I have increased this value to have a safer default. It should of course still be tuned to the aircraft, but this will hopefully cause less issues to those who forget.