### PR TITLE
Remove the unused PWM_SERVO_DRIVER feature which is unused

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -570,7 +570,6 @@ var FC = {
             {bit: 19, group: 'other', name: 'BLACKBOX', haveTip: true, showNameInTip: true},
             {bit: 28, group: 'other', name: 'PWM_OUTPUT_ENABLE', haveTip: true},
             {bit: 26, group: 'other', name: 'SOFTSPI'},
-            {bit: 27, group: 'other', name: 'PWM_SERVO_DRIVER', haveTip: true, showNameInTip: true},
             {bit: 29, group: 'other', name: 'OSD', haveTip: false, showNameInTip: false},
             {bit: 22, group: 'other', name: 'AIRMODE', haveTip: false, showNameInTip: false},
             {bit: 30, group: 'other', name: 'FW_LAUNCH', haveTip: false, showNameInTip: false},


### PR DESCRIPTION
The right way to enable the external PWM driver is now to set `servo_protocol` to `PWM_DRIVER`