### PR TITLE
New fixed Wing generic presets

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -190,122 +190,165 @@ helper.defaultsDialog = (function() {
             "reboot": true,
             "settings": [
                 { 
-					key: "platform_type"
-					value: "AIRPLANE"
-				},
-				{
-                    key: "gyro_hardware_lpf",
-                    value: "256HZ"
+			key: "platform_type"
+			value: "AIRPLANE"
+		},
+		{
+                	key: "gyro_hardware_lpf",
+                    	value: "256HZ"
                 },
                 { 
-					key: "gyro_lpf_hz"
-					value: "25"
-				},
-				{ 
-					key: "gyro_lpf_type"
-					value: "BIQUAD"
-				},
-				{ 
-					key: "dynamic_gyro_notch_enabled"
-					value: "ON"
-				},
-				{ 
-					key: "dynamic_gyro_notch_q"
-					value: "250"
-				},
-				{ 
-					key: "dynamic_gyro_notch_min_hz"
-					value: "30"
-				},
-				{ 
-					key: "motor_pwm_protocol"
-					value: "STANDARD"
-				},
-				{ 
-					key: "rc_yaw_expo"
-					value: "30"
-				},
-				{ 
-					key: "rc_expo"
-					value: "30"
-				},
-				{ 
-					key: "roll_rate"
-					value: "18"
-				},
-				{ 
-					key: "pitch_rate"
-					value: "9"
-				},
-				{ 
-					key: "yaw_rate"
-					value: "3"
-				},
-				{ 
-					key: "nav_fw_pos_z_p"
-					value: "20"
-				},
-				{ 
-					key: "nav_fw_pos_z_d"
-					value: "5"
-				},
-				{ 
-					key: "nav_fw_pos_xy_p"
-					value: "50"
-				},
-				{ 
-					key: "small_angle"
-					value: "180"
-				},
-				{ 
-					key: "nav_rth_allow_landing"
-					value: "FS_ONLY"
-				},
-				{ 
-					key: "nav_rth_altitude"
-					value: "5000"
-				},
-				{ 
-					key: "nav_wp_radius"
-					value: "1500"
-				},
-				{ 
-					key: "throttle_idle"
-					value: "5.000"
-				},
-				{ 
-					key: "applied_defaults"
-					value: "3"
-				},
-				{ 
-					key: "imu_acc_ignore_rate"
-					value: "10"
-				},
-				{ 
-					key: "airmode_type"
-					value: "STICK_CENTER_ONCE"
-				},
-				{ 
-					key: "airmode_type"
-					value: "STICK_CENTER_ONCE"
-				},
-				{ 
-					key: "nav_rth_climb_first"
-					value: "OFF"
-				},
-				{ 
-					key: "fw_turn_assist_pitch_gain"
-					value: "0.5"
-				},
-				{ 
-					key: "max_angle_inclination_rll"
-					value: "35"
-				},
-				{ 
-					key: "nav_fw_bank_angle"
-					value: "35"
-				},
-
+			key: "gyro_lpf_hz"
+			value: "25"
+		},
+		{ 
+			key: "gyro_lpf_type"
+			value: "BIQUAD"
+		},
+		{ 
+			key: "dynamic_gyro_notch_enabled"
+			value: "ON"
+		},
+		{ 
+			key: "dynamic_gyro_notch_q"
+			value: "250"
+		},
+		{ 
+			key: "dynamic_gyro_notch_min_hz"
+			value: "30"
+		},
+		{ 
+			key: "motor_pwm_protocol"
+			value: "STANDARD"
+		},
+		{ 
+			key: "rc_yaw_expo"
+			value: "30"
+		},
+		{ 
+			key: "rc_expo"
+			value: "30"
+		},
+		{ 
+			key: "roll_rate"
+			value: "18"
+		},
+		{ 
+			key: "pitch_rate"
+			value: "9"
+		},
+		{ 
+			key: "yaw_rate"
+			value: "3"
+		},
+		{ 
+			key: "nav_fw_pos_z_p"
+			value: "20"
+		},
+		{ 
+			key: "nav_fw_pos_z_d"
+			value: "5"
+		},
+		{ 
+			key: "nav_fw_pos_xy_p"
+			value: "50"
+		},
+		{ 
+			key: "small_angle"
+			value: "180"
+		},
+		{ 
+			key: "nav_rth_allow_landing"
+			value: "FS_ONLY"
+		},
+		{ 
+			key: "nav_rth_altitude"
+			value: "5000"
+		},
+		{ 
+			key: "nav_wp_radius"
+			value: "1500"
+		},
+		{ 
+			key: "throttle_idle"
+			value: "5.000"
+		},
+		{ 
+			key: "applied_defaults"
+			value: "3"
+		},
+		{ 
+			key: "imu_acc_ignore_rate"
+			value: "10"
+		},
+		{ 
+			key: "airmode_type"
+			value: "STICK_CENTER_ONCE"
+		},
+		{ 
+			key: "airmode_type"
+			value: "STICK_CENTER_ONCE"
+		},
+		{ 
+			key: "nav_rth_climb_first"
+			value: "OFF"
+		},
+		{ 
+			key: "fw_turn_assist_pitch_gain"
+			value: "0.5"
+		},
+		{ 
+			key: "max_angle_inclination_rll"
+			value: "35"
+		},
+		{ 
+			key: "nav_fw_bank_angle"
+			value: "35"
+		},
+		{ 
+			key: "fw_p_pitch"
+			value: "15"
+		},
+		{ 
+			key: "fw_i_pitch"
+			value: "10"
+		},
+		{ 
+			key: "fw_ff_pitch"
+			value: "60"
+		},
+		{ 
+			key: "fw_p_roll"
+			value: "10"
+		},
+		{ 
+			key: "fw_i_roll"
+			value: "8"
+		},
+		{ 
+			key: "fw_ff_roll"
+			value: "40"
+		},
+		{ 
+			key: "roll_rate"
+			value: "18"
+		},
+		{ 
+			key: "pitch_rate
+			value: "9"
+		},
+		{ 
+			key: "fw_p_yaw"
+			value: "20"
+		},
+		{ 
+			key: "fw_i_yaw"
+			value: "0"
+		},
+		{ 
+			key: "fw_ff_yaw"
+			value: "100"
+		},
             ],
             "features":[
                 {
@@ -314,129 +357,172 @@ helper.defaultsDialog = (function() {
                 }
             ]
         },
-		 {
-            "title": 'Flying Wing with no Tail',
+		{
+            "title": 'Flying Wing, Delta, etc.',
             "notRecommended": false,
             "id": 3,
             "reboot": true,
             "settings": [
                 { 
-					key: "platform_type"
-					value: "AIRPLANE"
-				},
-				{
-                    key: "gyro_hardware_lpf",
-                    value: "256HZ"
+			key: "platform_type"
+			value: "AIRPLANE"
+		},
+		{
+                    	key: "gyro_hardware_lpf",
+                    	value: "256HZ"
                 },
                 { 
-					key: "gyro_lpf_hz"
-					value: "25"
-				},
-				{ 
-					key: "gyro_lpf_type"
-					value: "BIQUAD"
-				},
-				{ 
-					key: "dynamic_gyro_notch_enabled"
-					value: "ON"
-				},
-				{ 
-					key: "dynamic_gyro_notch_q"
-					value: "250"
-				},
-				{ 
-					key: "dynamic_gyro_notch_min_hz"
-					value: "30"
-				},
-				{ 
-					key: "motor_pwm_protocol"
-					value: "STANDARD"
-				},
-				{ 
-					key: "rc_yaw_expo"
-					value: "30"
-				},
-				{ 
-					key: "rc_expo"
-					value: "30"
-				},
-				{ 
-					key: "roll_rate"
-					value: "18"
-				},
-				{ 
-					key: "pitch_rate"
-					value: "9"
-				},
-				{ 
-					key: "yaw_rate"
-					value: "3"
-				},
-				{ 
-					key: "nav_fw_pos_z_p"
-					value: "20"
-				},
-				{ 
-					key: "nav_fw_pos_z_d"
-					value: "5"
-				},
-				{ 
-					key: "nav_fw_pos_xy_p"
-					value: "50"
-				},
-				{ 
-					key: "small_angle"
-					value: "180"
-				},
-				{ 
-					key: "nav_rth_allow_landing"
-					value: "FS_ONLY"
-				},
-				{ 
-					key: "nav_rth_altitude"
-					value: "5000"
-				},
-				{ 
-					key: "nav_wp_radius"
-					value: "1500"
-				},
-				{ 
-					key: "throttle_idle"
-					value: "5.000"
-				},
-				{ 
-					key: "applied_defaults"
-					value: "3"
-				},
-				{ 
-					key: "imu_acc_ignore_rate"
-					value: "10"
-				},
-				{ 
-					key: "airmode_type"
-					value: "STICK_CENTER_ONCE"
-				},
-				{ 
-					key: "airmode_type"
-					value: "STICK_CENTER_ONCE"
-				},
-				{ 
-					key: "nav_rth_climb_first"
-					value: "OFF"
-				},
-				{ 
-					key: "fw_turn_assist_pitch_gain"
-					value: "0.2"
-				},
-				{ 
-					key: "max_angle_inclination_rll"
-					value: "45"
-				},
-				{ 
-					key: "nav_fw_bank_angle"
-					value: "45"
-				},
-
+			key: "gyro_lpf_hz"
+			value: "25"
+		},
+		{ 
+			key: "gyro_lpf_type"
+			value: "BIQUAD"
+		},
+		{ 
+			key: "dynamic_gyro_notch_enabled"
+			value: "ON"
+		},
+		{ 
+			key: "dynamic_gyro_notch_q"
+			value: "250"
+		},
+		{ 
+			key: "dynamic_gyro_notch_min_hz"
+			value: "30"
+		},
+		{ 
+			key: "motor_pwm_protocol"
+			value: "STANDARD"
+		},
+		{ 
+			key: "rc_yaw_expo"
+			value: "30"
+		},
+		{ 
+			key: "rc_expo"
+			value: "30"
+		},
+		{ 
+			key: "roll_rate"
+			value: "18"
+		},
+		{ 
+			key: "pitch_rate"
+			value: "9"
+		},
+		{ 
+			key: "yaw_rate"
+			value: "3"
+		},
+		{ 
+			key: "nav_fw_pos_z_p"
+			value: "20"
+		},
+		{ 
+			key: "nav_fw_pos_z_d"
+			value: "5"
+		},
+		{ 
+			key: "nav_fw_pos_xy_p"
+			value: "50"
+		},
+		{ 
+			key: "small_angle"
+			value: "180"
+		},
+		{ 
+			key: "nav_rth_allow_landing"
+			value: "FS_ONLY"
+		},
+		{ 
+			key: "nav_rth_altitude"
+			value: "5000"
+		},
+		{ 
+			key: "nav_wp_radius"
+			value: "1500"
+		},
+		{ 
+			key: "throttle_idle"
+			value: "5.000"
+		},
+		{ 
+			key: "applied_defaults"
+			value: "3"
+		},
+		{ 
+			key: "imu_acc_ignore_rate"
+			value: "10"
+		},
+		{ 
+			key: "airmode_type"
+			value: "STICK_CENTER_ONCE"
+		},
+		{ 
+			key: "airmode_type"
+			value: "STICK_CENTER_ONCE"
+		},
+		{ 
+			key: "nav_rth_climb_first"
+			value: "OFF"
+		},
+		{ 
+			key: "fw_turn_assist_pitch_gain"
+			value: "0.2"
+		},
+		{ 
+			key: "max_angle_inclination_rll"
+			value: "45"
+		},
+		{ 
+			key: "nav_fw_bank_angle"
+			value: "45"
+		},
+		{ 
+			key: "fw_p_pitch"
+			value: "10"
+		},
+		{ 
+			key: "fw_i_pitch"
+			value: "15"
+		},
+		{ 
+			key: "fw_ff_pitch"
+			value: "70"
+		},
+		{ 
+			key: "fw_p_roll"
+			value: "5"
+		},
+		{ 
+			key: "fw_i_roll"
+			value: "8"
+		},
+		{ 
+			key: "fw_ff_roll"
+			value: "35"
+		},
+		{ 
+			key: "roll_rate"
+			value: "18"
+		},
+		{ 
+			key: "pitch_rate
+			value: "9"
+		},
+		{ 
+			key: "fw_p_yaw"
+			value: "20"
+		},
+		{ 
+			key: "fw_i_yaw"
+			value: "0"
+		},
+		{ 
+			key: "fw_ff_yaw"
+			value: "100"
+		},
             ],
             "features":[
                 {

--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -335,7 +335,7 @@ helper.defaultsDialog = (function() {
                 },
                 {
                     key: "failsafe_mission",
-                    value: "OFF"
+                    value: "ON"
                 },
                 {
                     key: "nav_wp_radius",
@@ -501,7 +501,7 @@ helper.defaultsDialog = (function() {
                 },
                 {
                     key: "failsafe_mission",
-                    value: "OFF"
+                    value: "ON"
                 },
                 {
                     key: "nav_wp_radius",

--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -205,6 +205,10 @@ helper.defaultsDialog = (function() {
                     key: "gyro_lpf_hz",
                     value: 25
                 },
+		{
+                    key: "dterm_lpf_hz",
+                    value: 10
+                },
                 {
                     key: "gyro_lpf_type",
                     value: "BIQUAD"
@@ -370,6 +374,10 @@ helper.defaultsDialog = (function() {
                 {
                     key: "gyro_lpf_hz",
                     value: 25
+                },
+		{
+                    key: "dterm_lpf_hz",
+                    value: 10
                 },
                 {
                     key: "gyro_lpf_type",

--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -184,171 +184,163 @@ helper.defaultsDialog = (function() {
             ]
         },
         {
-            "title": 'Airplane with Tail',
+            "title": 'Airplane with a Tail',
             "notRecommended": false,
             "id": 3,
             "reboot": true,
             "settings": [
-                { 
-			key: "platform_type"
-			value: "AIRPLANE"
-		},
 		{
-                	key: "gyro_hardware_lpf",
-                    	value: "256HZ"
+                    key: "platform_type",
+                    value: "AIRPLANE"
                 },
-                { 
-			key: "gyro_lpf_hz"
-			value: "25"
+		{
+                    key: "applied_defaults",
+                    value: 3
+                },
+                {
+                    key: "gyro_hardware_lpf",
+                    value: "256HZ"
+                },
+                {
+                    key: "gyro_lpf_hz",
+                    value: 25
+                },
+                {
+                    key: "gyro_lpf_type",
+                    value: "BIQUAD"
+                },
+                {
+                    key: "dynamic_gyro_notch_enabled",
+                    value: "ON"
+                },
+                {
+                    key: "dynamic_gyro_notch_q",
+                    value: 250
+                },
+                {
+                    key: "dynamic_gyro_notch_min_hz",
+                    value: 30
+                },
+                {
+                    key: "motor_pwm_protocol",
+                    value: "STANDARD"
+                },
+		{ 
+		    key: "throttle_idle",
+		    value: 5.0
+		},
+                {
+                    key: "rc_yaw_expo",
+                    value: 30
+                },
+                {
+                    key: "rc_expo",
+                    value: 30
+                },
+                {
+                    key: "roll_rate",
+                    value: 18
+                },
+                {
+                    key: "pitch_rate",
+                    value: 9
+                },
+                {
+                    key: "yaw_rate",
+                    value: 3
+                },
+		{ 
+		    key: "nav_fw_pos_z_p",
+		    value: 20
 		},
 		{ 
-			key: "gyro_lpf_type"
-			value: "BIQUAD"
+		    key: "nav_fw_pos_z_d",
+		    value: 5
 		},
 		{ 
-			key: "dynamic_gyro_notch_enabled"
-			value: "ON"
+		    key: "nav_fw_pos_xy_p",
+		    value: 50
 		},
 		{ 
-			key: "dynamic_gyro_notch_q"
-			value: "250"
+		    key: "fw_turn_assist_pitch_gain",
+		    value: 0.5
 		},
 		{ 
-			key: "dynamic_gyro_notch_min_hz"
-			value: "30"
+		    key: "max_angle_inclination_rll",
+		    value: 350
 		},
 		{ 
-			key: "motor_pwm_protocol"
-			value: "STANDARD"
+                    key: "nav_fw_bank_angle",
+                    value: 35
 		},
 		{ 
-			key: "rc_yaw_expo"
-			value: "30"
+                    key: "fw_p_pitch",
+                    value: 15
 		},
 		{ 
-			key: "rc_expo"
-			value: "30"
+                    key: "fw_i_pitch",
+                    value: 10
 		},
 		{ 
-			key: "roll_rate"
-			value: "18"
+                    key: "fw_ff_pitch",
+                    value: 60
 		},
 		{ 
-			key: "pitch_rate"
-			value: "9"
+                    key: "fw_p_roll",
+                    value: 10
 		},
 		{ 
-			key: "yaw_rate"
-			value: "3"
+                    key: "fw_i_roll",
+                    value: 8
 		},
 		{ 
-			key: "nav_fw_pos_z_p"
-			value: "20"
+                    key: "fw_ff_roll",
+                    value: 40
 		},
 		{ 
-			key: "nav_fw_pos_z_d"
-			value: "5"
+                    key: "fw_p_yaw",
+                    value: 20
 		},
 		{ 
-			key: "nav_fw_pos_xy_p"
-			value: "50"
+                    key: "fw_i_yaw",
+                    value: 0
 		},
 		{ 
-			key: "small_angle"
-			value: "180"
+                    key: "fw_ff_yaw",
+                    value: 100
 		},
-		{ 
-			key: "nav_rth_allow_landing"
-			value: "FS_ONLY"
-		},
-		{ 
-			key: "nav_rth_altitude"
-			value: "5000"
-		},
-		{ 
-			key: "nav_wp_radius"
-			value: "1500"
-		},
-		{ 
-			key: "throttle_idle"
-			value: "5.000"
-		},
-		{ 
-			key: "applied_defaults"
-			value: "3"
-		},
-		{ 
-			key: "imu_acc_ignore_rate"
-			value: "10"
-		},
-		{ 
-			key: "airmode_type"
-			value: "STICK_CENTER_ONCE"
-		},
-		{ 
-			key: "airmode_type"
-			value: "STICK_CENTER_ONCE"
-		},
-		{ 
-			key: "nav_rth_climb_first"
-			value: "OFF"
-		},
-		{ 
-			key: "fw_turn_assist_pitch_gain"
-			value: "0.5"
-		},
-		{ 
-			key: "max_angle_inclination_rll"
-			value: "35"
-		},
-		{ 
-			key: "nav_fw_bank_angle"
-			value: "35"
-		},
-		{ 
-			key: "fw_p_pitch"
-			value: "15"
-		},
-		{ 
-			key: "fw_i_pitch"
-			value: "10"
-		},
-		{ 
-			key: "fw_ff_pitch"
-			value: "60"
-		},
-		{ 
-			key: "fw_p_roll"
-			value: "10"
-		},
-		{ 
-			key: "fw_i_roll"
-			value: "8"
-		},
-		{ 
-			key: "fw_ff_roll"
-			value: "40"
-		},
-		{ 
-			key: "roll_rate"
-			value: "18"
-		},
-		{ 
-			key: "pitch_rate
-			value: "9"
-		},
-		{ 
-			key: "fw_p_yaw"
-			value: "20"
-		},
-		{ 
-			key: "fw_i_yaw"
-			value: "0"
-		},
-		{ 
-			key: "fw_ff_yaw"
-			value: "100"
-		},
+				{
+                    key: "imu_acc_ignore_rate",
+                    value: 10
+                },
+				{
+                    key: "airmode_type",
+                    value: "STICK_CENTER_ONCE"
+                },
+                {
+                    key: "small_angle",
+                    value: 180
+                },
+                {
+                    key: "nav_fw_control_smoothness",
+                    value: 2
+                },
+                {
+                    key: "nav_rth_allow_landing",
+                    value: "FS_ONLY"
+                },
+                {
+                    key: "nav_rth_altitude",
+                    value: 5000
+                },
+                {
+                    key: "failsafe_mission",
+                    value: "OFF"
+                },
+                {
+                    key: "nav_wp_radius",
+                    value: 1500
+                },
             ],
             "features":[
                 {
@@ -358,179 +350,171 @@ helper.defaultsDialog = (function() {
             ]
         },
 		{
-            "title": 'Flying Wing, Delta, etc.',
+            "title": 'Airplane without a Tail (Wing, Delta, etc)',
             "notRecommended": false,
             "id": 3,
             "reboot": true,
             "settings": [
-                { 
-			key: "platform_type"
-			value: "AIRPLANE"
+		{
+                    key: "platform_type",
+                    value: "AIRPLANE"
+                },
+				{
+                    key: "applied_defaults",
+                    value: 3
+                },
+                {
+                    key: "gyro_hardware_lpf",
+                    value: "256HZ"
+                },
+                {
+                    key: "gyro_lpf_hz",
+                    value: 25
+                },
+                {
+                    key: "gyro_lpf_type",
+                    value: "BIQUAD"
+                },
+                {
+                    key: "dynamic_gyro_notch_enabled",
+                    value: "ON"
+                },
+                {
+                    key: "dynamic_gyro_notch_q",
+                    value: 250
+                },
+                {
+                    key: "dynamic_gyro_notch_min_hz",
+                    value: 30
+                },
+                {
+                    key: "motor_pwm_protocol",
+                    value: "STANDARD"
+                },
+		{ 
+                    key: "throttle_idle",
+                    value: 5.0
+		},
+                {
+                    key: "rc_yaw_expo",
+                    value: 30
+                },
+                {
+                    key: "rc_expo",
+                    value: 30
+                },
+                {
+                    key: "roll_rate",
+                    value: 18
+                },
+                {
+                    key: "pitch_rate",
+                    value: 9
+                },
+                {
+                    key: "yaw_rate",
+                    value: 3
+                },
+		{ 
+                    key: "nav_fw_pos_z_p",
+                    value: 20
+		},
+		{ 
+                    key: "nav_fw_pos_z_d",
+                    value: 5
+		},
+		{ 
+                    key: "nav_fw_pos_xy_p",
+                    value: 50
+		},
+		{ 
+                    key: "fw_turn_assist_pitch_gain",
+                    value: 0.2
+		},
+		{ 
+                    key: "max_angle_inclination_rll",
+                    value: 450
+		},
+		{ 
+                    key: "nav_fw_bank_angle",
+                    value: 45
+		},
+		{ 
+                    key: "fw_p_pitch",
+                    value: 10
+		},
+		{ 
+                    key: "fw_i_pitch",
+                    value: 15
+		},
+		{ 
+                    key: "fw_ff_pitch",
+                    value: 70
+		},
+		{ 
+                    key: "fw_p_roll",
+                    value: 5
+		},
+		{ 
+                    key: "fw_i_roll",
+                    value: 8
+		},
+		{ 
+                    key: "fw_ff_roll",
+                    value: 35
+		},
+		{ 
+                    key: "fw_p_yaw",
+                    value: 20
+		},
+		{ 
+                    key: "fw_i_yaw",
+                    value: 0
+		},
+		{ 
+                    key: "fw_ff_yaw",
+                    value: 100
 		},
 		{
-                    	key: "gyro_hardware_lpf",
-                    	value: "256HZ"
+                    key: "imu_acc_ignore_rate",
+                    value: 10
                 },
-                { 
-			key: "gyro_lpf_hz"
-			value: "25"
-		},
-		{ 
-			key: "gyro_lpf_type"
-			value: "BIQUAD"
-		},
-		{ 
-			key: "dynamic_gyro_notch_enabled"
-			value: "ON"
-		},
-		{ 
-			key: "dynamic_gyro_notch_q"
-			value: "250"
-		},
-		{ 
-			key: "dynamic_gyro_notch_min_hz"
-			value: "30"
-		},
-		{ 
-			key: "motor_pwm_protocol"
-			value: "STANDARD"
-		},
-		{ 
-			key: "rc_yaw_expo"
-			value: "30"
-		},
-		{ 
-			key: "rc_expo"
-			value: "30"
-		},
-		{ 
-			key: "roll_rate"
-			value: "18"
-		},
-		{ 
-			key: "pitch_rate"
-			value: "9"
-		},
-		{ 
-			key: "yaw_rate"
-			value: "3"
-		},
-		{ 
-			key: "nav_fw_pos_z_p"
-			value: "20"
-		},
-		{ 
-			key: "nav_fw_pos_z_d"
-			value: "5"
-		},
-		{ 
-			key: "nav_fw_pos_xy_p"
-			value: "50"
-		},
-		{ 
-			key: "small_angle"
-			value: "180"
-		},
-		{ 
-			key: "nav_rth_allow_landing"
-			value: "FS_ONLY"
-		},
-		{ 
-			key: "nav_rth_altitude"
-			value: "5000"
-		},
-		{ 
-			key: "nav_wp_radius"
-			value: "1500"
-		},
-		{ 
-			key: "throttle_idle"
-			value: "5.000"
-		},
-		{ 
-			key: "applied_defaults"
-			value: "3"
-		},
-		{ 
-			key: "imu_acc_ignore_rate"
-			value: "10"
-		},
-		{ 
-			key: "airmode_type"
-			value: "STICK_CENTER_ONCE"
-		},
-		{ 
-			key: "airmode_type"
-			value: "STICK_CENTER_ONCE"
-		},
-		{ 
-			key: "nav_rth_climb_first"
-			value: "OFF"
-		},
-		{ 
-			key: "fw_turn_assist_pitch_gain"
-			value: "0.2"
-		},
-		{ 
-			key: "max_angle_inclination_rll"
-			value: "45"
-		},
-		{ 
-			key: "nav_fw_bank_angle"
-			value: "45"
-		},
-		{ 
-			key: "fw_p_pitch"
-			value: "10"
-		},
-		{ 
-			key: "fw_i_pitch"
-			value: "15"
-		},
-		{ 
-			key: "fw_ff_pitch"
-			value: "70"
-		},
-		{ 
-			key: "fw_p_roll"
-			value: "5"
-		},
-		{ 
-			key: "fw_i_roll"
-			value: "8"
-		},
-		{ 
-			key: "fw_ff_roll"
-			value: "35"
-		},
-		{ 
-			key: "roll_rate"
-			value: "18"
-		},
-		{ 
-			key: "pitch_rate
-			value: "9"
-		},
-		{ 
-			key: "fw_p_yaw"
-			value: "20"
-		},
-		{ 
-			key: "fw_i_yaw"
-			value: "0"
-		},
-		{ 
-			key: "fw_ff_yaw"
-			value: "100"
-		},
-            ],
+		{
+                    key: "airmode_type",
+                    value: "STICK_CENTER_ONCE"
+                },
+                {
+                    key: "small_angle",
+                    value: 180
+                },
+                {
+                    key: "nav_fw_control_smoothness",
+                    value: 2
+                },
+                {
+                    key: "nav_rth_allow_landing",
+                    value: "FS_ONLY"
+                },
+                {
+                    key: "nav_rth_altitude",
+                    value: 5000
+                },
+                {
+                    key: "failsafe_mission",
+                    value: "OFF"
+                },
+                {
+                    key: "nav_wp_radius",
+                    value: 1500
+                },
+	   ],
             "features":[
                 {
                     bit: 4, // Enable MOTOR_STOP
                     state: true
                 }
             ]
-        },
+		},
         {
             "title": 'Rovers & Boats',
             "notRecommended": false,

--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -303,7 +303,7 @@ helper.defaultsDialog = (function() {
 		},
 		{ 
                     key: "fw_i_yaw",
-                    value: 0
+                    value: 5
 		},
 		{ 
                     key: "fw_ff_yaw",
@@ -469,7 +469,7 @@ helper.defaultsDialog = (function() {
 		},
 		{ 
                     key: "fw_i_yaw",
-                    value: 0
+                    value: 5
 		},
 		{ 
                     key: "fw_ff_yaw",

--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -184,99 +184,259 @@ helper.defaultsDialog = (function() {
             ]
         },
         {
-            "title": 'Airplane',
+            "title": 'Airplane with Tail',
             "notRecommended": false,
             "id": 3,
             "reboot": true,
             "settings": [
-                {
+                { 
+					key: "platform_type"
+					value: "AIRPLANE"
+				},
+				{
                     key: "gyro_hardware_lpf",
                     value: "256HZ"
                 },
+                { 
+					key: "gyro_lpf_hz"
+					value: "25"
+				},
+				{ 
+					key: "gyro_lpf_type"
+					value: "BIQUAD"
+				},
+				{ 
+					key: "dynamic_gyro_notch_enabled"
+					value: "ON"
+				},
+				{ 
+					key: "dynamic_gyro_notch_q"
+					value: "250"
+				},
+				{ 
+					key: "dynamic_gyro_notch_min_hz"
+					value: "30"
+				},
+				{ 
+					key: "motor_pwm_protocol"
+					value: "STANDARD"
+				},
+				{ 
+					key: "rc_yaw_expo"
+					value: "30"
+				},
+				{ 
+					key: "rc_expo"
+					value: "30"
+				},
+				{ 
+					key: "roll_rate"
+					value: "18"
+				},
+				{ 
+					key: "pitch_rate"
+					value: "9"
+				},
+				{ 
+					key: "yaw_rate"
+					value: "3"
+				},
+				{ 
+					key: "nav_fw_pos_z_p"
+					value: "20"
+				},
+				{ 
+					key: "nav_fw_pos_z_d"
+					value: "5"
+				},
+				{ 
+					key: "nav_fw_pos_xy_p"
+					value: "50"
+				},
+				{ 
+					key: "small_angle"
+					value: "180"
+				},
+				{ 
+					key: "nav_rth_allow_landing"
+					value: "FS_ONLY"
+				},
+				{ 
+					key: "nav_rth_altitude"
+					value: "5000"
+				},
+				{ 
+					key: "nav_wp_radius"
+					value: "1500"
+				},
+				{ 
+					key: "throttle_idle"
+					value: "5.000"
+				},
+				{ 
+					key: "applied_defaults"
+					value: "3"
+				},
+				{ 
+					key: "imu_acc_ignore_rate"
+					value: "10"
+				},
+				{ 
+					key: "airmode_type"
+					value: "STICK_CENTER_ONCE"
+				},
+				{ 
+					key: "airmode_type"
+					value: "STICK_CENTER_ONCE"
+				},
+				{ 
+					key: "nav_rth_climb_first"
+					value: "OFF"
+				},
+				{ 
+					key: "fw_turn_assist_pitch_gain"
+					value: "0.5"
+				},
+				{ 
+					key: "max_angle_inclination_rll"
+					value: "35"
+				},
+				{ 
+					key: "nav_fw_bank_angle"
+					value: "35"
+				},
+
+            ],
+            "features":[
                 {
-                    key: "gyro_lpf_hz",
-                    value: 25
-                },
-                {
-                    key: "gyro_lpf_type",
-                    value: "BIQUAD"
-                },
-                {
-                    key: "dynamic_gyro_notch_enabled",
-                    value: "ON"
-                },
-                {
-                    key: "dynamic_gyro_notch_q",
-                    value: 250
-                },
-                {
-                    key: "dynamic_gyro_notch_min_hz",
-                    value: 30
-                },
-                {
-                    key: "motor_pwm_protocol",
-                    value: "STANDARD"
-                },
-                {
-                    key: "rc_yaw_expo",
-                    value: 30
-                },
-                {
-                    key: "rc_expo",
-                    value: 30
-                },
-                {
-                    key: "roll_rate",
-                    value: 20
-                },
-                {
-                    key: "pitch_rate",
-                    value: 15
-                },
-                {
-                    key: "yaw_rate",
-                    value: 9
-                },
-                {
-                    key: "small_angle",
-                    value: 180
-                },
-                {
-                    key: "nav_fw_control_smoothness",
-                    value: 2
-                },
-                {
-                    key: "nav_rth_allow_landing",
-                    value: "FS_ONLY"
-                },
-                {
-                    key: "nav_rth_altitude",
-                    value: 5000
-                },
-                {
-                    key: "failsafe_mission",
-                    value: "OFF"
-                },
-                {
-                    key: "nav_wp_radius",
-                    value: 3000
-                },
-                {
-                    key: "platform_type",
-                    value: "AIRPLANE"
-                },
-                {
-                    key: "applied_defaults",
-                    value: 3
-                },
-                {
-                    key: "imu_acc_ignore_rate",
-                    value: 10
-                },
-                {
-                    key: "airmode_type",
-                    value: "STICK_CENTER_ONCE"
+                    bit: 4, // Enable MOTOR_STOP
+                    state: true
                 }
+            ]
+        },
+		 {
+            "title": 'Flying Wing with no Tail',
+            "notRecommended": false,
+            "id": 3,
+            "reboot": true,
+            "settings": [
+                { 
+					key: "platform_type"
+					value: "AIRPLANE"
+				},
+				{
+                    key: "gyro_hardware_lpf",
+                    value: "256HZ"
+                },
+                { 
+					key: "gyro_lpf_hz"
+					value: "25"
+				},
+				{ 
+					key: "gyro_lpf_type"
+					value: "BIQUAD"
+				},
+				{ 
+					key: "dynamic_gyro_notch_enabled"
+					value: "ON"
+				},
+				{ 
+					key: "dynamic_gyro_notch_q"
+					value: "250"
+				},
+				{ 
+					key: "dynamic_gyro_notch_min_hz"
+					value: "30"
+				},
+				{ 
+					key: "motor_pwm_protocol"
+					value: "STANDARD"
+				},
+				{ 
+					key: "rc_yaw_expo"
+					value: "30"
+				},
+				{ 
+					key: "rc_expo"
+					value: "30"
+				},
+				{ 
+					key: "roll_rate"
+					value: "18"
+				},
+				{ 
+					key: "pitch_rate"
+					value: "9"
+				},
+				{ 
+					key: "yaw_rate"
+					value: "3"
+				},
+				{ 
+					key: "nav_fw_pos_z_p"
+					value: "20"
+				},
+				{ 
+					key: "nav_fw_pos_z_d"
+					value: "5"
+				},
+				{ 
+					key: "nav_fw_pos_xy_p"
+					value: "50"
+				},
+				{ 
+					key: "small_angle"
+					value: "180"
+				},
+				{ 
+					key: "nav_rth_allow_landing"
+					value: "FS_ONLY"
+				},
+				{ 
+					key: "nav_rth_altitude"
+					value: "5000"
+				},
+				{ 
+					key: "nav_wp_radius"
+					value: "1500"
+				},
+				{ 
+					key: "throttle_idle"
+					value: "5.000"
+				},
+				{ 
+					key: "applied_defaults"
+					value: "3"
+				},
+				{ 
+					key: "imu_acc_ignore_rate"
+					value: "10"
+				},
+				{ 
+					key: "airmode_type"
+					value: "STICK_CENTER_ONCE"
+				},
+				{ 
+					key: "airmode_type"
+					value: "STICK_CENTER_ONCE"
+				},
+				{ 
+					key: "nav_rth_climb_first"
+					value: "OFF"
+				},
+				{ 
+					key: "fw_turn_assist_pitch_gain"
+					value: "0.2"
+				},
+				{ 
+					key: "max_angle_inclination_rll"
+					value: "45"
+				},
+				{ 
+					key: "nav_fw_bank_angle"
+					value: "45"
+				},
+
             ],
             "features":[
                 {

--- a/js/preset_definitions.js
+++ b/js/preset_definitions.js
@@ -1159,11 +1159,12 @@ presets.presets = [
     },
     {
         name: "Generic Airplane",
-        description: "General setup for airplanes.",
+        description: "General setup for airplanes with Tails and Elevator.",
         features: [
             "Adjusted gyro filtering",
-            "Adjusted PIDs",
-            "Adjusted rates"
+            "Adjusted PIFFs",
+            "Adjusted rates",
+			"Navigation PIDs"
         ],
         applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
         settingsMSP: [
@@ -1174,472 +1175,341 @@ presets.presets = [
         ],
         settings: [
             {
-                key: "gyro_hardware_lpf",
-                value: "256HZ"
+               key: "gyro_hardware_lpf",
+               value: "256HZ"
             },
-            {
-                key: "gyro_lpf_hz",
-                value: 25
-            },
-            {
-                key: "dynamic_gyro_notch_enabled",
-                value: "ON"
-            },
-            {
-                key: "dynamic_gyro_notch_q",
-                value: 250
-            },
-            {
-                key: "dynamic_gyro_notch_min_hz",
-                value: 30
-            },
-            {
-                key: "gyro_lpf_type",
-                value: "BIQUAD"
-            },
-            {
-                key: "platform_type",
-                value: "AIRPLANE"
-            },
-            {
-                key: "rc_expo",
-                value: 30
-            },
-            {
-                key: "manual_rc_expo",
-                value: 30
-            },
-            {
-                key: "imu_acc_ignore_rate",
-                value: 10
-            }
+			{ 
+				key: "gyro_lpf_hz"
+				value: "25"
+			},
+			{ 
+				key: "gyro_lpf_type"
+				value: "BIQUAD"
+			},
+			{ 
+				key: "dynamic_gyro_notch_enabled"
+				value: "ON"
+			},
+			{ 
+				key: "dynamic_gyro_notch_q"
+				value: "250"
+			},
+			{ 
+				key: "dynamic_gyro_notch_min_hz"
+				value: "30"
+			},
+			{ 
+				key: "motor_pwm_protocol"
+				value: "STANDARD"
+			},
+			{ 
+				key: "rc_yaw_expo"
+				value: "30"
+			},
+			{ 
+				key: "rc_expo"
+				value: "30"
+			},
+			{ 
+				key: "roll_rate"
+				value: "18"
+			},
+			{ 
+				key: "pitch_rate"
+				value: "9"
+			},
+			{ 
+				key: "yaw_rate"
+				value: "3"
+			},
+			{ 
+				key: "nav_fw_pos_z_p"
+				value: "20"
+			},
+			{ 
+				key: "nav_fw_pos_z_d"
+				value: "5"
+			},
+			{ 
+				key: "nav_fw_pos_xy_p"
+				value: "50"
+			},
+			{ 
+				key: "small_angle"
+				value: "180"
+			},
+			{ 
+				key: "nav_rth_allow_landing"
+				value: "FS_ONLY"
+			},
+			{ 
+				key: "nav_rth_altitude"
+				value: "5000"
+			},
+			{ 
+				key: "nav_wp_radius"
+				value: "1500"
+			},
+			{ 
+				key: "throttle_idle"
+				value: "5.000"
+			},
+			{ 
+				key: "applied_defaults"
+				value: "3"
+			},
+			{ 
+				key: "imu_acc_ignore_rate"
+				value: "10"
+			},
+			{ 
+				key: "airmode_type"
+				value: "STICK_CENTER_ONCE"
+			},
+			{ 
+				key: "airmode_type"
+				value: "STICK_CENTER_ONCE"
+			},
+			{ 
+				key: "nav_rth_climb_first"
+				value: "OFF"
+			},
+			{ 
+				key: "fw_turn_assist_pitch_gain"
+				value: "0.5"
+			},
+			{ 
+				key: "max_angle_inclination_rll"
+				value: "35"
+			},
+			{ 
+				key: "nav_fw_bank_angle"
+				value: "35"
+			},
+			{ 
+				key: "fw_p_pitch"
+				value: "15"
+			},
+			{ 
+				key: "fw_i_pitch"
+				value: "10"
+			},
+			{ 
+				key: "fw_ff_pitch"
+				value: "60"
+			},
+			{ 
+				key: "fw_p_roll"
+				value: "10"
+			},
+			{ 
+				key: "fw_i_roll"
+				value: "8"
+			},
+			{ 
+				key: "fw_ff_roll"
+				value: "40"
+			},
+			{ 
+				key: "roll_rate"
+				value: "18"
+			},
+			{ 
+				key: "pitch_rate
+				value: "9"
+			},
+			{ 
+				key: "fw_p_yaw"
+				value: "20"
+			},
+			{ 
+				key: "fw_i_yaw"
+				value: "0"
+			},
+			{ 
+				key: "fw_ff_yaw"
+				value: "100"
+			},
+            ],
         ],
         type: 'airplane'
     },
-    {
-        name: "Flying Wing Z84",
-        description: "Small flying wing on multirotor racer parts. 3S/4S battery, AUW under 500g.",
+	{
+        name: "Flying Wing, Delta, etc.",
+        description: "General setup for airplanes with Tails and Elevator.",
         features: [
             "Adjusted gyro filtering",
-            "Adjusted PIDs",
-            "Adjusted rates"
+            "Adjusted PIFFs",
+            "Adjusted rates",
+			"Navigation PIDs"
         ],
         applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
         settingsMSP: [
-            presets.elementHelper("RC_tuning", "roll_rate", 350),
-            presets.elementHelper("RC_tuning", "pitch_rate", 90),
-            presets.elementHelper("RC_tuning", "dynamic_THR_PID", 33),
-            presets.elementHelper("RC_tuning", "dynamic_THR_breakpoint", 1300),
-            presets.elementHelper("INAV_PID_CONFIG", "gyroscopeLpf", 4)
+            presets.elementHelper("RC_tuning", "roll_rate", 200),
+            presets.elementHelper("RC_tuning", "pitch_rate", 150),
+            presets.elementHelper("RC_tuning", "yaw_rate", 90),
+            presets.elementHelper("INAV_PID_CONFIG", "gyroscopeLpf", 1)
         ],
         settings: [
             {
-                key: "gyro_hardware_lpf",
-                value: "256HZ"
+               key: "gyro_hardware_lpf",
+               value: "256HZ"
             },
-            {
-                key: "gyro_lpf_hz",
-                value: 25
-            },
-            {
-                key: "dynamic_gyro_notch_enabled",
-                value: "ON"
-            },
-            {
-                key: "dynamic_gyro_notch_q",
-                value: 250
-            },
-            {
-                key: "dynamic_gyro_notch_min_hz",
-                value: 30
-            },
-            {
-                key: "gyro_lpf_type",
-                value: "BIQUAD"
-            },
-            {
-                key: "platform_type",
-                value: "AIRPLANE"
-            },
-            {
-                key: "fw_p_pitch",
-                value: 2
-            },
-            {
-                key: "fw_i_pitch",
-                value: 15
-            },
-            {
-                key: "fw_ff_pitch",
-                value: 70
-            },
-            {
-                key: "fw_p_roll",
-                value: 2
-            },
-            {
-                key: "fw_i_roll",
-                value: 15
-            },
-            {
-                key: "fw_ff_roll",
-                value: 30
-            },
-            {
-                key: "rc_expo",
-                value: 30
-            },
-            {
-                key: "manual_rc_expo",
-                value: 30
-            },
-            {
-                key: "imu_acc_ignore_rate",
-                value: 10
-            }
+			{ 
+				key: "gyro_lpf_hz"
+				value: "25"
+			},
+			{ 
+				key: "gyro_lpf_type"
+				value: "BIQUAD"
+			},
+			{ 
+				key: "dynamic_gyro_notch_enabled"
+				value: "ON"
+			},
+			{ 
+				key: "dynamic_gyro_notch_q"
+				value: "250"
+			},
+			{ 
+				key: "dynamic_gyro_notch_min_hz"
+				value: "30"
+			},
+			{ 
+				key: "motor_pwm_protocol"
+				value: "STANDARD"
+			},
+			{ 
+				key: "rc_yaw_expo"
+				value: "30"
+			},
+			{ 
+				key: "rc_expo"
+				value: "30"
+			},
+			{ 
+				key: "roll_rate"
+				value: "18"
+			},
+			{ 
+				key: "pitch_rate"
+				value: "9"
+			},
+			{ 
+				key: "yaw_rate"
+				value: "3"
+			},
+			{ 
+				key: "nav_fw_pos_z_p"
+				value: "20"
+			},
+			{ 
+				key: "nav_fw_pos_z_d"
+				value: "5"
+			},
+			{ 
+				key: "nav_fw_pos_xy_p"
+				value: "50"
+			},
+			{ 
+				key: "small_angle"
+				value: "180"
+			},
+			{ 
+				key: "nav_rth_allow_landing"
+				value: "FS_ONLY"
+			},
+			{ 
+				key: "nav_rth_altitude"
+				value: "5000"
+			},
+			{ 
+				key: "nav_wp_radius"
+				value: "1500"
+			},
+			{ 
+				key: "throttle_idle"
+				value: "5.000"
+			},
+			{ 
+				key: "applied_defaults"
+				value: "3"
+			},
+			{ 
+				key: "imu_acc_ignore_rate"
+				value: "10"
+			},
+			{ 
+				key: "airmode_type"
+				value: "STICK_CENTER_ONCE"
+			},
+			{ 
+				key: "airmode_type"
+				value: "STICK_CENTER_ONCE"
+			},
+			{ 
+				key: "nav_rth_climb_first"
+				value: "OFF"
+			},
+			{ 
+				key: "fw_turn_assist_pitch_gain"
+				value: "0.2"
+			},
+			{ 
+				key: "max_angle_inclination_rll"
+				value: "45"
+			},
+			{ 
+				key: "nav_fw_bank_angle"
+				value: "45"
+			},
+			{ 
+				key: "fw_p_pitch"
+				value: "10"
+			},
+			{ 
+				key: "fw_i_pitch"
+				value: "15"
+			},
+			{ 
+				key: "fw_ff_pitch"
+				value: "70"
+			},
+			{ 
+				key: "fw_p_roll"
+				value: "5"
+			},
+			{ 
+				key: "fw_i_roll"
+				value: "8"
+			},
+			{ 
+				key: "fw_ff_roll"
+				value: "35"
+			},
+			{ 
+				key: "roll_rate"
+				value: "18"
+			},
+			{ 
+				key: "pitch_rate
+				value: "9"
+			},
+			{ 
+				key: "fw_p_yaw"
+				value: "20"
+			},
+			{ 
+				key: "fw_i_yaw"
+				value: "0"
+			},
+			{ 
+				key: "fw_ff_yaw"
+				value: "100"
+			},
+            ],
         ],
-        type: 'flyingwing'
+        type: 'airplane'
     },
-    {
-        name: "Flying Wing S800 Sky Shadow",
-        description: "Flying wing on multirotor racer parts. 3S/4S battery and FPV equipment. AUW under 1000g.",
-        features: [
-            "Adjusted gyro filtering",
-            "Adjusted PIDs",
-            "Adjusted rates"
-        ],
-        applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
-        settingsMSP: [
-            presets.elementHelper("INAV_PID_CONFIG", "gyroscopeLpf", 0),
-            presets.elementHelper("FILTER_CONFIG", "gyroSoftLpfHz", 40),
-            presets.elementHelper("RC_tuning", "roll_rate", 280),
-            presets.elementHelper("RC_tuning", "pitch_rate", 140),
-            presets.elementHelper("RC_tuning", "dynamic_THR_PID", 20),
-            presets.elementHelper("RC_tuning", "dynamic_THR_breakpoint", 1600)
-        ],
-        settings: [
-            {
-                key: "gyro_hardware_lpf",
-                value: "256HZ"
-            },
-            {
-                key: "gyro_lpf_hz",
-                value: 25
-            },
-            {
-                key: "dynamic_gyro_notch_enabled",
-                value: "ON"
-            },
-            {
-                key: "dynamic_gyro_notch_q",
-                value: 250
-            },
-            {
-                key: "dynamic_gyro_notch_min_hz",
-                value: 30
-            },
-            {
-                key: "gyro_lpf_type",
-                value: "BIQUAD"
-            },
-            {
-                key: "platform_type",
-                value: "AIRPLANE"
-            },
-            {
-                key: "fw_p_pitch",
-                value: 6
-            },
-            {
-                key: "fw_i_pitch",
-                value: 9
-            },
-            {
-                key: "fw_ff_pitch",
-                value: 52
-            },
-            {
-                key: "fw_p_roll",
-                value: 6
-            },
-            {
-                key: "fw_i_roll",
-                value: 6
-            },
-            {
-                key: "fw_ff_roll",
-                value: 49
-            },
-            {
-                key: "rc_expo",
-                value: 30
-            },
-            {
-                key: "manual_rc_expo",
-                value: 30
-            },
-            {
-                key: "imu_acc_ignore_rate",
-                value: 10
-            }
-        ],
-        type: 'flyingwing'
-    },
-    {
-        name: "Ritewing Mini Drak",
-        description: "8x6 propeller, 2216 1400kV motor, 4S LiPo. AUW above 1200g.",
-        features: [
-            "Adjusted gyro filtering",
-            "Adjusted PIDs",
-            "Adjusted rates"
-        ],
-        applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
-        settingsMSP: [
-            presets.elementHelper("INAV_PID_CONFIG", "gyroscopeLpf", 0),
-            presets.elementHelper("FILTER_CONFIG", "gyroSoftLpfHz", 35),
-            presets.elementHelper("RC_tuning", "roll_rate", 260),
-            presets.elementHelper("RC_tuning", "pitch_rate", 140),
-            presets.elementHelper("RC_tuning", "dynamic_THR_PID", 30),
-            presets.elementHelper("RC_tuning", "dynamic_THR_breakpoint", 1550)
-        ],
-        settings: [
-            {
-                key: "gyro_hardware_lpf",
-                value: "256HZ"
-            },
-            {
-                key: "gyro_lpf_hz",
-                value: 25
-            },
-            {
-                key: "dynamic_gyro_notch_enabled",
-                value: "ON"
-            },
-            {
-                key: "dynamic_gyro_notch_q",
-                value: 250
-            },
-            {
-                key: "dynamic_gyro_notch_min_hz",
-                value: 30
-            },
-            {
-                key: "gyro_lpf_type",
-                value: "BIQUAD"
-            },
-            {
-                key: "platform_type",
-                value: "AIRPLANE"
-            },
-            {
-                key: "fw_p_pitch",
-                value: 5
-            },
-            {
-                key: "fw_i_pitch",
-                value: 14
-            },
-            {
-                key: "fw_ff_pitch",
-                value: 56
-            },
-            {
-                key: "fw_p_roll",
-                value: 7
-            },
-            {
-                key: "fw_i_roll",
-                value: 12
-            },
-            {
-                key: "fw_ff_roll",
-                value: 25
-            },
-            {
-                key: "rc_expo",
-                value: 30
-            },
-            {
-                key: "manual_rc_expo",
-                value: 30
-            },
-            {
-                key: "imu_acc_ignore_rate",
-                value: 10
-            }
-        ],
-        type: 'flyingwing'
-    },
-    {
-        name: "ZOHD Dart 250g",
-        description: "3x5x3 propeller, 1406 2600kV motor, 3S LiPo. 570mm wingspan, AUW potentially under 250g on 2S.<br /><br /><strong>Please set the Stabilised Roll weight to 80, and the Stabilised Pitch weight to 65.</strong>",
-        features: [
-            "Adjusted gyro filtering",
-            "Adjusted PIDs",
-            "Adjusted rates"
-        ],
-        applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
-        settingsMSP: [
-            presets.elementHelper("INAV_PID_CONFIG", "gyroscopeLpf", 3),
-            presets.elementHelper("FILTER_CONFIG", "gyroSoftLpfHz", 30),
-            presets.elementHelper("RC_tuning", "roll_rate", 360),
-            presets.elementHelper("RC_tuning", "pitch_rate", 130),
-            presets.elementHelper("RC_tuning", "dynamic_THR_PID", 30),
-            presets.elementHelper("RC_tuning", "dynamic_THR_breakpoint", 1500)
-        ],
-        settings: [
-            {
-                key: "gyro_hardware_lpf",
-                value: "256HZ"
-            },
-            {
-                key: "gyro_lpf_hz",
-                value: 25
-            },
-            {
-                key: "dynamic_gyro_notch_enabled",
-                value: "ON"
-            },
-            {
-                key: "dynamic_gyro_notch_q",
-                value: 250
-            },
-            {
-                key: "dynamic_gyro_notch_min_hz",
-                value: 30
-            },
-            {
-                key: "gyro_lpf_type",
-                value: "BIQUAD"
-            },
-            {
-                key: "platform_type",
-                value: "AIRPLANE"
-            },
-            {
-                key: "fw_p_pitch",
-                value: 3
-            },
-            {
-                key: "fw_i_pitch",
-                value: 7
-            },
-            {
-                key: "fw_ff_pitch",
-                value: 40
-            },
-            {
-                key: "fw_p_roll",
-                value: 2
-            },
-            {
-                key: "fw_i_roll",
-                value: 4
-            },
-            {
-                key: "fw_ff_roll",
-                value: 18
-            },
-            {
-                key: "rc_expo",
-                value: 70
-            },
-            {
-                key: "manual_rc_expo",
-                value: 70
-            },
-            {
-                key: "rc_yaw_expo",
-                value: 20
-            },
-            {
-                key: "imu_acc_ignore_rate",
-                value: 10
-            }
-        ],
-        type: 'flyingwing'
-    },
-    {
-        name: "SonicModell Mini AR Wing",
-        description: "5x4.5 propeller, 1805 2400kV motor, 3S LiPo. 600mm wingspan, AUW under 400g.",
-        features: [
-            "Adjusted gyro filtering",
-            "Adjusted PIDs",
-            "Adjusted rates"
-        ],
-        applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
-        settingsMSP: [
-            presets.elementHelper("INAV_PID_CONFIG", "gyroscopeLpf", 0),
-            presets.elementHelper("FILTER_CONFIG", "gyroSoftLpfHz", 35),
-            presets.elementHelper("RC_tuning", "roll_rate", 280),
-            presets.elementHelper("RC_tuning", "pitch_rate", 120)
-        ],
-        settings: [
-            {
-                key: "gyro_hardware_lpf",
-                value: "256HZ"
-            },
-            {
-                key: "gyro_lpf_hz",
-                value: 25
-            },
-            {
-                key: "dynamic_gyro_notch_enabled",
-                value: "ON"
-            },
-            {
-                key: "dynamic_gyro_notch_q",
-                value: 250
-            },
-            {
-                key: "dynamic_gyro_notch_min_hz",
-                value: 30
-            },
-            {
-                key: "gyro_lpf_type",
-                value: "BIQUAD"
-            },
-            {
-                key: "platform_type",
-                value: "AIRPLANE"
-            },
-            {
-                key: "fw_p_pitch",
-                value: 5
-            },
-            {
-                key: "fw_i_pitch",
-                value: 18
-            },
-            {
-                key: "fw_ff_pitch",
-                value: 60
-            },
-            {
-                key: "fw_p_roll",
-                value: 8
-            },
-            {
-                key: "fw_i_roll",
-                value: 16
-            },
-            {
-                key: "fw_ff_roll",
-                value: 64
-            },
-            {
-                key: "rc_expo",
-                value: 30
-            },
-            {
-                key: "manual_rc_expo",
-                value: 30
-            },
-            {
-                key: "imu_acc_ignore_rate",
-                value: 10
-            }
-        ],
-        type: 'flyingwing'
-    }
+    
 ];

--- a/js/preset_definitions.js
+++ b/js/preset_definitions.js
@@ -1279,7 +1279,7 @@ presets.presets = [
 	},
 	{ 
                 key: "fw_i_yaw",
-                value: 0
+                value: 5
 	},
 	{ 
                 key: "fw_ff_yaw",
@@ -1441,7 +1441,7 @@ presets.presets = [
 	},
 	{ 
                 key: "fw_i_yaw",
-                value: 0
+                value: 5
 	},
 	{ 
                 key: "fw_ff_yaw",

--- a/js/preset_definitions.js
+++ b/js/preset_definitions.js
@@ -1182,6 +1182,10 @@ presets.presets = [
                 value: 25
 	},
 	{
+                  key: "dterm_lpf_hz",
+                  value: 10
+        },
+	{
                 key: "gyro_lpf_type",
                 value: "BIQUAD"
 	},
@@ -1341,8 +1345,12 @@ presets.presets = [
 	},
 	{
                  key: "gyro_lpf_hz",
-                value: 25
+                 value: 25
 	},
+	{
+                  key: "dterm_lpf_hz",
+                  value: 10
+        },
 	{
                 key: "gyro_lpf_type",
                 value: "BIQUAD"

--- a/js/preset_definitions.js
+++ b/js/preset_definitions.js
@@ -1157,359 +1157,328 @@ presets.presets = [
         ],
         type: 'multirotor'
     },
-    {
-        name: "Generic Airplane",
-        description: "General setup for airplanes with Tails and Elevator.",
-        features: [
-            "Adjusted gyro filtering",
-            "Adjusted PIFFs",
-            "Adjusted rates",
-			"Navigation PIDs"
-        ],
-        applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
-        settingsMSP: [
-            presets.elementHelper("RC_tuning", "roll_rate", 200),
-            presets.elementHelper("RC_tuning", "pitch_rate", 150),
-            presets.elementHelper("RC_tuning", "yaw_rate", 90),
-            presets.elementHelper("INAV_PID_CONFIG", "gyroscopeLpf", 1)
-        ],
-        settings: [
-            {
-               key: "gyro_hardware_lpf",
-               value: "256HZ"
-            },
-			{ 
-				key: "gyro_lpf_hz"
-				value: "25"
-			},
-			{ 
-				key: "gyro_lpf_type"
-				value: "BIQUAD"
-			},
-			{ 
-				key: "dynamic_gyro_notch_enabled"
-				value: "ON"
-			},
-			{ 
-				key: "dynamic_gyro_notch_q"
-				value: "250"
-			},
-			{ 
-				key: "dynamic_gyro_notch_min_hz"
-				value: "30"
-			},
-			{ 
-				key: "motor_pwm_protocol"
-				value: "STANDARD"
-			},
-			{ 
-				key: "rc_yaw_expo"
-				value: "30"
-			},
-			{ 
-				key: "rc_expo"
-				value: "30"
-			},
-			{ 
-				key: "roll_rate"
-				value: "18"
-			},
-			{ 
-				key: "pitch_rate"
-				value: "9"
-			},
-			{ 
-				key: "yaw_rate"
-				value: "3"
-			},
-			{ 
-				key: "nav_fw_pos_z_p"
-				value: "20"
-			},
-			{ 
-				key: "nav_fw_pos_z_d"
-				value: "5"
-			},
-			{ 
-				key: "nav_fw_pos_xy_p"
-				value: "50"
-			},
-			{ 
-				key: "small_angle"
-				value: "180"
-			},
-			{ 
-				key: "nav_rth_allow_landing"
-				value: "FS_ONLY"
-			},
-			{ 
-				key: "nav_rth_altitude"
-				value: "5000"
-			},
-			{ 
-				key: "nav_wp_radius"
-				value: "1500"
-			},
-			{ 
-				key: "throttle_idle"
-				value: "5.000"
-			},
-			{ 
-				key: "applied_defaults"
-				value: "3"
-			},
-			{ 
-				key: "imu_acc_ignore_rate"
-				value: "10"
-			},
-			{ 
-				key: "airmode_type"
-				value: "STICK_CENTER_ONCE"
-			},
-			{ 
-				key: "airmode_type"
-				value: "STICK_CENTER_ONCE"
-			},
-			{ 
-				key: "nav_rth_climb_first"
-				value: "OFF"
-			},
-			{ 
-				key: "fw_turn_assist_pitch_gain"
-				value: "0.5"
-			},
-			{ 
-				key: "max_angle_inclination_rll"
-				value: "35"
-			},
-			{ 
-				key: "nav_fw_bank_angle"
-				value: "35"
-			},
-			{ 
-				key: "fw_p_pitch"
-				value: "15"
-			},
-			{ 
-				key: "fw_i_pitch"
-				value: "10"
-			},
-			{ 
-				key: "fw_ff_pitch"
-				value: "60"
-			},
-			{ 
-				key: "fw_p_roll"
-				value: "10"
-			},
-			{ 
-				key: "fw_i_roll"
-				value: "8"
-			},
-			{ 
-				key: "fw_ff_roll"
-				value: "40"
-			},
-			{ 
-				key: "roll_rate"
-				value: "18"
-			},
-			{ 
-				key: "pitch_rate
-				value: "9"
-			},
-			{ 
-				key: "fw_p_yaw"
-				value: "20"
-			},
-			{ 
-				key: "fw_i_yaw"
-				value: "0"
-			},
-			{ 
-				key: "fw_ff_yaw"
-				value: "100"
-			},
-            ],
-        ],
-        type: 'airplane'
-    },
 	{
-        name: "Flying Wing, Delta, etc.",
-        description: "General setup for airplanes with Tails and Elevator.",
-        features: [
-            "Adjusted gyro filtering",
-            "Adjusted PIFFs",
-            "Adjusted rates",
-			"Navigation PIDs"
-        ],
+		name: 'Airplane with a tail',
+        description: "General setup for airplanes with tails.",
+        features: ["Adjusted gyro filtering", "Adjusted PIDs", "Adjusted rates"],
         applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
-        settingsMSP: [
-            presets.elementHelper("RC_tuning", "roll_rate", 200),
-            presets.elementHelper("RC_tuning", "pitch_rate", 150),
-            presets.elementHelper("RC_tuning", "yaw_rate", 90),
-            presets.elementHelper("INAV_PID_CONFIG", "gyroscopeLpf", 1)
-        ],
+        settingsMSP: [],
+		type: 'airplane',
         settings: [
-            {
-               key: "gyro_hardware_lpf",
-               value: "256HZ"
-            },
-			{ 
-				key: "gyro_lpf_hz"
-				value: "25"
-			},
-			{ 
-				key: "gyro_lpf_type"
-				value: "BIQUAD"
-			},
-			{ 
-				key: "dynamic_gyro_notch_enabled"
-				value: "ON"
-			},
-			{ 
-				key: "dynamic_gyro_notch_q"
-				value: "250"
-			},
-			{ 
-				key: "dynamic_gyro_notch_min_hz"
-				value: "30"
-			},
-			{ 
-				key: "motor_pwm_protocol"
-				value: "STANDARD"
-			},
-			{ 
-				key: "rc_yaw_expo"
-				value: "30"
-			},
-			{ 
-				key: "rc_expo"
-				value: "30"
-			},
-			{ 
-				key: "roll_rate"
-				value: "18"
-			},
-			{ 
-				key: "pitch_rate"
-				value: "9"
-			},
-			{ 
-				key: "yaw_rate"
-				value: "3"
-			},
-			{ 
-				key: "nav_fw_pos_z_p"
-				value: "20"
-			},
-			{ 
-				key: "nav_fw_pos_z_d"
-				value: "5"
-			},
-			{ 
-				key: "nav_fw_pos_xy_p"
-				value: "50"
-			},
-			{ 
-				key: "small_angle"
-				value: "180"
-			},
-			{ 
-				key: "nav_rth_allow_landing"
-				value: "FS_ONLY"
-			},
-			{ 
-				key: "nav_rth_altitude"
-				value: "5000"
-			},
-			{ 
-				key: "nav_wp_radius"
-				value: "1500"
-			},
-			{ 
-				key: "throttle_idle"
-				value: "5.000"
-			},
-			{ 
-				key: "applied_defaults"
-				value: "3"
-			},
-			{ 
-				key: "imu_acc_ignore_rate"
-				value: "10"
-			},
-			{ 
-				key: "airmode_type"
-				value: "STICK_CENTER_ONCE"
-			},
-			{ 
-				key: "airmode_type"
-				value: "STICK_CENTER_ONCE"
-			},
-			{ 
-				key: "nav_rth_climb_first"
-				value: "OFF"
-			},
-			{ 
-				key: "fw_turn_assist_pitch_gain"
-				value: "0.2"
-			},
-			{ 
-				key: "max_angle_inclination_rll"
-				value: "45"
-			},
-			{ 
-				key: "nav_fw_bank_angle"
-				value: "45"
-			},
-			{ 
-				key: "fw_p_pitch"
-				value: "10"
-			},
-			{ 
-				key: "fw_i_pitch"
-				value: "15"
-			},
-			{ 
-				key: "fw_ff_pitch"
-				value: "70"
-			},
-			{ 
-				key: "fw_p_roll"
-				value: "5"
-			},
-			{ 
-				key: "fw_i_roll"
-				value: "8"
-			},
-			{ 
-				key: "fw_ff_roll"
-				value: "35"
-			},
-			{ 
-				key: "roll_rate"
-				value: "18"
-			},
-			{ 
-				key: "pitch_rate
-				value: "9"
-			},
-			{ 
-				key: "fw_p_yaw"
-				value: "20"
-			},
-			{ 
-				key: "fw_i_yaw"
-				value: "0"
-			},
-			{ 
-				key: "fw_ff_yaw"
-				value: "100"
-			},
-            ],
-        ],
-        type: 'airplane'
+	{
+                key: "platform_type",
+                value: "AIRPLANE"
+	},
+	{
+                key: "applied_defaults",
+                value: 3
+	},
+	{
+                key: "gyro_hardware_lpf",
+                value: "256HZ"
+	},
+	{
+                key: "gyro_lpf_hz",
+                value: 25
+	},
+	{
+                key: "gyro_lpf_type",
+                value: "BIQUAD"
+	},
+	{
+                key: "dynamic_gyro_notch_enabled",
+                value: "ON"
+	},
+	{
+                key: "dynamic_gyro_notch_q",
+                value: 250
+	},
+	{
+                key: "dynamic_gyro_notch_min_hz",
+                value: 30
+	},
+	{
+                key: "motor_pwm_protocol",
+                value: "STANDARD"
+	},
+	{ 
+                key: "throttle_idle",
+                value: 5.0
+	},
+	{
+                key: "rc_yaw_expo",
+                value: 30
+	},
+	{
+                key: "rc_expo",
+                value: 30
+	},
+	{
+                key: "roll_rate",
+                value: 18
+	},
+	{
+                key: "pitch_rate",
+                value: 9
+	},
+	{
+                key: "yaw_rate",
+                value: 3
+	},
+	{ 
+                key: "nav_fw_pos_z_p",
+				value: 20
+	},
+	{ 
+                key: "nav_fw_pos_z_d",
+                value: 5
+	},
+	{ 
+                key: "nav_fw_pos_xy_p",
+                value: 50
+	},
+	{ 
+                key: "fw_turn_assist_pitch_gain",
+                value: 0.5
+	},
+	{ 
+                key: "max_angle_inclination_rll",
+                value: 350
+	},
+	{ 
+                key: "nav_fw_bank_angle",
+                value: 35
+	},
+	{ 
+                key: "fw_p_pitch",
+                value: 15
+	},
+	{ 
+                key: "fw_i_pitch",
+                value: 10
+	},
+	{ 
+                key: "fw_ff_pitch",
+                value: 60
+	},
+	{ 
+                key: "fw_p_roll",
+                value: 10
+	},
+	{ 
+                key: "fw_i_roll",
+                value: 8
+	},
+	{ 
+                key: "fw_ff_roll",
+                value: 40
+	},
+	{ 
+                key: "fw_p_yaw",
+                value: 20
+	},
+	{ 
+                key: "fw_i_yaw",
+                value: 0
+	},
+	{ 
+                key: "fw_ff_yaw",
+                value: 100
+	},
+	{
+                key: "imu_acc_ignore_rate",
+                value: 10
+	},
+	{
+                key: "airmode_type",
+                value: "STICK_CENTER_ONCE"
+	},
+	{
+                key: "small_angle",
+                value: 180
+	},
+	{
+                key: "nav_fw_control_smoothness",
+                value: 2
+	},
+	{
+                key: "nav_rth_allow_landing",
+                value: "FS_ONLY"
+	},
+	{
+                key: "nav_rth_altitude",
+                value: 5000
+	},
+	{
+                key: "failsafe_mission",
+		value: "ON"
+	},
+	{
+                key: "nav_wp_radius",
+                value: 1500
+	},
+		],
     },
-    
+    {
+        name: "Airplane without tail",
+        description: "General setup for airplanes without tails: Flying Wing, Delta, etc.",
+		features: ["Adjusted gyro filtering", "Adjusted PIDs", "Adjusted rates"],
+        applyDefaults: ["INAV_PID_CONFIG", "RC_tuning", "PID_ADVANCED", "FILTER_CONFIG"],
+        settingsMSP: [],
+		type: 'flyingwing',
+        settings: [
+	{
+                key: "platform_type",
+                value: "AIRPLANE"
+	},
+	{
+                key: "applied_defaults",
+                value: 3
+	},
+	{
+                key: "gyro_hardware_lpf",
+                value: "256HZ"
+	},
+	{
+                 key: "gyro_lpf_hz",
+                value: 25
+	},
+	{
+                key: "gyro_lpf_type",
+                value: "BIQUAD"
+	},
+	{
+                key: "dynamic_gyro_notch_enabled",
+                value: "ON"
+	},
+	{
+                key: "dynamic_gyro_notch_q",
+                value: 250
+	},
+	{
+                key: "dynamic_gyro_notch_min_hz",
+                value: 30
+	},
+	{
+                key: "motor_pwm_protocol",
+                value: "STANDARD"
+	},
+	{ 
+                key: "throttle_idle",
+                value: 5.0
+	},
+	{
+                key: "rc_yaw_expo",
+                value: 30
+	},
+	{
+                key: "rc_expo",
+                value: 30
+	},
+	{
+                key: "roll_rate",
+                value: 18
+	},
+	{
+                key: "pitch_rate",
+                value: 9
+	},
+	{
+                key: "yaw_rate",
+                value: 3
+	},
+	{ 
+                key: "nav_fw_pos_z_p",
+                value: 20
+	},
+	{ 
+                key: "nav_fw_pos_z_d",
+                value: 5
+	},
+	{ 
+                key: "nav_fw_pos_xy_p",
+                value: 50
+	},
+	{ 
+                key: "fw_turn_assist_pitch_gain",
+                value: 0.2
+	},
+	{ 
+                key: "max_angle_inclination_rll",
+                value: 450
+	},
+	{ 
+                key: "nav_fw_bank_angle",
+                value: 45
+	},
+	{ 
+                key: "fw_p_pitch",
+                value: 10
+	},
+	{ 
+                key: "fw_i_pitch",
+                value: 15
+	},
+	{ 
+                key: "fw_ff_pitch",
+                value: 70
+	},
+	{ 
+                key: "fw_p_roll",
+                value: 5
+	},
+	{ 
+                key: "fw_i_roll",
+                value: 8
+	},
+	{ 
+                key: "fw_ff_roll",
+                value: 35
+	},
+	{ 
+                key: "fw_p_yaw",
+                value: 20
+	},
+	{ 
+                key: "fw_i_yaw",
+                value: 0
+	},
+	{ 
+                key: "fw_ff_yaw",
+                value: 100
+	},
+	{
+                key: "imu_acc_ignore_rate",
+                value: 10
+	},
+	{
+                key: "airmode_type",
+                value: "STICK_CENTER_ONCE"
+	},
+	{
+                key: "small_angle",
+                value: 180
+	},
+	{
+                key: "nav_fw_control_smoothness",
+                value: 2
+	},
+	{
+                key: "nav_rth_allow_landing",
+                value: "FS_ONLY"
+	},
+	{
+                key: "nav_rth_altitude",
+                value: 5000
+	},
+	{
+                key: "failsafe_mission",
+                value: "ON"
+	},
+	{
+                key: "nav_wp_radius",
+                value: 1500
+	},
+	],
+    },
 ];

--- a/src/css/defaults_dialog.css
+++ b/src/css/defaults_dialog.css
@@ -16,7 +16,7 @@
     position: absolute;
     width: 500px;
     height: 485px;
-    overflow-y: auto;
+    overflow-y: none;
     top: 0;
     bottom: 0;
     left: 0;

--- a/src/css/defaults_dialog.css
+++ b/src/css/defaults_dialog.css
@@ -15,7 +15,7 @@
     z-index: 2002;
     position: absolute;
     width: 500px;
-    height: 450px;
+    height: 485px;
     overflow-y: auto;
     top: 0;
     bottom: 0;

--- a/src/css/defaults_dialog.css
+++ b/src/css/defaults_dialog.css
@@ -16,7 +16,7 @@
     position: absolute;
     width: 500px;
     height: 485px;
-    overflow-y: none;
+    overflow: none;
     top: 0;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
Removed the outdated Fixed wing model specific presets and created generic presets for Tailed and Tail-less Planes. 
These are tested on different planes already from 680mm size up to 1.6m and bigger planes tested soon. Stable flight and RTH behavior as well as position hold for basic flight and safe maiden. 