### PR TITLE
Reformat Mission Control Safehome and Home tables

### DIFF
--- a/src/css/tabs/mission_planer.css
+++ b/src/css/tabs/mission_planer.css
@@ -302,7 +302,7 @@
 .tab-mission-control .safehomesTable {
     width: 100%;
     text-align: center;
-    font-size: 8px;
+    font-size: 12px;
 }
 
 .tab-mission-control .safehomesTable input[type="text"] {
@@ -311,7 +311,7 @@
 }
 
 .tab-mission-control .safehomesTable input[type="number"] {
-    font-size: 8px;
+    font-size: 10px;
     width: 100%;
     -moz-appearance: textfield;
 }
@@ -498,8 +498,8 @@
     width:20px;
 }
 
-.tab-mission-control .textLegend{   
-    margin:2px; 
+.tab-mission-control .textLegend{
+    margin:2px;
 }
 .tab-mission-control .valueLegend{
     float:right;

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -13,7 +13,7 @@
                         </div>
                     </div>
                     <div class="spacer" id="ActionContent">
-                        
+
                         <div class="btn save_btn">
                             <a id="loadFileMissionButton" class="btnicon ic_loadFromFile" href="#" title="Load Mission File"></a>
                             <a id="saveFileMissionButton" class="btnicon ic_save2File" href="#" title="Save Mission File"></a>
@@ -86,7 +86,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="missionPlanerHome" class="gui_box grey" style="display: none">
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title i18n-replaced" data-i18n="missionHomeHead">Take Off home</div>
@@ -102,20 +102,20 @@
                             <table class="safehomesTable">
                                 <thead>
                                     <tr>
-                                        <th style="width: 50px" data-i18n="SafehomeSelected"></th>
-                                        <th style="width: 120px" data-i18n="SafehomeLon"></th>
-                                        <th style="width: 120px" data-i18n="SafehomeLat"></th>
-                                        <th style="width: 120px" data-i18n="SafehomeAlt"></th>
+                                        <th style="width: 40px" data-i18n="SafehomeSelected"></th>
+                                        <th style="width: 140px" data-i18n="SafehomeLat"></th>
+                                        <th style="width: 140px" data-i18n="SafehomeLon"></th>
+                                        <th style="width: 100px" data-i18n="SafehomeAlt"></th>
                                     </tr>
                                 </thead>
                                 <tbody id="homeTableBody">
                                     <tr>
-                                    <td><div id="viewHomePoint" class="btnTable btnTableIcon"> 
-                                            <a class="ic_center" data-role="home-center" href="#"  title="move to center view"></a> 
+                                    <td><div id="viewHomePoint" class="btnTable btnTableIcon">
+                                            <a class="ic_center" data-role="home-center" href="#"  title="move to center view"></a>
                                         </div>
-                                    </td> 
-                                    <td><input type="number" class="home-lon" /></td>
+                                    </td>
                                     <td><input type="number" class="home-lat" /></td>
+                                    <td><input type="number" class="home-lon" /></td>
                                     <td><span id="elevationValueAtHome">NA</span></td>
                                     </tr>
                                 </tbody>
@@ -123,7 +123,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="missionPlanerSafehome" class="gui_box grey" style="display: none">
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title i18n-replaced" data-i18n="missionSafehomeHead">Safe Home manager</div>
@@ -141,11 +141,11 @@
                             <table class="safehomesTable">
                                 <thead>
                                     <tr>
-                                        <th style="width: 80px" data-i18n="SafehomeSelected"></th>
-                                        <th style="width: 50px" data-i18n="SafehomeId"></th>
-                                        <th style="width: 80px" data-i18n="SafehomeEnabled"></th>
-                                        <th style="width: 120px" data-i18n="SafehomeLon"></th>
-                                        <th style="width: 120px" data-i18n="SafehomeLat"></th>
+                                        <th style="width: 40px" data-i18n="SafehomeSelected"></th>
+                                        <th style="width: 40px" data-i18n="SafehomeId"></th>
+                                        <th style="width: 60px" data-i18n="SafehomeEnabled"></th>
+                                        <th style="width: 140px" data-i18n="SafehomeLat"></th>
+                                        <th style="width: 140px" data-i18n="SafehomeLon"></th>
                                     </tr>
                                 </thead>
                                 <tbody id="safehomesTableBody">
@@ -244,7 +244,7 @@
                             </tbody>
                         </table>
                         </div>
-                        
+
 						<!-- <div class="point-radio" id="pointOptionclass" style="display: none">
 							<div class="radio-line">
 								<input type="radio" id="Options_None" name="Options" value="None" checked>
@@ -256,7 +256,7 @@
 								<input type="checkbox" id="Options_LandRTH">
 								<label for="Options_LandRTH">Land after RTH</label><br>
 							</div>
-							<div class="radio-line">	
+							<div class="radio-line">
 								<input type="radio" id="Options_JUMP" name="Options" value="JUMP">
 								<label class="radio-options" for="Options_JUMP">JUMP</label>
 								<label for="Options_TargetJUMP">Target WP: </label>
@@ -264,14 +264,14 @@
 								<label for="Options_NumberJUMP">Repeat: </label>
 								<input id="Options_NumberJUMP" type="text" value="0" required><br>
 							</div>
-							<div class="radio-line">	
+							<div class="radio-line">
 								<input type="radio" id="Options_HEAD" name="Options" value="SET_HEAD">
 								<label class="radio-options" for="Options_HEAD">HEAD</label>
 								<label for="Options_HeadingHead">Heading: </label>
 								<input id="Options_HeadingHead" type="text" value="-1" required><br>
 							</div>
                         </div> -->
-						
+
                     </div>
                 </div>
             </div>

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -108,7 +108,7 @@ TABS.mission_control.initialize = function (callback) {
             $('#saveEepromMissionButton').hide();
             isOffline = true;
         }
-        
+
         $safehomesTable = $('.safehomesTable');
         $safehomesTableBody = $('#safehomesTableBody');
         $waypointOptionsTable = $('.waypointOptionsTable');
@@ -140,7 +140,7 @@ TABS.mission_control.initialize = function (callback) {
         function get_attitude_data() {
             MSP.send_message(MSPCodes.MSP_ATTITUDE, false, false, update_gpsTrack);
         }
-      
+
         function update_gpsTrack() {
 
           let lat = GPS_DATA.lat / 10000000;
@@ -338,29 +338,29 @@ TABS.mission_control.initialize = function (callback) {
 
     ///////////////////////////////////////////////
     //
-    // define & init parameters 
+    // define & init parameters
     //
     ///////////////////////////////////////////////
-    
+
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init parameters for Map Layer
     //////////////////////////////////////////////////////////////////////////////////////////////
     var markers = [];           // Layer for Waypoints
     var lines = [];             // Layer for lines between waypoints
     var safehomeMarkers =[];    // layer for Safehome points
-    
+
     var map;
-    
+
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init parameters for Selected Marker
     //////////////////////////////////////////////////////////////////////////////////////////////
     var selectedMarker = null;
     var selectedFeature = null;
     var tempMarker = null;
-    
+
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init parameters for default Settings
-    //////////////////////////////////////////////////////////////////////////////////////////////   
+    //////////////////////////////////////////////////////////////////////////////////////////////
     var vMaxDistSH = 0;
     var settings = {};
     if (CONFIGURATOR.connectionValid) {
@@ -381,23 +381,23 @@ TABS.mission_control.initialize = function (callback) {
     }
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init Waypoints parameters
-    //////////////////////////////////////////////////////////////////////////////////////////////    
+    //////////////////////////////////////////////////////////////////////////////////////////////
     var mission = new WaypointCollection();
-    
+
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init home parameters
-    ////////////////////////////////////////////////////////////////////////////////////////////// 
+    //////////////////////////////////////////////////////////////////////////////////////////////
     var HOME = new Waypoint(0,0,0,0);
     var homeMarkers =[];    // layer for home point
-    
+
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init Safehome parameters
-    //////////////////////////////////////////////////////////////////////////////////////////////    
+    //////////////////////////////////////////////////////////////////////////////////////////////
     //var SAFEHOMES = new SafehomeCollection(); // TO COMMENT FOR RELEASE : DECOMMENT FOR DEBUG
     //SAFEHOMES.inflate(); // TO COMMENT FOR RELEASE : DECOMMENT FOR DEBUG
     //var safehomeRangeRadius = 200; //meters
     //var safehomeSafeRadius = 50; //meters
-    
+
     /////////////////////////////////////////////
     //
     // Reinit Jquery Form
@@ -413,11 +413,11 @@ TABS.mission_control.initialize = function (callback) {
         $('#missionDistance').text(0);
         $('#MPeditPoint').fadeOut(300);
     }
-    
+
     function clearFilename() {
         $('#missionFilename').text('');
     }
-    
+
     /////////////////////////////////////////////
     //
     // Manage Settings
@@ -441,21 +441,21 @@ TABS.mission_control.initialize = function (callback) {
         $('#MPdefaultPointSpeed').val(String(settings.speed));
         $('#MPdefaultSafeRangeSH').val(String(settings.safeRadiusSH));
     }
-    
+
     function closeSettingsPanel() {
         $('#missionPlanerSettings').hide();
-    }    
-    
+    }
+
     /////////////////////////////////////////////
     //
     // Manage Safehome
     //
-    /////////////////////////////////////////////  
+    /////////////////////////////////////////////
     function closeSafehomePanel() {
         $('#missionPlanerSafehome').hide();
         cleanSafehomeLayers();
-    } 
-    
+    }
+
     function renderSafehomesTable() {
         /*
          * Process safehome table UI
@@ -474,16 +474,16 @@ TABS.mission_control.initialize = function (callback) {
                     </td> \
                     <td><span class="safehome-number"/></td>\
                     <td class="safehome-enabled"><input type="checkbox" class="togglesmall safehome-enabled-value"/></td> \
-                    <td><input type="number" class="safehome-lon" /></td>\
                     <td><input type="number" class="safehome-lat" /></td>\
+                    <td><input type="number" class="safehome-lon" /></td>\
                     </tr>\
                 ');
 
                 const $row = $safehomesTableBody.find('tr:last');
-                
-                
+
+
                 $row.find(".safehome-number").text(safehome.getNumber()+1);
-                
+
                 $row.find(".safehome-enabled-value").prop('checked',safehome.isUsed()).change(function () {
                     safehome.setEnabled((($(this).prop('checked')) ? 1 : 0));
                     SAFEHOMES.updateSafehome(safehome);
@@ -497,7 +497,7 @@ TABS.mission_control.initialize = function (callback) {
                     cleanSafehomeLayers();
                     renderSafehomesOnMap();
                 });
-                
+
                 $row.find(".safehome-lat").val(safehome.getLatMap()).change(function () {
                     safehome.setLat(Math.round(Number($(this).val()) * 10000000));
                     SAFEHOMES.updateSafehome(safehome);
@@ -511,8 +511,8 @@ TABS.mission_control.initialize = function (callback) {
         GUI.switchery();
         localize();
     }
-    
-    
+
+
     function renderSafehomesOnMap() {
         /*
          * Process safehome on Map
@@ -521,14 +521,14 @@ TABS.mission_control.initialize = function (callback) {
             map.addLayer(addSafeHomeMarker(safehome));
         });
     }
-    
-    function cleanSafehomeLayers() {       
+
+    function cleanSafehomeLayers() {
         for (var i in safehomeMarkers) {
             map.removeLayer(safehomeMarkers[i]);
         }
         safehomeMarkers = [];
     }
-    
+
     function getSafehomeIcon(safehome) {
         /*
          * Process Safehome Icon
@@ -554,7 +554,7 @@ TABS.mission_control.initialize = function (callback) {
             }))
         });
     }
-    
+
     function addSafeHomeMarker(safehome) {
         /*
          * add safehome on Map
@@ -566,7 +566,7 @@ TABS.mission_control.initialize = function (callback) {
         });
 
         //iconFeature.setStyle(getSafehomeIcon(safehome, safehome.isUsed()));
-        
+
         let circleStyle = new ol.style.Style({
             stroke: new ol.style.Stroke({
                 color: 'rgba(144, 12, 63, 0.5)',
@@ -577,7 +577,7 @@ TABS.mission_control.initialize = function (callback) {
                 // color: 'rgba(251, 225, 155, 0.1)'
             // })
         });
-        
+
         let circleSafeStyle = new ol.style.Style({
             stroke: new ol.style.Stroke({
                 color: 'rgba(136, 204, 62, 1)',
@@ -588,7 +588,7 @@ TABS.mission_control.initialize = function (callback) {
                 color: 'rgba(136, 204, 62, 0.1)'
             }) */
         });
-        
+
         var vectorLayer = new ol.layer.Vector({
             source: new ol.source.Vector({
                         features: [iconFeature]
@@ -608,9 +608,9 @@ TABS.mission_control.initialize = function (callback) {
         vectorLayer.kind = "safehome";
         vectorLayer.number = safehome.getNumber();
         vectorLayer.selection = false;
-        
+
         safehomeMarkers.push(vectorLayer);
-        
+
         return vectorLayer;
     }
 
@@ -621,7 +621,7 @@ TABS.mission_control.initialize = function (callback) {
         let radiusProjected = (radius / ol.proj.METERS_PER_UNIT.m) * resolutionRate;
         return radiusProjected;
     }
-    
+
     /////////////////////////////////////////////
     //
     // Manage Take Off Home
@@ -632,47 +632,47 @@ TABS.mission_control.initialize = function (callback) {
         $('#missionPlanerElevation').hide();
         cleanHomeLayers();
     }
-    
-    function cleanHomeLayers() {       
+
+    function cleanHomeLayers() {
         for (var i in homeMarkers) {
             map.removeLayer(homeMarkers[i]);
         }
         homeMarkers = [];
     }
-    
+
     function renderHomeTable() {
         /*
          * Process home table UI
-         */                
+         */
+
+        $(".home-lat").val(HOME.getLatMap()).change(function () {
+            HOME.setLat(Math.round(Number($(this).val()) * 10000000));
+            cleanHomeLayers();
+            renderHomeOnMap();
+        });
 
         $(".home-lon").val(HOME.getLonMap()).change(function () {
             HOME.setLon(Math.round(Number($(this).val()) * 10000000));
             cleanHomeLayers();
             renderHomeOnMap();
         });
-        
-        $(".home-lat").val(HOME.getLatMap()).change(function () {
-            HOME.setLat(Math.round(Number($(this).val()) * 10000000));
-            cleanHomeLayers();
-            renderHomeOnMap();
-        });
-        
+
         (async () => {
             const elevationAtHome = await HOME.getElevation(globalSettings);
             $('#elevationValueAtHome').text(elevationAtHome+' m');
             HOME.setAlt(elevationAtHome);
         })()
-        
+
     }
-    
-    
+
+
     function renderHomeOnMap() {
         /*
          * Process home on Map
          */
         map.addLayer(addHomeMarker(HOME));
     }
-    
+
     function addHomeMarker(home) {
         /*
          * add safehome on Map
@@ -684,7 +684,7 @@ TABS.mission_control.initialize = function (callback) {
         });
 
         //iconFeature.setStyle(getSafehomeIcon(safehome, safehome.isUsed()));
-        
+
         var vectorLayer = new ol.layer.Vector({
             source: new ol.source.Vector({
                         features: [iconFeature]
@@ -698,12 +698,12 @@ TABS.mission_control.initialize = function (callback) {
         vectorLayer.kind = "home";
         vectorLayer.number = home.getNumber();
         vectorLayer.selection = false;
-        
+
         homeMarkers.push(vectorLayer);
-        
+
         return vectorLayer;
     }
-    
+
     function getHomeIcon(home) {
         /*
          * Process Safehome Icon
@@ -722,23 +722,23 @@ TABS.mission_control.initialize = function (callback) {
     function updateHome() {
         renderHomeTable();
         cleanHomeLayers();
-        renderHomeOnMap();     
-        plotElevation();    
+        renderHomeOnMap();
+        plotElevation();
     }
     /////////////////////////////////////////////
     //
     // Manage Waypoint
     //
     /////////////////////////////////////////////
-    
+
     function removeAllWaypoints() {
-        mission.reinit(); 
+        mission.reinit();
         cleanLayers();
         clearEditForm();
         updateTotalInfo();
         clearFilename();
     }
-    
+
     function addWaypointMarker(waypoint, isEdit=false) {
 
         let coord = ol.proj.fromLonLat([waypoint.getLonMap(), waypoint.getLatMap()]);
@@ -756,7 +756,7 @@ TABS.mission_control.initialize = function (callback) {
         var vectorLayer = new ol.layer.Vector({
             source: vectorSource
         });
-        
+
         vectorLayer.kind = "waypoint";
         vectorLayer.number = waypoint.getNumber();
         vectorLayer.layerNumber = waypoint.getLayerNumber();
@@ -774,7 +774,7 @@ TABS.mission_control.initialize = function (callback) {
             5:    'POI',
             8:    'LDG'
         };
-        
+
         return new ol.style.Style({
             image: new ol.style.Icon(({
                 anchor: [0.5, 1],
@@ -796,8 +796,8 @@ TABS.mission_control.initialize = function (callback) {
             }))
         });
     }
-    
-    
+
+
     function repaintLine4Waypoints(mission) {
         let oldPos,
             oldAction,
@@ -809,7 +809,7 @@ TABS.mission_control.initialize = function (callback) {
         cleanLines();
         mission.get().forEach(function (element) {
             if (!element.isAttached()) {
-                let coord = ol.proj.fromLonLat([element.getLonMap(), element.getLatMap()]);                
+                let coord = ol.proj.fromLonLat([element.getLonMap(), element.getLatMap()]);
                 if (element.getAction() == 5) {
                     // If action is Set_POI, increment counter of POI
                     poiList.push(element.getNumber());
@@ -817,7 +817,7 @@ TABS.mission_control.initialize = function (callback) {
                     activateHead = false;
                 }
                 else {
-                    // If classic WPs, draw standard line in-between 
+                    // If classic WPs, draw standard line in-between
                     if (typeof oldPos !== 'undefined' && activatePoi != true && activateHead != true){
                         paintLine(oldPos, coord, element.getNumber());
                     }
@@ -839,7 +839,7 @@ TABS.mission_control.initialize = function (callback) {
             }
             else if (element.isAttached()) {
                 if (element.getAction() == MWNP.WPTYPE.JUMP) {
-                    let coord = ol.proj.fromLonLat([mission.getWaypoint(element.getP1()).getLonMap(), mission.getWaypoint(element.getP1()).getLatMap()]);  
+                    let coord = ol.proj.fromLonLat([mission.getWaypoint(element.getP1()).getLonMap(), mission.getWaypoint(element.getP1()).getLatMap()]);
                     paintLine(oldPos, coord, element.getNumber(), color='#e935d6', lineDash=5, lineText="Repeat x"+(element.getP2() == -1 ? " infinite" : String(element.getP2())), selection=false, arrow=true);
                 }
                 // If classic WPs is defined with a heading = -1, change Boolean for POI to false. If it is defined with a value different from -1, activate Heading boolean
@@ -864,14 +864,14 @@ TABS.mission_control.initialize = function (callback) {
         let lengthMission = mission.getDistance(true);
         $('#missionDistance').text(lengthMission[lengthMission.length -1] != -1 ? lengthMission[lengthMission.length -1].toFixed(1) : 'infinite');
     }
-    
+
     function paintLine(pos1, pos2, pos2ID, color='#1497f1', lineDash=0, lineText="", selection=true, arrow=false) {
         var line = new ol.geom.LineString([pos1, pos2]);
 
         var feature = new ol.Feature({
             geometry: line
         });
-        
+
         feature.setStyle(
             new ol.style.Style({
                 stroke: new ol.style.Stroke({
@@ -890,7 +890,7 @@ TABS.mission_control.initialize = function (callback) {
                 }),
             }),
         );
-        
+
         if (arrow) {
             let dx = pos2[0] - pos1[0];
             let dy = pos2[1] - pos1[1];
@@ -910,7 +910,7 @@ TABS.mission_control.initialize = function (callback) {
                 })
             );
         }
-        
+
 
         if (arrow) {
             var vectorSource = new ol.source.Vector({
@@ -931,7 +931,7 @@ TABS.mission_control.initialize = function (callback) {
         vectorLayer.kind = "line";
         vectorLayer.selection = selection;
         vectorLayer.number = pos2ID;
-        
+
         lines.push(vectorLayer);
 
 /*         var length = ol.Sphere.getLength(line) + parseFloat($('#missionDistance').text());
@@ -939,26 +939,26 @@ TABS.mission_control.initialize = function (callback) {
 
         map.addLayer(vectorLayer);
     }
-    
-    function cleanLayers() {       
+
+    function cleanLayers() {
         for (var i in lines) {
             map.removeLayer(lines[i]);
         }
         lines = [];
-        
+
         for (var i in markers) {
             map.removeLayer(markers[i]);
         }
         markers = [];
     }
-    
-    function cleanLines() {       
+
+    function cleanLines() {
         for (var i in lines) {
             map.removeLayer(lines[i]);
         }
         lines = [];
     }
-        
+
     function redrawLayers() {
         if (!mission.isEmpty()) {
             mission.get().forEach(function (element) {
@@ -969,15 +969,15 @@ TABS.mission_control.initialize = function (callback) {
         }
         repaintLine4Waypoints(mission);
     }
-    
+
     function redrawLayer() {
         if (selectedFeature && selectedMarker) {
             selectedFeature.setStyle(getWaypointIcon(selectedMarker, true));
         }
         repaintLine4Waypoints(mission);
     }
-    
-    
+
+
     function renderWaypointOptionsTable(waypoint) {
         /*
          * Process Waypoint Options table UI
@@ -998,7 +998,7 @@ TABS.mission_control.initialize = function (callback) {
             ');
 
             const $row = $waypointOptionsTableBody.find('tr:last');
-            
+
             for (var i = 1; i <= 3; i++) {
                 if (dictOfLabelParameterPoint[element.getAction()]['parameter'+String(i)] != '') {
                     $row.find(".waypointOptions-p"+String(i)).prop("disabled", false);
@@ -1007,9 +1007,9 @@ TABS.mission_control.initialize = function (callback) {
                     $row.find(".waypointOptions-p"+String(i)).prop("disabled", true);
                 }
             }
-            
+
             GUI.fillSelect($row.find(".waypointOptions-action"), waypointOptions, waypointOptions.indexOf(MWNP.WPTYPE.REV[element.getAction()]));
-            
+
             $row.find(".waypointOptions-action").val(waypointOptions.indexOf(MWNP.WPTYPE.REV[element.getAction()])).change(function () {
                     element.setAction(MWNP.WPTYPE[waypointOptions[$(this).val()]]);
                     for (var i = 1; i <= 3; i++) {
@@ -1024,7 +1024,7 @@ TABS.mission_control.initialize = function (callback) {
                     cleanLines();
                     redrawLayer();
                 });
-            
+
             $row.find(".waypointOptions-number").text(element.getAttachedNumber()+1);
 
 
@@ -1061,7 +1061,7 @@ TABS.mission_control.initialize = function (callback) {
                 cleanLines();
                 redrawLayer();
             });
-            
+
             $row.find(".waypointOptions-p2").val(element.getP2()).change(function () {
                 if (MWNP.WPTYPE.REV[element.getAction()] == "JUMP") {
                     if ($(this).val() > 10 || ($(this).val() < 0 && $(this).val() != -1))
@@ -1077,13 +1077,13 @@ TABS.mission_control.initialize = function (callback) {
             });
 
             $row.find("[data-role='waypointOptions-delete']").attr("data-index", element.getAttachedNumber()+1);
-            
+
         });
         GUI.switchery();
         localize();
         return waypoint;
     }
-    
+
     /////////////////////////////////////////////
     //
     // Manage Map construction
@@ -1091,10 +1091,10 @@ TABS.mission_control.initialize = function (callback) {
     /////////////////////////////////////////////
     function initMap() {
         var app = {};
-        
+
         //////////////////////////////////////////////////////////////////////////////////////////////
         //      Drag behavior definition
-        //////////////////////////////////////////////////////////////////////////////////////////////  
+        //////////////////////////////////////////////////////////////////////////////////////////////
 
         /**
          * @constructor
@@ -1171,8 +1171,8 @@ TABS.mission_control.initialize = function (callback) {
 
         };
         ol.inherits(app.PlannerSettingsControl, ol.control.Control);
-        
-        
+
+
         /**
          * @constructor
          * @extends {ol.control.Control}
@@ -1211,7 +1211,7 @@ TABS.mission_control.initialize = function (callback) {
 
         };
         ol.inherits(app.PlannerSafehomeControl, ol.control.Control);
-        
+
         /**
          * @constructor
          * @extends {ol.control.Control}
@@ -1248,7 +1248,7 @@ TABS.mission_control.initialize = function (callback) {
 
         };
         ol.inherits(app.PlannerElevationControl, ol.control.Control);
-        
+
         /**
          * @param {ol.MapBrowserEvent} evt Map browser event.
          * @return {boolean} `true` to start the drag sequence.
@@ -1293,7 +1293,7 @@ TABS.mission_control.initialize = function (callback) {
             if (tempMarker.kind == "waypoint" ||tempMarker.kind == "safehome" || tempMarker.kind == "home") {
                 geometry.translate(deltaX, deltaY);
                 this.coordinate_[0] = evt.coordinate[0];
-                this.coordinate_[1] = evt.coordinate[1]; 
+                this.coordinate_[1] = evt.coordinate[1];
             }
 
             let coord = ol.proj.toLonLat(geometry.getCoordinates());
@@ -1306,7 +1306,7 @@ TABS.mission_control.initialize = function (callback) {
                 mission.updateWaypoint(tempWp);
                 repaintLine4Waypoints(mission);
             }
-            else if (tempMarker.kind == "safehome") {                
+            else if (tempMarker.kind == "safehome") {
                 let tempSH = SAFEHOMES.getSafehome(tempMarker.number);
                 tempSH.setLon(Math.round(coord[0] * 10000000));
                 tempSH.setLat(Math.round(coord[1] * 10000000));
@@ -1314,13 +1314,13 @@ TABS.mission_control.initialize = function (callback) {
                 $safehomesTableBody.find('tr:nth-child('+String(tempMarker.number+1)+') > td > .safehome-lon').val(Math.round(coord[0] * 10000000) / 10000000);
                 $safehomesTableBody.find('tr:nth-child('+String(tempMarker.number+1)+') > td > .safehome-lat').val(Math.round(coord[1] * 10000000) / 10000000);
             }
-            else if (tempMarker.kind == "home") {                
+            else if (tempMarker.kind == "home") {
                 HOME.setLon(Math.round(coord[0] * 10000000));
                 HOME.setLat(Math.round(coord[1] * 10000000));
                 $('.home-lon').val(Math.round(coord[0] * 10000000) / 10000000);
                 $('.home-lat').val(Math.round(coord[1] * 10000000) / 10000000);
             }
-            
+
         };
 
         /**
@@ -1392,7 +1392,7 @@ TABS.mission_control.initialize = function (callback) {
         } else {
             mapLayer = new ol.source.OSM();
         }
-        
+
         if (CONFIGURATOR.connectionValid) {
             control_list = [
                 new app.PlannerSettingsControl(),
@@ -1410,7 +1410,7 @@ TABS.mission_control.initialize = function (callback) {
 
         //////////////////////////////////////////////////////////////////////////////////////////////
         // Map object definition
-        //////////////////////////////////////////////////////////////////////////////////////////////          
+        //////////////////////////////////////////////////////////////////////////////////////////////
         map = new ol.Map({
             controls: ol.control.defaults({
                 attributionOptions: {
@@ -1456,7 +1456,7 @@ TABS.mission_control.initialize = function (callback) {
             }
         });
         //////////////////////////////////////////////////////////////////////////
-        // Map on-click behavior definition 
+        // Map on-click behavior definition
         //////////////////////////////////////////////////////////////////////////
         map.on('click', function (evt) {
             if (selectedMarker != null && selectedFeature != null) {
@@ -1497,8 +1497,8 @@ TABS.mission_control.initialize = function (callback) {
                 $('#pointP1').val(selectedMarker.getP1());
                 $('#pointP2').val(selectedMarker.getP2());
                 changeSwitchery($('#pointP3'), selectedMarker.getP3() == 1);
-               
-                
+
+
                 // Selection box update depending on choice of type of waypoint
                 for (var j in dictOfLabelParameterPoint[selectedMarker.getAction()]) {
                     if (dictOfLabelParameterPoint[selectedMarker.getAction()][j] != '') {
@@ -1578,7 +1578,7 @@ TABS.mission_control.initialize = function (callback) {
             let altitudeMeters = app.ConvertCentimetersToMeters($(this).val());
             $('#altitudeInMeters').text(` ${altitudeMeters}m`);
         });
-        
+
         /////////////////////////////////////////////
         // Callback to show/hide menu boxes
         /////////////////////////////////////////////
@@ -1594,7 +1594,7 @@ TABS.mission_control.initialize = function (callback) {
                 $('#ActionContent').fadeOut(300);
             }
         });
-        
+
         $('#showHideInfoButton').on('click', function () {
             var src = ($(this).children().attr('class') === 'ic_hide')
                 ? 'ic_show'
@@ -1607,7 +1607,7 @@ TABS.mission_control.initialize = function (callback) {
                 $('#InfoContent').fadeOut(300);
             }
         });
-        
+
         $('#showHideSafehomeButton').on('click', function () {
             var src = ($(this).children().attr('class') === 'ic_hide')
                 ? 'ic_show'
@@ -1620,7 +1620,7 @@ TABS.mission_control.initialize = function (callback) {
                 $('#SafehomeContent').fadeOut(300);
             }
         });
-        
+
         $('#showHideHomeButton').on('click', function () {
             var src = ($(this).children().attr('class') === 'ic_hide')
                 ? 'ic_show'
@@ -1633,7 +1633,7 @@ TABS.mission_control.initialize = function (callback) {
                 $('#HomeContent').fadeOut(300);
             }
         });
-        
+
         $('#showHideWPeditButton').on('click', function () {
             var src = ($(this).children().attr('class') === 'ic_hide')
                 ? 'ic_show'
@@ -1646,7 +1646,7 @@ TABS.mission_control.initialize = function (callback) {
                 $('#WPeditContent').fadeOut(300);
             }
         });
-        
+
         /////////////////////////////////////////////
         // Callback for Waypoint edition
         /////////////////////////////////////////////
@@ -1670,7 +1670,7 @@ TABS.mission_control.initialize = function (callback) {
                 redrawLayer();
             }
         });
-        
+
         $('#pointLat').on('change', function (event) {
             if (selectedMarker) {
                 selectedMarker.setLat(Math.round(Number($('#pointLat').val()) * 10000000));
@@ -1683,7 +1683,7 @@ TABS.mission_control.initialize = function (callback) {
                 plotElevation();
             }
         });
-        
+
         $('#pointLon').on('change', function (event) {
             if (selectedMarker) {
                 selectedMarker.setLon(Math.round(Number($('#pointLon').val()) * 10000000));
@@ -1696,7 +1696,7 @@ TABS.mission_control.initialize = function (callback) {
                 plotElevation();
             }
         });
-        
+
         $('#pointAlt').on('change', function (event) {
             if (selectedMarker) {
                 selectedMarker.setAlt(Number($('#pointAlt').val()));
@@ -1706,7 +1706,7 @@ TABS.mission_control.initialize = function (callback) {
                 plotElevation();
             }
         });
-        
+
         $('#pointP1').on('change', function (event) {
             if (selectedMarker) {
                 selectedMarker.setP1(Number($('#pointP1').val()));
@@ -1715,7 +1715,7 @@ TABS.mission_control.initialize = function (callback) {
                 redrawLayer();
             }
         });
-        
+
         $('#pointP2').on('change', function (event) {
             if (selectedMarker) {
                 selectedMarker.setP2(Number($('#pointP2').val()));
@@ -1724,7 +1724,7 @@ TABS.mission_control.initialize = function (callback) {
                 redrawLayer();
             }
         });
-        
+
         $('#pointP3').on('change', function (event) {
             if (selectedMarker) {
                 selectedMarker.setP3( $('#pointP3').prop("checked") ? 1.0 : 0.0);
@@ -1734,7 +1734,7 @@ TABS.mission_control.initialize = function (callback) {
                         $('#elevationValueAtWP').text(elevationAtWP);
                         $('#elevationAtWP').fadeIn(300);
                     })()
-                    
+
                 }
                 else {
                     $('#elevationAtWP').fadeOut(300);
@@ -1745,7 +1745,7 @@ TABS.mission_control.initialize = function (callback) {
                 plotElevation();
             }
         });
-        
+
         /////////////////////////////////////////////
         // Callback for Waypoint Options Table
         /////////////////////////////////////////////
@@ -1760,7 +1760,7 @@ TABS.mission_control.initialize = function (callback) {
                 selectedFeature.setStyle(getWaypointIcon(selectedMarker, true));
             }
         });
-        
+
         $("[data-role='waypointOptions-add']").click(function () {
             if (selectedMarker) {
                 mission.addAttachedFromWaypoint(selectedMarker);
@@ -1772,7 +1772,7 @@ TABS.mission_control.initialize = function (callback) {
                 selectedFeature.setStyle(getWaypointIcon(selectedMarker, true));
             }
         });
-        
+
         /////////////////////////////////////////////
         // Callback for SAFEHOMES Table
         /////////////////////////////////////////////
@@ -1784,13 +1784,13 @@ TABS.mission_control.initialize = function (callback) {
             SAFEHOMES.updateSafehome(tmpSH);
             renderSafehomesTable();
             cleanSafehomeLayers();
-            renderSafehomesOnMap();     
+            renderSafehomesOnMap();
         });
-       
+
         $('#cancelSafehome').on('click', function () {
             closeSafehomePanel();
         });
-        
+
         $('#loadEepromSafehomeButton').on('click', function () {
             $(this).addClass('disabled');
             GUI.log('Start of getting Safehome points');
@@ -1802,9 +1802,9 @@ TABS.mission_control.initialize = function (callback) {
                 GUI.log('End of getting Safehome points');
                 $('#loadEepromSafehomeButton').removeClass('disabled');
             }, 500);
-            
+
         });
-        
+
         $('#saveEepromSafehomeButton').on('click', function () {
             $(this).addClass('disabled');
             GUI.log('Start of sending Safehome points');
@@ -1815,7 +1815,7 @@ TABS.mission_control.initialize = function (callback) {
                 $('#saveEepromSafehomeButton').removeClass('disabled');
             }, 500);
         });
-        
+
         /////////////////////////////////////////////
         // Callback for HOME Table
         /////////////////////////////////////////////
@@ -1825,15 +1825,15 @@ TABS.mission_control.initialize = function (callback) {
             HOME.setLat(Math.round(ol.proj.toLonLat(mapCenter)[1] * 1e7));
             updateHome();
         });
-        
+
         $('#cancelHome').on('click', function () {
             closeHomePanel();
         });
-        
+
         $('#cancelPlot').on('click', function () {
             closeHomePanel();
         });
-        
+
         /////////////////////////////////////////////
         // Callback for Remove buttons
         /////////////////////////////////////////////
@@ -1875,11 +1875,11 @@ TABS.mission_control.initialize = function (callback) {
                 }
             }
         });
-        
-        
+
+
         /////////////////////////////////////////////
         // Callback for Save/load buttons
-        /////////////////////////////////////////////       
+        /////////////////////////////////////////////
         $('#loadFileMissionButton').on('click', function () {
             if (markers.length && !confirm(chrome.i18n.getMessage('confirm_delete_all_points'))) return;
             removeAllWaypoints();
@@ -1912,7 +1912,7 @@ TABS.mission_control.initialize = function (callback) {
             sendWaypointsToFC();
             GUI.log('End send point');
             $('#saveMissionButton').removeClass('disabled');
-            
+
         });
 
         $('#loadEepromMissionButton').on('click', function () {
@@ -1921,7 +1921,7 @@ TABS.mission_control.initialize = function (callback) {
             GUI.log(chrome.i18n.getMessage('eeprom_load_ok'));
             MSP.send_message(MSPCodes.MSP_WP_MISSION_LOAD, [0], getWaypointsFromFC);
         });
-        
+
         $('#saveEepromMissionButton').on('click', function () {
             $(this).addClass('disabled');
             GUI.log('Start send point');
@@ -1943,7 +1943,7 @@ TABS.mission_control.initialize = function (callback) {
             saveSettings();
             if (settings.safeRadiusSH != oldSafeRadiusSH  && $('#showHideSafehomeButton').is(":visible")) {
                 cleanSafehomeLayers();
-                renderSafehomesOnMap(); 
+                renderSafehomesOnMap();
                 $('#SafeHomeSafeDistance').text(settings.safeRadiusSH);
             }
             closeSettingsPanel();
@@ -1953,7 +1953,7 @@ TABS.mission_control.initialize = function (callback) {
             loadSettings();
             closeSettingsPanel();
         });
-        
+
 
 
         updateTotalInfo();
@@ -2075,7 +2075,7 @@ TABS.mission_control.initialize = function (callback) {
                     map.getView().setCenter(coord);
                     map.getView().setZoom(16);
                 }
-                
+
                 redrawLayers();
                 updateHome();
                 updateTotalInfo();
@@ -2095,14 +2095,14 @@ TABS.mission_control.initialize = function (callback) {
 
         var data = {
             'version': { $: { 'value': '2.3-pre8' } },
-            'mwp': { $: { 'cx': (Math.round(center[0] * 10000000) / 10000000), 
-                          'cy': (Math.round(center[1] * 10000000) / 10000000), 
+            'mwp': { $: { 'cx': (Math.round(center[0] * 10000000) / 10000000),
+                          'cy': (Math.round(center[1] * 10000000) / 10000000),
                           'home-x' : HOME.getLonMap(),
                           'home-y' : HOME.getLatMap(),
                           'zoom': zoom } },
             'missionitem': []
         };
-        
+
         mission.get().forEach(function (waypoint) {
             var point = { $: {
                         'no': waypoint.getNumber()+1,
@@ -2116,7 +2116,7 @@ TABS.mission_control.initialize = function (callback) {
                     } };
             data.missionitem.push(point);
         });
-        
+
         var builder = new window.xml2js.Builder({ 'rootName': 'mission', 'renderOpts': { 'pretty': true, 'indent': '\t', 'newline': '\n' } });
         var xml = builder.buildObject(data);
         fs.writeFile(filename, xml, (err) => {
@@ -2148,7 +2148,7 @@ TABS.mission_control.initialize = function (callback) {
             updateTotalInfo();
         }, 2000);
     }
-    
+
     function sendWaypointsToFC() {
         MISSION_PLANER.reinit();
         MISSION_PLANER.copy(mission);
@@ -2169,26 +2169,26 @@ TABS.mission_control.initialize = function (callback) {
     }
 
 
-    
+
     function updateTotalInfo() {
         if (CONFIGURATOR.connectionValid) {
             $('#availablePoints').text(mission.getCountBusyPoints() + '/' + mission.getMaxWaypoints());
             $('#missionValid').html(mission.getValidMission() ? chrome.i18n.getMessage('armingCheckPass') : chrome.i18n.getMessage('armingCheckFail'));
         }
-    }   
-    
+    }
+
 
     function updateFilename(filename) {
         $('#missionFilename').text(filename);
         $('#infoMissionFilename').show();
     }
-    
+
     function changeSwitchery(element, checked) {
       if ( ( element.is(':checked') && checked == false ) || ( !element.is(':checked') && checked == true ) ) {
         element.parent().find('.switcherymid').trigger('click');
       }
     }
-    
+
     function plotElevation() {
         if ($('#missionPlanerElevation').is(":visible")) {
             if (mission.get().length == 0) {


### PR DESCRIPTION
Swaps longitude and latitude to more conventional order of Lat, Long in Mission Control Safehome and Home tables.

Also reformats text sizing/column widths to make tables more readable.

Saved with trailing whitespace removed ... not sure if this is an issue ? 