### PR TITLE
Rename OSD SW to OSD OFF and LEDLOW to LEDS OFF

### DIFF
--- a/tabs/auxiliary.js
+++ b/tabs/auxiliary.js
@@ -35,17 +35,17 @@ TABS.auxiliary.initialize = function (callback) {
     function sort_modes_for_display() {
         // This array defines the order that the modes are displayed in the configurator modes page
         configuratorBoxOrder = [
-            "ARM",                                                                                  // Arming
-            "ANGLE", "HORIZON", "MANUAL",                                                           // Flight modes
-            "NAV RTH", "NAV POSHOLD", "NAV CRUISE",                                                 // Navigation mode
-            "NAV ALTHOLD", "HEADING HOLD", "AIR MODE",                                              // Flight mode modifiers
-            "NAV WP", "GCS NAV", "HOME RESET",                                                      // Navigation
-            "SERVO AUTOTRIM", "AUTO TUNE", "NAV LAUNCH", "LOITER CHANGE", "FLAPERON",               // Fixed wing specific
-            "FPV ANGLE MIX", "TURN ASSIST", "MC BRAKING", "SURFACE", "HEADFREE", "HEADADJ",         // Multi-rotor specific
-            "BEEPER", "LEDLOW", "LIGHTS",                                                           // Feedback
-            "OSD SW", "OSD ALT 1", "OSD ALT 2", "OSD ALT 3",                                        // OSD
-            "CAMSTAB", "CAMERA CONTROL 1", "CAMERA CONTROL 2", "CAMERA CONTROL 3",                  // FPV Camera
-            "BLACKBOX", "FAILSAFE", "KILLSWITCH", "TELEMETRY", "MSP RC OVERRIDE", "USER1", "USER2"  // Misc
+            "ARM",                                                                                     // Arming
+            "ANGLE", "HORIZON", "MANUAL",                                                              // Flight modes
+            "NAV RTH", "NAV POSHOLD", "NAV CRUISE",                                                    // Navigation mode
+            "NAV ALTHOLD", "HEADING HOLD", "AIR MODE",                                                 // Flight mode modifiers
+            "NAV WP", "GCS NAV", "HOME RESET",                                                         // Navigation
+            "SERVO AUTOTRIM", "AUTO TUNE", "NAV LAUNCH", "LOITER CHANGE", "FLAPERON",                  // Fixed wing specific
+            "TURTLE", "FPV ANGLE MIX", "TURN ASSIST", "MC BRAKING", "SURFACE", "HEADFREE", "HEADADJ",  // Multi-rotor specific
+            "BEEPER", "LEDS OFF", "LIGHTS",                                                            // Feedback
+            "OSD OFF", "OSD ALT 1", "OSD ALT 2", "OSD ALT 3",                                          // OSD
+            "CAMSTAB", "CAMERA CONTROL 1", "CAMERA CONTROL 2", "CAMERA CONTROL 3",                     // FPV Camera
+            "BLACKBOX", "FAILSAFE", "KILLSWITCH", "TELEMETRY", "MSP RC OVERRIDE", "USER1", "USER2"     // Misc
         ];
 
         // Sort the modes


### PR DESCRIPTION
These 2 labels tend to confuse people. So I have renamed them to make it more obvious to people. I have also added turtle mode in to the modes ordering.

![image](https://user-images.githubusercontent.com/17590174/114438914-46df5680-9bc0-11eb-8b87-a9b12f98e1d4.png)

Requires https://github.com/iNavFlight/inav/pull/6821
Fixes #1136 