### PR TITLE
Added battery symbol in front of percentage

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -760,7 +760,7 @@ OSD.constants = {
                 {
                     name: 'MAIN_BATT_REMAINING_PERCENTAGE',
                     id: 38,
-                    preview: '100%'
+                    preview: FONT.symbol(SYM.BATT) + '100%'
                 },
                 {
                     name: 'REMAINING_FLIGHT_TIME',


### PR DESCRIPTION
This PR adds the battery symbol in front of the battery percentage. Currently the percentage has no indication of what it is for. This PR fixes that.

Requires https://github.com/iNavFlight/inav/pull/7371

![WIN_20210823_18_34_29_Pro](https://user-images.githubusercontent.com/17590174/130493828-8c26143e-9e20-4640-bf5f-fc71269388e9.jpg)
