### PR TITLE
Fix Blackbox log file TXT extension attempt 2

### DIFF
--- a/tabs/onboard_logging.js
+++ b/tabs/onboard_logging.js
@@ -353,11 +353,10 @@ TABS.onboard_logging.initialize = function (callback) {
         const date = new Date();
         const filename = 'blackbox_log_' + date.getFullYear() + '-'  + zeroPad(date.getMonth() + 1, 2) + '-'
                 + zeroPad(date.getDate(), 2) + '_' + zeroPad(date.getHours(), 2) + zeroPad(date.getMinutes(), 2)
-                + zeroPad(date.getSeconds(), 2);
-        const accepts = '.txt';
+                + zeroPad(date.getSeconds(), 2) + '.txt';
 
         nwdialog.setContext(document);
-        nwdialog.saveFileDialog(filename, accepts, '', function(file) {
+        nwdialog.saveFileDialog(filename, function(file) {
             onComplete(file);
         });
     }

--- a/tabs/onboard_logging.js
+++ b/tabs/onboard_logging.js
@@ -353,7 +353,7 @@ TABS.onboard_logging.initialize = function (callback) {
         const date = new Date();
         const filename = 'blackbox_log_' + date.getFullYear() + '-'  + zeroPad(date.getMonth() + 1, 2) + '-'
                 + zeroPad(date.getDate(), 2) + '_' + zeroPad(date.getHours(), 2) + zeroPad(date.getMinutes(), 2)
-                + zeroPad(date.getSeconds(), 2) + '.txt';
+                + zeroPad(date.getSeconds(), 2) + '.TXT';
 
         nwdialog.setContext(document);
         nwdialog.saveFileDialog(filename, function(file) {


### PR DESCRIPTION
Hard codes ".TXT" to the log filename which hopefully avoids OS related issues using an appended extension in the file save dialogue.

Should close https://github.com/iNavFlight/inav-configurator/issues/1338.