### PR TITLE
Add GPS valid Fix to programming

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -1279,6 +1279,7 @@ var FC = {
                     31: "3D home distance [m]",
                     32: "CRSF LQ",
                     33: "CRSF SNR",
+                    34: "GPS Valid Fix",
                 }
             },
             3: {


### PR DESCRIPTION
This adds a boolean for when there is a valid GPS 3D fix in the programming. Useful for sanity checks.

Requires https://github.com/iNavFlight/inav/pull/6750