### PR TITLE
Added search box for targets

### DIFF
--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -262,3 +262,16 @@
     text-shadow: none;
     opacity: 0.5;
 }
+
+.tab-firmware_flasher .target_search {
+    padding-left: 3px;
+    height: 20px;
+    line-height: 20px;
+    text-align: left;
+    border: 1px solid silver;
+    border-radius: 3px;
+    margin-right: 11px;
+    margin-bottom: 5px;
+    font-size: 12px;
+    font-weight: normal;
+}

--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -265,6 +265,7 @@
 
 .tab-firmware_flasher .target_search {
     padding-left: 3px;
+    width: 295px;
     height: 20px;
     line-height: 20px;
     text-align: left;

--- a/tabs/firmware_flasher.html
+++ b/tabs/firmware_flasher.html
@@ -4,7 +4,8 @@
             <div class="spacer">
                 <table class="cf_table" style="margin-top: 10px;">
                     <tr>
-                        <td><select name="board">
+                        <td><input class="target_search" placeholder="Search targets..."><br />
+                            <select name="board" id="board_targets">
                                 <option value="0">Loading ...</option>
                         </select></td>
                         <td><span class="description" i18n="firmwareFlasherOnlineSelectBoardDescription"></span></td>

--- a/tabs/firmware_flasher.html
+++ b/tabs/firmware_flasher.html
@@ -4,7 +4,7 @@
             <div class="spacer">
                 <table class="cf_table" style="margin-top: 10px;">
                     <tr>
-                        <td><input class="target_search" placeholder="Search targets..."><br />
+                        <td><input class="target_search" placeholder="Search targets..." autocomplete="on"><br />
                             <select name="board" id="board_targets">
                                 <option value="0">Loading ...</option>
                         </select></td>

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -53,8 +53,46 @@ TABS.firmware_flasher.initialize = function (callback) {
             buildBoardOptions();
         });
 
-        var buildBoardOptions = function(){
+        $('.target_search').on('input', function(){
+            var searchText = $('.target_search').val().toLocaleLowerCase();
 
+            $('#board_targets option').each(function(i){
+                var target = $(this);
+                //alert("Comparing " + searchText + " with " + target.text());
+                if (searchText.length > 0 && i !== 0) { 
+                    if (target.text().toLowerCase().includes(searchText)) {
+                        target.show();
+                    } else {
+                        target.hide();
+                    }
+                } else {
+                    target.show();
+                }
+            });
+        });
+
+        /*$('.target_search').on('input', function(){
+            var searchText = $('.target_search').val();
+            var targetList = $('#board_targets > option');
+            alert("Searching... " + searchText + " through " + targetList.length + " targets.")
+            for (var ti = 0; ti < targetList.length; ti++) {
+                alert ("Target: " + targetList[ti]);
+                alert("Comparing " + searchText + " with " + targetList[ti].text);
+                if (searchText.length > 0) { 
+                    if ((targetList[i].text().toLowerCase().includes(searchText.toLowerCase())) === FALSE) {
+                        targetList[i].hide();
+                        alert("Hiding " + targetList[ti].text());
+                    } else {
+                        alert("Search string found.");
+                    }
+                } else {
+                    alert("Nothing to search, show everything.");
+                    targetList[ti].show();
+                }
+            }
+        });*/
+
+        var buildBoardOptions = function(){
             var boards_e = $('select[name="board"]').empty();
             var showDevReleases = ($('input.show_development_releases').is(':checked'));
             boards_e.append($("<option value='0'>{0}</option>".format(chrome.i18n.getMessage('firmwareFlasherOptionLabelSelectBoard'))));

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -71,27 +71,6 @@ TABS.firmware_flasher.initialize = function (callback) {
             });
         });
 
-        /*$('.target_search').on('input', function(){
-            var searchText = $('.target_search').val();
-            var targetList = $('#board_targets > option');
-            alert("Searching... " + searchText + " through " + targetList.length + " targets.")
-            for (var ti = 0; ti < targetList.length; ti++) {
-                alert ("Target: " + targetList[ti]);
-                alert("Comparing " + searchText + " with " + targetList[ti].text);
-                if (searchText.length > 0) { 
-                    if ((targetList[i].text().toLowerCase().includes(searchText.toLowerCase())) === FALSE) {
-                        targetList[i].hide();
-                        alert("Hiding " + targetList[ti].text());
-                    } else {
-                        alert("Search string found.");
-                    }
-                } else {
-                    alert("Nothing to search, show everything.");
-                    targetList[ti].show();
-                }
-            }
-        });*/
-
         var buildBoardOptions = function(){
             var boards_e = $('select[name="board"]').empty();
             var showDevReleases = ($('input.show_development_releases').is(':checked'));


### PR DESCRIPTION
Added a search field for targets on the firmware flasher page. 

I was inspired by @nmaggioni's search box on the OSD page. Now we can search targets, which should make them easier to find.

https://youtu.be/F-aPR9DaTcw

![image](https://user-images.githubusercontent.com/17590174/125527655-a5cc769c-31f6-459a-99f4-830a63f5f5b0.png)
