### PR TITLE
Change to facilitate the new Metric + MPH units set (#7195)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2770,11 +2770,17 @@
     "osdUnitMetric": {
         "message": "Metric"
     },
+    "osdUnitMetricMPH": {
+        "message": "Metric + MPH"
+    },
+    "osdUnitMetricMPHTip": {
+        "message": "Use metric units except for the speed, which is displayed in miles per hour."
+    },
     "osdUnitUK": {
         "message": "UK"
     },
     "osdUnitUKTip": {
-        "message": "Use metric units except for the speed, which is displayed in miles per hour."
+        "message": "Use imperial units except for the temperature, which is displayed in Celsius."
     },
     "osd_rssi_alarm": {
         "message": "RSSI (%)"

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -452,7 +452,7 @@ button {
 }
 
 .tab-osd .settings select {
-    width: 65px;
+    width: 75px;
     margin-right: 11px;
 }
 

--- a/tabs/osd.html
+++ b/tabs/osd.html
@@ -6,9 +6,9 @@
             <p data-i18n="osd_unsupported_msg2" class="note"></p>
         </div>
         <div class="supported hide">
+            <select class="osd_layouts">
+            </select>
             <div class="cf_column third_left osd__elements">
-                <select class="osd_layouts">
-                </select>
                 <div class="spacer_right">
                     <div id="osd_group_template" class="gui_box grey">
                         <div

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -501,7 +501,8 @@ OSD.constants = {
     UNIT_TYPES: [
         {name: 'osdUnitImperial', value: 0},
         {name: 'osdUnitMetric', value: 1},
-        {name: 'osdUnitUK', tip: 'osdUnitUKTip', value: 2},
+        {name: 'osdUnitMetricMPH', tip: 'osdUnitMetricMPHTip', value: 2},
+        {name: 'osdUnitUK', tip: 'osdUnitUKTip', value: 3},
     ],
     AHISIDEBARWIDTHPOSITION: 7,
     AHISIDEBARHEIGHTPOSITION: 3,
@@ -1387,7 +1388,7 @@ OSD.constants = {
                     id: 98,
                     preview: function(osd_data) {
                         var scale;
-                        if (OSD.data.preferences.units === 0) {
+                        if (OSD.data.preferences.units === 0 || OSD.data.preferences.units === 3) {
                             scale = FONT.embed_dot("0.10") + FONT.symbol(SYM.MI);
                         } else {
                             scale = "100" + FONT.symbol(SYM.M);


### PR DESCRIPTION
Ref https://github.com/iNavFlight/inav/pull/7195
Fixes https://github.com/iNavFlight/inav/issues/7191

The units used as "UK" were incorrect. We use imperial for distance and speed. To correct this, I have added a new units set called Metric + MPH. Check the firmware PR (above) for full details.