### PR TITLE
Allow editing of derivative on airplane

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -71,7 +71,7 @@ var FC = {
         return (MIXER_CONFIG.platformType == PLATFORM_AIRPLANE || MIXER_CONFIG.platformType == PLATFORM_ROVER || MIXER_CONFIG.platformType == PLATFORM_BOAT) || ((MIXER_CONFIG.platformType == PLATFORM_MULTIROTOR || MIXER_CONFIG.platformType == PLATFORM_TRICOPTER) && semver.gte(CONFIG.flightControllerVersion, "2.6.0"));
     },
     isRpyDComponentUsed: function () {
-        return MIXER_CONFIG.platformType == PLATFORM_MULTIROTOR || MIXER_CONFIG.platformType == PLATFORM_TRICOPTER;
+        return MIXER_CONFIG.platformType == PLATFORM_AIRPLANE || MIXER_CONFIG.platformType == PLATFORM_MULTIROTOR || MIXER_CONFIG.platformType == PLATFORM_TRICOPTER;
     },
     isCdComponentUsed: function () {
         return FC.isRpyDComponentUsed();

--- a/js/fc.js
+++ b/js/fc.js
@@ -71,7 +71,7 @@ var FC = {
         return (MIXER_CONFIG.platformType == PLATFORM_AIRPLANE || MIXER_CONFIG.platformType == PLATFORM_ROVER || MIXER_CONFIG.platformType == PLATFORM_BOAT) || ((MIXER_CONFIG.platformType == PLATFORM_MULTIROTOR || MIXER_CONFIG.platformType == PLATFORM_TRICOPTER) && semver.gte(CONFIG.flightControllerVersion, "2.6.0"));
     },
     isRpyDComponentUsed: function () {
-        return MIXER_CONFIG.platformType == PLATFORM_AIRPLANE || MIXER_CONFIG.platformType == PLATFORM_MULTIROTOR || MIXER_CONFIG.platformType == PLATFORM_TRICOPTER;
+        return true; // Currently all platforms use D term
     },
     isCdComponentUsed: function () {
         return FC.isRpyDComponentUsed();


### PR DESCRIPTION
This configurator change allows derivative to be edited on the airplane platform. It is to work along side @avsaase PIDFF controller on airplanes. PR https://github.com/iNavFlight/inav/pull/6669

![image](https://user-images.githubusercontent.com/17590174/110685164-e67e8300-81d5-11eb-80c5-70b0e1f3d048.png)
