### PR TITLE
Remove expo from Rates & Expo tab

### DIFF
--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -4,7 +4,7 @@
     <div class="content_wrapper">
         <div class="tab_title subtab__header">
             <span class="subtab__header_label subtab__header_label--current" for="subtab-pid">PID gains</span>
-            <span class="subtab__header_label" for="subtab-rates">Rates & Expo</span>
+            <span class="subtab__header_label" for="subtab-rates">Rates</span>
             <span class="subtab__header_label" for="subtab-filters">Filters</span>
             <span class="subtab__header_label" for="subtab-mechanics">Mechanics</span>
         </div>
@@ -167,7 +167,7 @@
         </div>
 
         <div id="subtab-rates" class="subtab__content">
-            <div class="tab_subtitle" style="margin-top: 1em;">Rates & Expo</div>
+            <div class="tab_subtitle" style="margin-top: 1em;">Rates</div>
             <div class="clear-both"></div>
             <div class="cf_column">
                 <table class="settings-table settings-table--inav">
@@ -193,18 +193,6 @@
                                 <input type="number" id="rate-yaw" class="rate-tpa_input" step="10" min="20"
                                     max="1800" />
                                 degrees per second
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>Roll & Pitch Expo</th>
-                            <td>
-                                <input data-setting="rc_expo" type="number" class="rate-tpa_input" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>Yaw Expo</th>
-                            <td>
-                                <input data-setting="rc_yaw_expo" type="number" class="rate-tpa_input" />
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
Expo has been duplicated in multiple locations. This adds confusion and brings up questions as to where it should be changed. To simplify things, I recommend removing expo from the _PID Tuning_ page. It makes more sense to have it on the _Receiver_ page as:

- There are more expo settings already on the _Receiver_ page (**RC Expo**, **RC Expo Yaw**, **Manual RC Expo**, **Manual RC Expo Yaw**, and **Throttle Expo**), compared to only RC Expo (**Roll & Pitch Expo**) and RC Expo Yaw (**Yaw Expo**) on the _Rates & Expo_ page.
- Expo is something traditionally related to a feature on the transmitter, so it makes more sense to have it with the receiver settings.

To lessen confusion, the tab name has also been renamed from **Rates & Expo** to simply **Rates**.

![image](https://user-images.githubusercontent.com/17590174/110169524-b8bdc680-7df0-11eb-9f3b-e4ab300efe86.png)
The new **Rates** page

![image](https://user-images.githubusercontent.com/17590174/110169572-c83d0f80-7df0-11eb-87b2-f719e431a6b4.png)
The **Receiver** page for reference