### PR TITLE
Enter Keypress trigger bug

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -2527,13 +2527,6 @@ TABS.osd.initialize = function (callback) {
             });
         });
 
-        $(document).keypress(function (e) {
-            if (e.which == 13) { // enter
-                // Trigger regular Flashing sequence
-                $('a.flash_font').click();
-            }
-        });
-
         $('.update_preview').on('change', function () {
             if (OSD.data) {
                 // Force an OSD redraw by saving any element


### PR DESCRIPTION
Currently, pressing the Enter key outside of the Font Manager box calls the flash font function even if there's nothing to load. This makes the FC go into an infinite loop or load the last font loaded in the session. Looks like an old thing ported from Betaflight/Chrome. Not needed anymore.