### PR TITLE
Limit images width in release notes

### DIFF
--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -176,6 +176,10 @@
     padding: 5px;
 }
 
+.tab-firmware_flasher .release_info .notes img {
+    max-width: 100%;
+}
+
 .tab-firmware_flasher .git_info {
     display: none;
     margin-bottom: 10px;


### PR DESCRIPTION
Minor cosmetic fix that crudely prevents chaos.

Before:

![before](https://user-images.githubusercontent.com/3594528/122597899-5a011d80-d06c-11eb-9f7e-6fa8a7612f47.png)

After:

![after](https://user-images.githubusercontent.com/3594528/122597911-5cfc0e00-d06c-11eb-848b-c3c4373cf4d7.png)
