### PR TITLE
Mission control altitude sanity checking + other altitude/elevation related changes

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3346,7 +3346,7 @@
     },
     "osdSettingPLUS_CODE_DIGITS_HELP": {
         "message": "Precision at the equator: 10=13.9x13.9m; 11=2.8x3.5m; 12=56x87cm; 13=11x22cm."
-    }, 
+    },
     "osdSettingPLUS_CODE_SHORT_HELP": {
         "message": "Removing 2, 4 and 6 leading digits requires a reference location within, respectively, ~800km, ~40km and ~2km to recover the original coordinates."
     },
@@ -3997,6 +3997,12 @@
     },
     "MissionPlannerJumpTargetRemoval": {
         "message": "You can't remove a Waypoint which is defined as a JUMP target! \nYou first need to remove the target on the waypoint triggering the JUMP."
+    },
+    "MissionPlannerAltitudeChangeReset": {
+        "message": "Altitude below ground level. Change ignored"
+    },
+    "MissionPlannerAltitudeSetDefault": {
+        "message": "Altitude below ground level, setting to default"
     },
     "SafehomeSelected": {
         "message": ""

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -4001,9 +4001,6 @@
     "MissionPlannerAltitudeChangeReset": {
         "message": "Altitude below ground level. Change ignored"
     },
-    "MissionPlannerAltitudeSetDefault": {
-        "message": "Altitude below ground level, setting to default"
-    },
     "SafehomeSelected": {
         "message": ""
     },

--- a/js/waypoint.js
+++ b/js/waypoint.js
@@ -139,10 +139,8 @@ let Waypoint = function (number, action, lat, lon, alt=0, p1=0, p2=0, p3=0, endM
     self.getElevation = async function (globalSettings) {
         let elevation;
         if (globalSettings.mapProviderType == 'bing') {
-            let elevationEarthModel = "ellipsoid";
-            if ($('#elevationEarthModel').prop("checked")) {
-                elevationEarthModel = "sealevel";
-            }
+            let elevationEarthModel = $('#elevationEarthModel').prop("checked") ? "sealevel" : "ellipsoid";
+
             const response = await fetch('http://dev.virtualearth.net/REST/v1/Elevation/List?points='+self.getLatMap()+','+self.getLonMap()+'&heights='+elevationEarthModel+'&key='+globalSettings.mapApiKey);
             const myJson = await response.json();
             elevation = myJson.resourceSets[0].resources[0].elevations[0];

--- a/js/waypoint.js
+++ b/js/waypoint.js
@@ -15,7 +15,7 @@ let Waypoint = function (number, action, lat, lon, alt=0, p1=0, p2=0, p3=0, endM
     self.setNumber = function (data) {
         number = data;
     };
-    
+
     self.getLayerNumber = function () {
         return layerNumber;
     };
@@ -23,7 +23,7 @@ let Waypoint = function (number, action, lat, lon, alt=0, p1=0, p2=0, p3=0, endM
     self.setLayerNumber = function (data) {
         layerNumber = data;
     };
-    
+
     self.getPoiNumber = function () {
         return poiNumber;
     };
@@ -31,7 +31,7 @@ let Waypoint = function (number, action, lat, lon, alt=0, p1=0, p2=0, p3=0, endM
     self.setPoiNumber = function (data) {
         poiNumber = data;
     };
-    
+
     self.isUsed = function () {
         return isUsed;
     };
@@ -39,7 +39,7 @@ let Waypoint = function (number, action, lat, lon, alt=0, p1=0, p2=0, p3=0, endM
     self.setUsed = function (data) {
         isUsed = data;
     };
-    
+
     self.isAttached = function () {
         return isAttached;
     };
@@ -51,7 +51,7 @@ let Waypoint = function (number, action, lat, lon, alt=0, p1=0, p2=0, p3=0, endM
     self.getLon = function () {
         return lon;
     };
-    
+
     self.getLonMap = function () {
         return lon / 10000000;
     };
@@ -63,7 +63,7 @@ let Waypoint = function (number, action, lat, lon, alt=0, p1=0, p2=0, p3=0, endM
     self.getLat = function () {
         return lat;
     };
-    
+
     self.getLatMap = function () {
         return lat / 10000000;
     };
@@ -71,55 +71,55 @@ let Waypoint = function (number, action, lat, lon, alt=0, p1=0, p2=0, p3=0, endM
     self.setLat = function (data) {
         lat = data;
     };
-    
+
     self.getAction = function () {
         return action;
     };
-    
+
     self.setAction = function (data) {
         action = data;
     };
-    
+
     self.getAlt = function () {
         return alt;
     };
-    
+
     self.setAlt = function (data) {
         alt = data;
     };
-    
+
     self.getP1 = function () {
         return p1;
     };
-    
+
     self.setP1 = function (data) {
         p1 = data;
     };
-    
+
     self.getP2 = function () {
         return p2;
     };
-    
+
     self.setP2 = function (data) {
         p2 = data;
     };
-    
+
     self.getP3 = function () {
         return p3;
     };
-    
+
     self.setP3 = function (data) {
         p3 = data;
     };
-    
+
     self.getEndMission = function () {
         return endMission;
     };
-    
+
     self.setEndMission = function (data) {
         endMission = data;
     };
-    
+
     self.getAttachedId = function () {
         return attachedId;
     };
@@ -127,7 +127,7 @@ let Waypoint = function (number, action, lat, lon, alt=0, p1=0, p2=0, p3=0, endM
     self.setAttachedId = function (data) {
         attachedId = data;
     };
-    
+
     self.getAttachedNumber = function () {
         return attachedNumber;
     };
@@ -135,16 +135,20 @@ let Waypoint = function (number, action, lat, lon, alt=0, p1=0, p2=0, p3=0, endM
     self.setAttachedNumber = function (data) {
         attachedNumber = data;
     };
-    
+
     self.getElevation = async function (globalSettings) {
         let elevation;
         if (globalSettings.mapProviderType == 'bing') {
-            const response = await fetch('http://dev.virtualearth.net/REST/v1/Elevation/List?points='+self.getLatMap()+','+self.getLonMap()+'&heights=ellipsoid&key='+globalSettings.mapApiKey);
-            const myJson = await response.json(); 
+            let elevationEarthModel = "ellipsoid";
+            if ($('#elevationEarthModel').prop("checked")) {
+                elevationEarthModel = "sealevel";
+            }
+            const response = await fetch('http://dev.virtualearth.net/REST/v1/Elevation/List?points='+self.getLatMap()+','+self.getLonMap()+'&heights='+elevationEarthModel+'&key='+globalSettings.mapApiKey);
+            const myJson = await response.json();
             elevation = myJson.resourceSets[0].resources[0].elevations[0];
         }
         else {
-            elevation = "NA";
+            elevation = "N/A";
         }
         return elevation;
     }

--- a/js/waypointCollection.js
+++ b/js/waypointCollection.js
@@ -424,10 +424,8 @@ let WaypointCollection = function () {
             samples = 1024;
         }
         if (globalSettings.mapProviderType == 'bing') {
-            let elevationEarthModel = "ellipsoid";
-            if ($('#elevationEarthModel').prop("checked")) {
-                elevationEarthModel = "sealevel";
-            }
+            let elevationEarthModel = $('#elevationEarthModel').prop("checked") ? "sealevel" : "ellipsoid";
+
             if (point2measure.length >1) {
                 const response = await fetch('http://dev.virtualearth.net/REST/v1/Elevation/Polyline?points='+point2measure+'&heights='+elevationEarthModel+'&samples='+String(samples+1)+'&key='+globalSettings.mapApiKey);
                 const myJson = await response.json();

--- a/js/waypointCollection.js
+++ b/js/waypointCollection.js
@@ -10,7 +10,7 @@ let WaypointCollection = function () {
         countBusyPoints = 0,
         version = 0,
         center = {}
-        
+
     self.getMaxWaypoints = function () {
         return maxWaypoints;
     };
@@ -18,15 +18,15 @@ let WaypointCollection = function () {
     self.setMaxWaypoints = function (data) {
         maxWaypoints = data;
     };
-    
+
     self.getValidMission = function () {
         return isValidMission;
     };
-    
+
     self.setValidMission = function (data) {
         isValidMission = data;
     };
-    
+
     self.getCountBusyPoints = function () {
         return countBusyPoints;
     };
@@ -34,7 +34,7 @@ let WaypointCollection = function () {
     self.setCountBusyPoints = function (data) {
         countBusyPoints = data;
     };
-    
+
     self.getVersion = function () {
         return version;
     };
@@ -42,11 +42,11 @@ let WaypointCollection = function () {
     self.setVersion = function (data) {
         version = data;
     };
-    
+
     self.getCenter = function () {
         return center;
     };
-    
+
     self.setCenter = function (data) {
         center = data;
     };
@@ -54,11 +54,11 @@ let WaypointCollection = function () {
     self.setCenterZoom = function (data) {
         center.zoom = data;
     };
-    
+
     self.setCenterLon = function (data) {
         center.lon = data;
     };
-    
+
     self.setCenterLat = function (data) {
         center.lat = data;
     };
@@ -70,7 +70,7 @@ let WaypointCollection = function () {
     self.get = function () {
         return data;
     };
-    
+
     self.isEmpty = function () {
         return data == [];
     };
@@ -78,7 +78,7 @@ let WaypointCollection = function () {
     self.flush = function () {
         data = [];
     };
-    
+
     self.reinit = function () {
         data = [];
         maxWaypoints = 60;
@@ -99,13 +99,13 @@ let WaypointCollection = function () {
             }
         }
     };
-    
+
     self.updateWaypoint = function(newWaypoint) {
         if (newWaypoint.isUsed()) {
             data[newWaypoint.getNumber()] = newWaypoint;
         }
     };
-    
+
     self.dropWaypoint = function(newWaypoint) {
         self.getWaypoint(newWaypoint.getNumber()).setUsed(false);
         let indexId = newWaypoint.getNumber()
@@ -120,7 +120,7 @@ let WaypointCollection = function () {
         data.splice(indexId, 1);
 
     };
-    
+
     self.insertWaypoint = function (newWaypoint, indexId) {
         data.forEach(function (wp) {
             if (wp.getNumber() >= indexId) {
@@ -133,7 +133,7 @@ let WaypointCollection = function () {
         data.splice(indexId, 0, newWaypoint);
     };
 
-    
+
     self.drop = function (waypointId) {
         self.getWaypoint(waypointId).setUsed(false);
         var tmpData = [];
@@ -148,7 +148,7 @@ let WaypointCollection = function () {
 
         data = tmpData;
     };
-    
+
     self.update = function (bMWPfile=false, bReverse=false) {
         let oldWPNumber = 0;
         let optionIdx = 0;
@@ -167,7 +167,7 @@ let WaypointCollection = function () {
                         element.setP1(element.getP1()+1);
                     }
                 }
-                
+
                 if ([MWNP.WPTYPE.JUMP,MWNP.WPTYPE.SET_HEAD,MWNP.WPTYPE.RTH].includes(element.getAction())) {
                     element.setAttachedId(oldWPNumber);
                     element.setAttachedNumber(optionIdx);
@@ -189,7 +189,7 @@ let WaypointCollection = function () {
             }
         });
     };
-    
+
     self.getNonAttachedList = function () {
         let tmpData = [];
         data.forEach(function (element) {
@@ -199,8 +199,8 @@ let WaypointCollection = function () {
         });
 
         return tmpData;
-    } 
-    
+    }
+
     self.getAttachedList = function () {
         let tmpData = [];
         data.forEach(function (element) {
@@ -210,8 +210,8 @@ let WaypointCollection = function () {
         });
 
         return tmpData;
-    } 
-    
+    }
+
     self.getAttachedFromWaypoint = function (waypoint) {
         let tmpData = [];
         data.forEach(function (element) {
@@ -221,8 +221,8 @@ let WaypointCollection = function () {
         });
 
         return tmpData;
-    } 
-    
+    }
+
     self.addAttachedFromWaypoint = function (waypoint) {
         let tmpNumber = 0;
         let tmpData = self.getAttachedFromWaypoint(waypoint);
@@ -234,8 +234,8 @@ let WaypointCollection = function () {
         tempWp.setAttachedId(waypoint.getNumber());
         self.insertWaypoint(tempWp, waypoint.getNumber()+tmpNumber+1);
         self.update();
-    } 
-    
+    }
+
     self.dropAttachedFromWaypoint = function (waypoint, waypointAttachedNumber) {
         data.forEach(function (element) {
             if (element.isAttached() && element.getAttachedId() == waypoint.getNumber() && element.getAttachedNumber() == waypointAttachedNumber) {
@@ -243,9 +243,9 @@ let WaypointCollection = function () {
                 self.update();
             }
         });
-        
-    } 
-    
+
+    }
+
     self.extractBuffer = function(waypointId) {
         let buffer = [];
         let waypoint = self.getWaypoint(waypointId);
@@ -270,10 +270,10 @@ let WaypointCollection = function () {
         buffer.push(lowByte(waypoint.getP3())); //sbufReadU16(src);       // P3
         buffer.push(highByte(waypoint.getP3()));
         buffer.push(waypoint.getEndMission()); //sbufReadU8(src);      // future: to set nav flag
-        
+
         return buffer;
     }
-    
+
     self.missionDisplayDebug = function() {
         if (data && data.length != 0) {
             data.forEach(function (element) {
@@ -289,7 +289,7 @@ let WaypointCollection = function () {
             });
         }
     }
-    
+
     self.copy = function(mission){
         mission.get().forEach(function (element) {
             self.put(element);
@@ -300,7 +300,7 @@ let WaypointCollection = function () {
         self.setVersion(mission.getVersion());
         self.setCenter(mission.getCenter());
     }
-    
+
     self.convertJumpNumberToWaypoint = function(jumpId) {
         let outputNumber = 0;
         self.getNonAttachedList().forEach(function (element) {
@@ -310,7 +310,7 @@ let WaypointCollection = function () {
         });
         return outputNumber;
     }
-    
+
     self.isJumpTargetAttached = function(waypoint) {
         let lJumptTargetAttached = [];
         data.forEach(function (element) {
@@ -320,7 +320,7 @@ let WaypointCollection = function () {
         });
         return (lJumptTargetAttached.length != 0 && lJumptTargetAttached != 'undefined')
     }
-    
+
     self.getPoiList = function() {
         let poiList = [];
         data.forEach(function (element) {
@@ -330,7 +330,7 @@ let WaypointCollection = function () {
         });
         return poiList;
     }
-    
+
     self.getPoint2Measure = function(reverse=false) {
         let point2measure = [];
         let altPoint2measure = [];
@@ -383,10 +383,10 @@ let WaypointCollection = function () {
                 nStart++;
             }
         }
-        
+
         return [nLoop, point2measure, altPoint2measure, namePoint2measure, refPoint2measure];
     }
-    
+
     self.getDistance = function(display) {
         let lengthLine = [];
         const [nLoop, point2measure, altPoint2measure, namePoint2measure, refPoint2measure] = self.getPoint2Measure();
@@ -394,9 +394,9 @@ let WaypointCollection = function () {
             return [-1];
         }
         else {
-        
+
             const cumulativeSum = (sum => value => sum += value)(0);
-            
+
             let oldCoord = [];
             point2measure.forEach(function (coord) {
                 if (oldCoord != 'undefined' && oldCoord != []) {
@@ -408,7 +408,7 @@ let WaypointCollection = function () {
             return lengthLine.map(cumulativeSum);
         }
     }
-    
+
     self.getElevation = async function(globalSettings) {
         const [nLoop, point2measure, altPoint2measure, namePoint2measure, refPoint2measure] = self.getPoint2Measure(true);
         let lengthMission = self.getDistance(true);
@@ -424,19 +424,23 @@ let WaypointCollection = function () {
             samples = 1024;
         }
         if (globalSettings.mapProviderType == 'bing') {
+            let elevationEarthModel = "ellipsoid";
+            if ($('#elevationEarthModel').prop("checked")) {
+                elevationEarthModel = "sealevel";
+            }
             if (point2measure.length >1) {
-                const response = await fetch('http://dev.virtualearth.net/REST/v1/Elevation/Polyline?points='+point2measure+'&heights=ellipsoid&samples='+String(samples+1)+'&key='+globalSettings.mapApiKey);
-                const myJson = await response.json(); 
+                const response = await fetch('http://dev.virtualearth.net/REST/v1/Elevation/Polyline?points='+point2measure+'&heights='+elevationEarthModel+'&samples='+String(samples+1)+'&key='+globalSettings.mapApiKey);
+                const myJson = await response.json();
                 elevation = myJson.resourceSets[0].resources[0].elevations;
             }
             else {
-                const response = await fetch('http://dev.virtualearth.net/REST/v1/Elevation/List?points='+point2measure+'&heights=ellipsoid&key='+globalSettings.mapApiKey);
-                const myJson = await response.json(); 
+                const response = await fetch('http://dev.virtualearth.net/REST/v1/Elevation/List?points='+point2measure+'&heights='+elevationEarthModel+'&key='+globalSettings.mapApiKey);
+                const myJson = await response.json();
                 elevation = myJson.resourceSets[0].resources[0].elevations;
             }
         }
         else {
-            elevation = "NA";
+            elevation = "N/A";
         }
         //console.log("elevation ", elevation);
         return [lengthMission, totalMissionDistance, samples, elevation, altPoint2measure, namePoint2measure, refPoint2measure];

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -13,7 +13,7 @@
                         </div>
                     </div>
                     <div class="spacer" id="ActionContent">
-                        
+
                         <div class="btn save_btn">
                             <a id="loadFileMissionButton" class="btnicon ic_loadFromFile" href="#" title="Load Mission File"></a>
                             <a id="saveFileMissionButton" class="btnicon ic_save2File" href="#" title="Save Mission File"></a>
@@ -86,7 +86,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div id="missionPlanerHome" class="gui_box grey" style="display: none">
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title i18n-replaced" data-i18n="missionHomeHead">Take Off home</div>
@@ -110,10 +110,10 @@
                                 </thead>
                                 <tbody id="homeTableBody">
                                     <tr>
-                                    <td><div id="viewHomePoint" class="btnTable btnTableIcon"> 
-                                            <a class="ic_center" data-role="home-center" href="#"  title="move to center view"></a> 
+                                    <td><div id="viewHomePoint" class="btnTable btnTableIcon">
+                                            <a class="ic_center" data-role="home-center" href="#"  title="move to center view"></a>
                                         </div>
-                                    </td> 
+                                    </td>
                                     <td><input type="number" class="home-lon" /></td>
                                     <td><input type="number" class="home-lat" /></td>
                                     <td><span id="elevationValueAtHome">NA</span></td>
@@ -122,8 +122,12 @@
                             </table>
                         </div>
                     </div>
+                    <div class="point" id="elevationEarthModelclass" style="display: none">
+                        <label class="spacer_box_title i18n-replaced" for="elevationEarthModel">Use Sea Level Earth DEM Model: </label>
+                        <input id="elevationEarthModel" type="checkbox" value="0" class="togglemedium" required>
+                    </div>
                 </div>
-                
+
                 <div id="missionPlanerSafehome" class="gui_box grey" style="display: none">
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title i18n-replaced" data-i18n="missionSafehomeHead">Safe Home manager</div>
@@ -215,7 +219,11 @@
                         </div>
                         <div class="point" id="elevationAtWP" style="display: none">
                             <label class="point-label">Elevation (m): </label>
-                            <span id="elevationValueAtWP">NA</span>
+                            <span id="elevationValueAtWP">N/A</span>
+                        </div>
+                        <div class="point" id="groundClearanceAtWP" style="display: none">
+                            <label class="point-label">Grd Dist (m): </label>
+                            <span id="groundClearanceValueAtWP">N/A</span>
                         </div>
                         <div class="point" id="pointP1class" style="display: none">
                             <label class="point-label" for="pointP1">Parameter 1: </label>
@@ -244,7 +252,7 @@
                             </tbody>
                         </table>
                         </div>
-                        
+
 						<!-- <div class="point-radio" id="pointOptionclass" style="display: none">
 							<div class="radio-line">
 								<input type="radio" id="Options_None" name="Options" value="None" checked>
@@ -256,7 +264,7 @@
 								<input type="checkbox" id="Options_LandRTH">
 								<label for="Options_LandRTH">Land after RTH</label><br>
 							</div>
-							<div class="radio-line">	
+							<div class="radio-line">
 								<input type="radio" id="Options_JUMP" name="Options" value="JUMP">
 								<label class="radio-options" for="Options_JUMP">JUMP</label>
 								<label for="Options_TargetJUMP">Target WP: </label>
@@ -264,14 +272,14 @@
 								<label for="Options_NumberJUMP">Repeat: </label>
 								<input id="Options_NumberJUMP" type="text" value="0" required><br>
 							</div>
-							<div class="radio-line">	
+							<div class="radio-line">
 								<input type="radio" id="Options_HEAD" name="Options" value="SET_HEAD">
 								<label class="radio-options" for="Options_HEAD">HEAD</label>
 								<label for="Options_HeadingHead">Heading: </label>
 								<input id="Options_HeadingHead" type="text" value="-1" required><br>
 							</div>
                         </div> -->
-						
+
                     </div>
                 </div>
             </div>

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -116,7 +116,7 @@
                                     </td>
                                     <td><input type="number" class="home-lon" /></td>
                                     <td><input type="number" class="home-lat" /></td>
-                                    <td><span id="elevationValueAtHome">NA</span></td>
+                                    <td><span id="elevationValueAtHome">N/A</span></td>
                                     </tr>
                                 </tbody>
                             </table>

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -108,7 +108,7 @@ TABS.mission_control.initialize = function (callback) {
             $('#saveEepromMissionButton').hide();
             isOffline = true;
         }
-        
+
         $safehomesTable = $('.safehomesTable');
         $safehomesTableBody = $('#safehomesTableBody');
         $waypointOptionsTable = $('.waypointOptionsTable');
@@ -140,7 +140,7 @@ TABS.mission_control.initialize = function (callback) {
         function get_attitude_data() {
             MSP.send_message(MSPCodes.MSP_ATTITUDE, false, false, update_gpsTrack);
         }
-      
+
         function update_gpsTrack() {
 
           let lat = GPS_DATA.lat / 10000000;
@@ -338,29 +338,29 @@ TABS.mission_control.initialize = function (callback) {
 
     ///////////////////////////////////////////////
     //
-    // define & init parameters 
+    // define & init parameters
     //
     ///////////////////////////////////////////////
-    
+
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init parameters for Map Layer
     //////////////////////////////////////////////////////////////////////////////////////////////
     var markers = [];           // Layer for Waypoints
     var lines = [];             // Layer for lines between waypoints
     var safehomeMarkers =[];    // layer for Safehome points
-    
+
     var map;
-    
+
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init parameters for Selected Marker
     //////////////////////////////////////////////////////////////////////////////////////////////
     var selectedMarker = null;
     var selectedFeature = null;
     var tempMarker = null;
-    
+
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init parameters for default Settings
-    //////////////////////////////////////////////////////////////////////////////////////////////   
+    //////////////////////////////////////////////////////////////////////////////////////////////
     var vMaxDistSH = 0;
     var settings = {};
     if (CONFIGURATOR.connectionValid) {
@@ -381,23 +381,23 @@ TABS.mission_control.initialize = function (callback) {
     }
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init Waypoints parameters
-    //////////////////////////////////////////////////////////////////////////////////////////////    
+    //////////////////////////////////////////////////////////////////////////////////////////////
     var mission = new WaypointCollection();
-    
+
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init home parameters
-    ////////////////////////////////////////////////////////////////////////////////////////////// 
+    //////////////////////////////////////////////////////////////////////////////////////////////
     var HOME = new Waypoint(0,0,0,0);
     var homeMarkers =[];    // layer for home point
-    
+
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init Safehome parameters
-    //////////////////////////////////////////////////////////////////////////////////////////////    
+    //////////////////////////////////////////////////////////////////////////////////////////////
     //var SAFEHOMES = new SafehomeCollection(); // TO COMMENT FOR RELEASE : DECOMMENT FOR DEBUG
     //SAFEHOMES.inflate(); // TO COMMENT FOR RELEASE : DECOMMENT FOR DEBUG
     //var safehomeRangeRadius = 200; //meters
     //var safehomeSafeRadius = 50; //meters
-    
+
     /////////////////////////////////////////////
     //
     // Reinit Jquery Form
@@ -413,11 +413,11 @@ TABS.mission_control.initialize = function (callback) {
         $('#missionDistance').text(0);
         $('#MPeditPoint').fadeOut(300);
     }
-    
+
     function clearFilename() {
         $('#missionFilename').text('');
     }
-    
+
     /////////////////////////////////////////////
     //
     // Manage Settings
@@ -441,21 +441,21 @@ TABS.mission_control.initialize = function (callback) {
         $('#MPdefaultPointSpeed').val(String(settings.speed));
         $('#MPdefaultSafeRangeSH').val(String(settings.safeRadiusSH));
     }
-    
+
     function closeSettingsPanel() {
         $('#missionPlanerSettings').hide();
-    }    
-    
+    }
+
     /////////////////////////////////////////////
     //
     // Manage Safehome
     //
-    /////////////////////////////////////////////  
+    /////////////////////////////////////////////
     function closeSafehomePanel() {
         $('#missionPlanerSafehome').hide();
         cleanSafehomeLayers();
-    } 
-    
+    }
+
     function renderSafehomesTable() {
         /*
          * Process safehome table UI
@@ -480,10 +480,10 @@ TABS.mission_control.initialize = function (callback) {
                 ');
 
                 const $row = $safehomesTableBody.find('tr:last');
-                
-                
+
+
                 $row.find(".safehome-number").text(safehome.getNumber()+1);
-                
+
                 $row.find(".safehome-enabled-value").prop('checked',safehome.isUsed()).change(function () {
                     safehome.setEnabled((($(this).prop('checked')) ? 1 : 0));
                     SAFEHOMES.updateSafehome(safehome);
@@ -497,7 +497,7 @@ TABS.mission_control.initialize = function (callback) {
                     cleanSafehomeLayers();
                     renderSafehomesOnMap();
                 });
-                
+
                 $row.find(".safehome-lat").val(safehome.getLatMap()).change(function () {
                     safehome.setLat(Math.round(Number($(this).val()) * 10000000));
                     SAFEHOMES.updateSafehome(safehome);
@@ -511,8 +511,8 @@ TABS.mission_control.initialize = function (callback) {
         GUI.switchery();
         localize();
     }
-    
-    
+
+
     function renderSafehomesOnMap() {
         /*
          * Process safehome on Map
@@ -521,14 +521,14 @@ TABS.mission_control.initialize = function (callback) {
             map.addLayer(addSafeHomeMarker(safehome));
         });
     }
-    
-    function cleanSafehomeLayers() {       
+
+    function cleanSafehomeLayers() {
         for (var i in safehomeMarkers) {
             map.removeLayer(safehomeMarkers[i]);
         }
         safehomeMarkers = [];
     }
-    
+
     function getSafehomeIcon(safehome) {
         /*
          * Process Safehome Icon
@@ -554,7 +554,7 @@ TABS.mission_control.initialize = function (callback) {
             }))
         });
     }
-    
+
     function addSafeHomeMarker(safehome) {
         /*
          * add safehome on Map
@@ -566,7 +566,7 @@ TABS.mission_control.initialize = function (callback) {
         });
 
         //iconFeature.setStyle(getSafehomeIcon(safehome, safehome.isUsed()));
-        
+
         let circleStyle = new ol.style.Style({
             stroke: new ol.style.Stroke({
                 color: 'rgba(144, 12, 63, 0.5)',
@@ -577,7 +577,7 @@ TABS.mission_control.initialize = function (callback) {
                 // color: 'rgba(251, 225, 155, 0.1)'
             // })
         });
-        
+
         let circleSafeStyle = new ol.style.Style({
             stroke: new ol.style.Stroke({
                 color: 'rgba(136, 204, 62, 1)',
@@ -588,7 +588,7 @@ TABS.mission_control.initialize = function (callback) {
                 color: 'rgba(136, 204, 62, 0.1)'
             }) */
         });
-        
+
         var vectorLayer = new ol.layer.Vector({
             source: new ol.source.Vector({
                         features: [iconFeature]
@@ -608,9 +608,9 @@ TABS.mission_control.initialize = function (callback) {
         vectorLayer.kind = "safehome";
         vectorLayer.number = safehome.getNumber();
         vectorLayer.selection = false;
-        
+
         safehomeMarkers.push(vectorLayer);
-        
+
         return vectorLayer;
     }
 
@@ -621,7 +621,7 @@ TABS.mission_control.initialize = function (callback) {
         let radiusProjected = (radius / ol.proj.METERS_PER_UNIT.m) * resolutionRate;
         return radiusProjected;
     }
-    
+
     /////////////////////////////////////////////
     //
     // Manage Take Off Home
@@ -632,47 +632,47 @@ TABS.mission_control.initialize = function (callback) {
         $('#missionPlanerElevation').hide();
         cleanHomeLayers();
     }
-    
-    function cleanHomeLayers() {       
+
+    function cleanHomeLayers() {
         for (var i in homeMarkers) {
             map.removeLayer(homeMarkers[i]);
         }
         homeMarkers = [];
     }
-    
+
     function renderHomeTable() {
         /*
          * Process home table UI
-         */                
+         */
 
         $(".home-lon").val(HOME.getLonMap()).change(function () {
             HOME.setLon(Math.round(Number($(this).val()) * 10000000));
             cleanHomeLayers();
             renderHomeOnMap();
         });
-        
+
         $(".home-lat").val(HOME.getLatMap()).change(function () {
             HOME.setLat(Math.round(Number($(this).val()) * 10000000));
             cleanHomeLayers();
             renderHomeOnMap();
         });
-        
+
         (async () => {
             const elevationAtHome = await HOME.getElevation(globalSettings);
             $('#elevationValueAtHome').text(elevationAtHome+' m');
             HOME.setAlt(elevationAtHome);
         })()
-        
+
     }
-    
-    
+
+
     function renderHomeOnMap() {
         /*
          * Process home on Map
          */
         map.addLayer(addHomeMarker(HOME));
     }
-    
+
     function addHomeMarker(home) {
         /*
          * add safehome on Map
@@ -684,7 +684,7 @@ TABS.mission_control.initialize = function (callback) {
         });
 
         //iconFeature.setStyle(getSafehomeIcon(safehome, safehome.isUsed()));
-        
+
         var vectorLayer = new ol.layer.Vector({
             source: new ol.source.Vector({
                         features: [iconFeature]
@@ -698,12 +698,12 @@ TABS.mission_control.initialize = function (callback) {
         vectorLayer.kind = "home";
         vectorLayer.number = home.getNumber();
         vectorLayer.selection = false;
-        
+
         homeMarkers.push(vectorLayer);
-        
+
         return vectorLayer;
     }
-    
+
     function getHomeIcon(home) {
         /*
          * Process Safehome Icon
@@ -722,23 +722,23 @@ TABS.mission_control.initialize = function (callback) {
     function updateHome() {
         renderHomeTable();
         cleanHomeLayers();
-        renderHomeOnMap();     
-        plotElevation();    
+        renderHomeOnMap();
+        plotElevation();
     }
     /////////////////////////////////////////////
     //
     // Manage Waypoint
     //
     /////////////////////////////////////////////
-    
+
     function removeAllWaypoints() {
-        mission.reinit(); 
+        mission.reinit();
         cleanLayers();
         clearEditForm();
         updateTotalInfo();
         clearFilename();
     }
-    
+
     function addWaypointMarker(waypoint, isEdit=false) {
 
         let coord = ol.proj.fromLonLat([waypoint.getLonMap(), waypoint.getLatMap()]);
@@ -756,7 +756,7 @@ TABS.mission_control.initialize = function (callback) {
         var vectorLayer = new ol.layer.Vector({
             source: vectorSource
         });
-        
+
         vectorLayer.kind = "waypoint";
         vectorLayer.number = waypoint.getNumber();
         vectorLayer.layerNumber = waypoint.getLayerNumber();
@@ -774,7 +774,7 @@ TABS.mission_control.initialize = function (callback) {
             5:    'POI',
             8:    'LDG'
         };
-        
+
         return new ol.style.Style({
             image: new ol.style.Icon(({
                 anchor: [0.5, 1],
@@ -796,8 +796,8 @@ TABS.mission_control.initialize = function (callback) {
             }))
         });
     }
-    
-    
+
+
     function repaintLine4Waypoints(mission) {
         let oldPos,
             oldAction,
@@ -809,7 +809,7 @@ TABS.mission_control.initialize = function (callback) {
         cleanLines();
         mission.get().forEach(function (element) {
             if (!element.isAttached()) {
-                let coord = ol.proj.fromLonLat([element.getLonMap(), element.getLatMap()]);                
+                let coord = ol.proj.fromLonLat([element.getLonMap(), element.getLatMap()]);
                 if (element.getAction() == 5) {
                     // If action is Set_POI, increment counter of POI
                     poiList.push(element.getNumber());
@@ -817,7 +817,7 @@ TABS.mission_control.initialize = function (callback) {
                     activateHead = false;
                 }
                 else {
-                    // If classic WPs, draw standard line in-between 
+                    // If classic WPs, draw standard line in-between
                     if (typeof oldPos !== 'undefined' && activatePoi != true && activateHead != true){
                         paintLine(oldPos, coord, element.getNumber());
                     }
@@ -839,7 +839,7 @@ TABS.mission_control.initialize = function (callback) {
             }
             else if (element.isAttached()) {
                 if (element.getAction() == MWNP.WPTYPE.JUMP) {
-                    let coord = ol.proj.fromLonLat([mission.getWaypoint(element.getP1()).getLonMap(), mission.getWaypoint(element.getP1()).getLatMap()]);  
+                    let coord = ol.proj.fromLonLat([mission.getWaypoint(element.getP1()).getLonMap(), mission.getWaypoint(element.getP1()).getLatMap()]);
                     paintLine(oldPos, coord, element.getNumber(), color='#e935d6', lineDash=5, lineText="Repeat x"+(element.getP2() == -1 ? " infinite" : String(element.getP2())), selection=false, arrow=true);
                 }
                 // If classic WPs is defined with a heading = -1, change Boolean for POI to false. If it is defined with a value different from -1, activate Heading boolean
@@ -864,14 +864,14 @@ TABS.mission_control.initialize = function (callback) {
         let lengthMission = mission.getDistance(true);
         $('#missionDistance').text(lengthMission[lengthMission.length -1] != -1 ? lengthMission[lengthMission.length -1].toFixed(1) : 'infinite');
     }
-    
+
     function paintLine(pos1, pos2, pos2ID, color='#1497f1', lineDash=0, lineText="", selection=true, arrow=false) {
         var line = new ol.geom.LineString([pos1, pos2]);
 
         var feature = new ol.Feature({
             geometry: line
         });
-        
+
         feature.setStyle(
             new ol.style.Style({
                 stroke: new ol.style.Stroke({
@@ -890,7 +890,7 @@ TABS.mission_control.initialize = function (callback) {
                 }),
             }),
         );
-        
+
         if (arrow) {
             let dx = pos2[0] - pos1[0];
             let dy = pos2[1] - pos1[1];
@@ -910,7 +910,7 @@ TABS.mission_control.initialize = function (callback) {
                 })
             );
         }
-        
+
 
         if (arrow) {
             var vectorSource = new ol.source.Vector({
@@ -931,7 +931,7 @@ TABS.mission_control.initialize = function (callback) {
         vectorLayer.kind = "line";
         vectorLayer.selection = selection;
         vectorLayer.number = pos2ID;
-        
+
         lines.push(vectorLayer);
 
 /*         var length = ol.Sphere.getLength(line) + parseFloat($('#missionDistance').text());
@@ -939,26 +939,26 @@ TABS.mission_control.initialize = function (callback) {
 
         map.addLayer(vectorLayer);
     }
-    
-    function cleanLayers() {       
+
+    function cleanLayers() {
         for (var i in lines) {
             map.removeLayer(lines[i]);
         }
         lines = [];
-        
+
         for (var i in markers) {
             map.removeLayer(markers[i]);
         }
         markers = [];
     }
-    
-    function cleanLines() {       
+
+    function cleanLines() {
         for (var i in lines) {
             map.removeLayer(lines[i]);
         }
         lines = [];
     }
-        
+
     function redrawLayers() {
         if (!mission.isEmpty()) {
             mission.get().forEach(function (element) {
@@ -969,15 +969,15 @@ TABS.mission_control.initialize = function (callback) {
         }
         repaintLine4Waypoints(mission);
     }
-    
+
     function redrawLayer() {
         if (selectedFeature && selectedMarker) {
             selectedFeature.setStyle(getWaypointIcon(selectedMarker, true));
         }
         repaintLine4Waypoints(mission);
     }
-    
-    
+
+
     function renderWaypointOptionsTable(waypoint) {
         /*
          * Process Waypoint Options table UI
@@ -998,7 +998,7 @@ TABS.mission_control.initialize = function (callback) {
             ');
 
             const $row = $waypointOptionsTableBody.find('tr:last');
-            
+
             for (var i = 1; i <= 3; i++) {
                 if (dictOfLabelParameterPoint[element.getAction()]['parameter'+String(i)] != '') {
                     $row.find(".waypointOptions-p"+String(i)).prop("disabled", false);
@@ -1007,9 +1007,9 @@ TABS.mission_control.initialize = function (callback) {
                     $row.find(".waypointOptions-p"+String(i)).prop("disabled", true);
                 }
             }
-            
+
             GUI.fillSelect($row.find(".waypointOptions-action"), waypointOptions, waypointOptions.indexOf(MWNP.WPTYPE.REV[element.getAction()]));
-            
+
             $row.find(".waypointOptions-action").val(waypointOptions.indexOf(MWNP.WPTYPE.REV[element.getAction()])).change(function () {
                     element.setAction(MWNP.WPTYPE[waypointOptions[$(this).val()]]);
                     for (var i = 1; i <= 3; i++) {
@@ -1024,7 +1024,7 @@ TABS.mission_control.initialize = function (callback) {
                     cleanLines();
                     redrawLayer();
                 });
-            
+
             $row.find(".waypointOptions-number").text(element.getAttachedNumber()+1);
 
 
@@ -1061,7 +1061,7 @@ TABS.mission_control.initialize = function (callback) {
                 cleanLines();
                 redrawLayer();
             });
-            
+
             $row.find(".waypointOptions-p2").val(element.getP2()).change(function () {
                 if (MWNP.WPTYPE.REV[element.getAction()] == "JUMP") {
                     if ($(this).val() > 10 || ($(this).val() < 0 && $(this).val() != -1))
@@ -1077,13 +1077,13 @@ TABS.mission_control.initialize = function (callback) {
             });
 
             $row.find("[data-role='waypointOptions-delete']").attr("data-index", element.getAttachedNumber()+1);
-            
+
         });
         GUI.switchery();
         localize();
         return waypoint;
     }
-    
+
     /////////////////////////////////////////////
     //
     // Manage Map construction
@@ -1091,10 +1091,10 @@ TABS.mission_control.initialize = function (callback) {
     /////////////////////////////////////////////
     function initMap() {
         var app = {};
-        
+
         //////////////////////////////////////////////////////////////////////////////////////////////
         //      Drag behavior definition
-        //////////////////////////////////////////////////////////////////////////////////////////////  
+        //////////////////////////////////////////////////////////////////////////////////////////////
 
         /**
          * @constructor
@@ -1171,8 +1171,8 @@ TABS.mission_control.initialize = function (callback) {
 
         };
         ol.inherits(app.PlannerSettingsControl, ol.control.Control);
-        
-        
+
+
         /**
          * @constructor
          * @extends {ol.control.Control}
@@ -1211,7 +1211,7 @@ TABS.mission_control.initialize = function (callback) {
 
         };
         ol.inherits(app.PlannerSafehomeControl, ol.control.Control);
-        
+
         /**
          * @constructor
          * @extends {ol.control.Control}
@@ -1248,7 +1248,7 @@ TABS.mission_control.initialize = function (callback) {
 
         };
         ol.inherits(app.PlannerElevationControl, ol.control.Control);
-        
+
         /**
          * @param {ol.MapBrowserEvent} evt Map browser event.
          * @return {boolean} `true` to start the drag sequence.
@@ -1293,7 +1293,7 @@ TABS.mission_control.initialize = function (callback) {
             if (tempMarker.kind == "waypoint" ||tempMarker.kind == "safehome" || tempMarker.kind == "home") {
                 geometry.translate(deltaX, deltaY);
                 this.coordinate_[0] = evt.coordinate[0];
-                this.coordinate_[1] = evt.coordinate[1]; 
+                this.coordinate_[1] = evt.coordinate[1];
             }
 
             let coord = ol.proj.toLonLat(geometry.getCoordinates());
@@ -1301,12 +1301,14 @@ TABS.mission_control.initialize = function (callback) {
                 let tempWp = mission.getWaypoint(tempMarker.number);
                 tempWp.setLon(Math.round(coord[0] * 10000000));
                 tempWp.setLat(Math.round(coord[1] * 10000000));
-                $('#pointLon').val(Math.round(coord[0] * 10000000) / 10000000);
-                $('#pointLat').val(Math.round(coord[1] * 10000000) / 10000000);
+                if (selectedMarker != null && tempMarker.number == selectedMarker.getLayerNumber()) {
+                    $('#pointLon').val(Math.round(coord[0] * 10000000) / 10000000);
+                    $('#pointLat').val(Math.round(coord[1] * 10000000) / 10000000);
+                }
                 mission.updateWaypoint(tempWp);
                 repaintLine4Waypoints(mission);
             }
-            else if (tempMarker.kind == "safehome") {                
+            else if (tempMarker.kind == "safehome") {
                 let tempSH = SAFEHOMES.getSafehome(tempMarker.number);
                 tempSH.setLon(Math.round(coord[0] * 10000000));
                 tempSH.setLat(Math.round(coord[1] * 10000000));
@@ -1314,13 +1316,13 @@ TABS.mission_control.initialize = function (callback) {
                 $safehomesTableBody.find('tr:nth-child('+String(tempMarker.number+1)+') > td > .safehome-lon').val(Math.round(coord[0] * 10000000) / 10000000);
                 $safehomesTableBody.find('tr:nth-child('+String(tempMarker.number+1)+') > td > .safehome-lat').val(Math.round(coord[1] * 10000000) / 10000000);
             }
-            else if (tempMarker.kind == "home") {                
+            else if (tempMarker.kind == "home") {
                 HOME.setLon(Math.round(coord[0] * 10000000));
                 HOME.setLat(Math.round(coord[1] * 10000000));
                 $('.home-lon').val(Math.round(coord[0] * 10000000) / 10000000);
                 $('.home-lat').val(Math.round(coord[1] * 10000000) / 10000000);
             }
-            
+
         };
 
         /**
@@ -1351,14 +1353,15 @@ TABS.mission_control.initialize = function (callback) {
          * @return {boolean} `false` to stop the drag sequence.
          */
         app.Drag.prototype.handleUpEvent = function (evt) {
-            if (tempMarker.kind == "waypoint" ){
+            if ( tempMarker.kind == "waypoint" ) {
+                if (selectedMarker != null && tempMarker.number == selectedMarker.getLayerNumber()) {
                     (async () => {
-                        if (mission.getWaypoint(tempMarker.number).getP3() == 1.0) {
-                            const elevationAtWP = await mission.getWaypoint(tempMarker.number).getElevation(globalSettings);
-                            $('#elevationValueAtWP').text(elevationAtWP);
-                        }
+                        const elevationAtWP = await mission.getWaypoint(tempMarker.number).getElevation(globalSettings);
+                        $('#elevationValueAtWP').text(elevationAtWP);
+                        checkAltElevSanity(false);
                         plotElevation();
                     })()
+                }
             }
             else if (tempMarker.kind == "home" ) {
                 (async () => {
@@ -1392,7 +1395,7 @@ TABS.mission_control.initialize = function (callback) {
         } else {
             mapLayer = new ol.source.OSM();
         }
-        
+
         if (CONFIGURATOR.connectionValid) {
             control_list = [
                 new app.PlannerSettingsControl(),
@@ -1410,7 +1413,7 @@ TABS.mission_control.initialize = function (callback) {
 
         //////////////////////////////////////////////////////////////////////////////////////////////
         // Map object definition
-        //////////////////////////////////////////////////////////////////////////////////////////////          
+        //////////////////////////////////////////////////////////////////////////////////////////////
         map = new ol.Map({
             controls: ol.control.defaults({
                 attributionOptions: {
@@ -1456,7 +1459,7 @@ TABS.mission_control.initialize = function (callback) {
             }
         });
         //////////////////////////////////////////////////////////////////////////
-        // Map on-click behavior definition 
+        // Map on-click behavior definition
         //////////////////////////////////////////////////////////////////////////
         map.on('click', function (evt) {
             if (selectedMarker != null && selectedFeature != null) {
@@ -1488,6 +1491,18 @@ TABS.mission_control.initialize = function (callback) {
 
                 var altitudeMeters = app.ConvertCentimetersToMeters(selectedMarker.getAlt());
 
+                if (globalSettings.mapProviderType == 'bing') {
+                    $('#elevationAtWP').fadeIn();
+                    $('#groundClearanceAtWP').fadeIn();
+                    (async () => {
+                        const elevationAtWP = await selectedMarker.getElevation(globalSettings);
+                        $('#elevationValueAtWP').text(elevationAtWP);
+                    })()
+                } else {
+                    $('#elevationAtWP').fadeOut();
+                    $('#groundClearanceAtWP').fadeOut();
+                }
+
                 $('#altitudeInMeters').text(` ${altitudeMeters}m`);
                 $('#pointLon').val(Math.round(coord[0] * 10000000) / 10000000);
                 $('#pointLat').val(Math.round(coord[1] * 10000000) / 10000000);
@@ -1497,8 +1512,8 @@ TABS.mission_control.initialize = function (callback) {
                 $('#pointP1').val(selectedMarker.getP1());
                 $('#pointP2').val(selectedMarker.getP2());
                 changeSwitchery($('#pointP3'), selectedMarker.getP3() == 1);
-               
-                
+
+
                 // Selection box update depending on choice of type of waypoint
                 for (var j in dictOfLabelParameterPoint[selectedMarker.getAction()]) {
                     if (dictOfLabelParameterPoint[selectedMarker.getAction()][j] != '') {
@@ -1578,7 +1593,7 @@ TABS.mission_control.initialize = function (callback) {
             let altitudeMeters = app.ConvertCentimetersToMeters($(this).val());
             $('#altitudeInMeters').text(` ${altitudeMeters}m`);
         });
-        
+
         /////////////////////////////////////////////
         // Callback to show/hide menu boxes
         /////////////////////////////////////////////
@@ -1594,7 +1609,7 @@ TABS.mission_control.initialize = function (callback) {
                 $('#ActionContent').fadeOut(300);
             }
         });
-        
+
         $('#showHideInfoButton').on('click', function () {
             var src = ($(this).children().attr('class') === 'ic_hide')
                 ? 'ic_show'
@@ -1607,7 +1622,7 @@ TABS.mission_control.initialize = function (callback) {
                 $('#InfoContent').fadeOut(300);
             }
         });
-        
+
         $('#showHideSafehomeButton').on('click', function () {
             var src = ($(this).children().attr('class') === 'ic_hide')
                 ? 'ic_show'
@@ -1620,7 +1635,7 @@ TABS.mission_control.initialize = function (callback) {
                 $('#SafehomeContent').fadeOut(300);
             }
         });
-        
+
         $('#showHideHomeButton').on('click', function () {
             var src = ($(this).children().attr('class') === 'ic_hide')
                 ? 'ic_show'
@@ -1633,7 +1648,7 @@ TABS.mission_control.initialize = function (callback) {
                 $('#HomeContent').fadeOut(300);
             }
         });
-        
+
         $('#showHideWPeditButton').on('click', function () {
             var src = ($(this).children().attr('class') === 'ic_hide')
                 ? 'ic_show'
@@ -1646,7 +1661,7 @@ TABS.mission_control.initialize = function (callback) {
                 $('#WPeditContent').fadeOut(300);
             }
         });
-        
+
         /////////////////////////////////////////////
         // Callback for Waypoint edition
         /////////////////////////////////////////////
@@ -1656,7 +1671,6 @@ TABS.mission_control.initialize = function (callback) {
                 if ([MWNP.WPTYPE.SET_POI,MWNP.WPTYPE.POSHOLD_TIME,MWNP.WPTYPE.LAND].includes(selectedMarker.getAction())) {
                     selectedMarker.setP1(0.0);
                     selectedMarker.setP2(0.0);
-                    selectedMarker.setP3(0.0);
                 }
                 for (var j in dictOfLabelParameterPoint[selectedMarker.getAction()]) {
                     if (dictOfLabelParameterPoint[selectedMarker.getAction()][j] != '') {
@@ -1670,7 +1684,7 @@ TABS.mission_control.initialize = function (callback) {
                 redrawLayer();
             }
         });
-        
+
         $('#pointLat').on('change', function (event) {
             if (selectedMarker) {
                 selectedMarker.setLat(Math.round(Number($('#pointLat').val()) * 10000000));
@@ -1683,7 +1697,7 @@ TABS.mission_control.initialize = function (callback) {
                 plotElevation();
             }
         });
-        
+
         $('#pointLon').on('change', function (event) {
             if (selectedMarker) {
                 selectedMarker.setLon(Math.round(Number($('#pointLon').val()) * 10000000));
@@ -1696,17 +1710,17 @@ TABS.mission_control.initialize = function (callback) {
                 plotElevation();
             }
         });
-        
+
         $('#pointAlt').on('change', function (event) {
             if (selectedMarker) {
-                selectedMarker.setAlt(Number($('#pointAlt').val()));
+                checkAltElevSanity(true);
                 mission.updateWaypoint(selectedMarker);
                 mission.update();
                 redrawLayer();
                 plotElevation();
             }
         });
-        
+
         $('#pointP1').on('change', function (event) {
             if (selectedMarker) {
                 selectedMarker.setP1(Number($('#pointP1').val()));
@@ -1715,7 +1729,7 @@ TABS.mission_control.initialize = function (callback) {
                 redrawLayer();
             }
         });
-        
+
         $('#pointP2').on('change', function (event) {
             if (selectedMarker) {
                 selectedMarker.setP2(Number($('#pointP2').val()));
@@ -1724,28 +1738,40 @@ TABS.mission_control.initialize = function (callback) {
                 redrawLayer();
             }
         });
-        
+
         $('#pointP3').on('change', function (event) {
             if (selectedMarker) {
+                const P3Value = selectedMarker.getP3();
                 selectedMarker.setP3( $('#pointP3').prop("checked") ? 1.0 : 0.0);
-                if ($('#pointP3').prop("checked")) {
+                if (globalSettings.mapProviderType == 'bing') {
                     (async () => {
                         const elevationAtWP = await selectedMarker.getElevation(globalSettings);
                         $('#elevationValueAtWP').text(elevationAtWP);
-                        $('#elevationAtWP').fadeIn(300);
+                        var altitude = Number($('#pointAlt').val());
+                        if (P3Value != selectedMarker.getP3()) {
+                            if ($('#pointP3').prop("checked")) {
+                                if (altitude < 0) {
+                                    alert("Altitude below ground level, setting to default");
+                                    altitude = Number($('#MPdefaultPointAlt').val());
+                                }
+                                selectedMarker.setAlt(altitude + elevationAtWP * 100);
+                            } else {
+                                selectedMarker.setAlt(altitude - Number(elevationAtWP) * 100);
+                            }
+                        }
+                        $('#pointAlt').val(selectedMarker.getAlt());
+                        altitudeMeters = app.ConvertCentimetersToMeters(selectedMarker.getAlt());
+                        $('#altitudeInMeters').text(` ${altitudeMeters}m`);
+                        checkAltElevSanity(false);
+                        mission.updateWaypoint(selectedMarker);
+                        mission.update();
+                        redrawLayer();
+                        plotElevation();
                     })()
-                    
                 }
-                else {
-                    $('#elevationAtWP').fadeOut(300);
-                }
-                mission.updateWaypoint(selectedMarker);
-                mission.update();
-                redrawLayer();
-                plotElevation();
             }
         });
-        
+
         /////////////////////////////////////////////
         // Callback for Waypoint Options Table
         /////////////////////////////////////////////
@@ -1760,7 +1786,7 @@ TABS.mission_control.initialize = function (callback) {
                 selectedFeature.setStyle(getWaypointIcon(selectedMarker, true));
             }
         });
-        
+
         $("[data-role='waypointOptions-add']").click(function () {
             if (selectedMarker) {
                 mission.addAttachedFromWaypoint(selectedMarker);
@@ -1772,7 +1798,7 @@ TABS.mission_control.initialize = function (callback) {
                 selectedFeature.setStyle(getWaypointIcon(selectedMarker, true));
             }
         });
-        
+
         /////////////////////////////////////////////
         // Callback for SAFEHOMES Table
         /////////////////////////////////////////////
@@ -1784,13 +1810,13 @@ TABS.mission_control.initialize = function (callback) {
             SAFEHOMES.updateSafehome(tmpSH);
             renderSafehomesTable();
             cleanSafehomeLayers();
-            renderSafehomesOnMap();     
+            renderSafehomesOnMap();
         });
-       
+
         $('#cancelSafehome').on('click', function () {
             closeSafehomePanel();
         });
-        
+
         $('#loadEepromSafehomeButton').on('click', function () {
             $(this).addClass('disabled');
             GUI.log('Start of getting Safehome points');
@@ -1802,9 +1828,9 @@ TABS.mission_control.initialize = function (callback) {
                 GUI.log('End of getting Safehome points');
                 $('#loadEepromSafehomeButton').removeClass('disabled');
             }, 500);
-            
+
         });
-        
+
         $('#saveEepromSafehomeButton').on('click', function () {
             $(this).addClass('disabled');
             GUI.log('Start of sending Safehome points');
@@ -1815,7 +1841,7 @@ TABS.mission_control.initialize = function (callback) {
                 $('#saveEepromSafehomeButton').removeClass('disabled');
             }, 500);
         });
-        
+
         /////////////////////////////////////////////
         // Callback for HOME Table
         /////////////////////////////////////////////
@@ -1824,16 +1850,39 @@ TABS.mission_control.initialize = function (callback) {
             HOME.setLon(Math.round(ol.proj.toLonLat(mapCenter)[0] * 1e7));
             HOME.setLat(Math.round(ol.proj.toLonLat(mapCenter)[1] * 1e7));
             updateHome();
+            if (globalSettings.mapProviderType == 'bing') {
+                $('#elevationEarthModelclass').fadeIn(300);
+            }
         });
-        
+
         $('#cancelHome').on('click', function () {
             closeHomePanel();
         });
-        
+
         $('#cancelPlot').on('click', function () {
             closeHomePanel();
         });
-        
+
+        $('#elevationEarthModel').on('change', function (event) {
+            if (globalSettings.mapProviderType == 'bing') {
+                (async () => {
+                    if (selectedMarker) {
+                        const elevationAtWP = await selectedMarker.getElevation(globalSettings);
+                        $('#elevationValueAtWP').text(elevationAtWP);
+                        mission.updateWaypoint(selectedMarker);
+                    }
+                    const elevationAtHome = await HOME.getElevation(globalSettings);
+                    $('#elevationValueAtHome').text(elevationAtHome+' m');
+                    HOME.setAlt(elevationAtHome);
+
+                    checkAltElevSanity(false);
+                    mission.update();
+                    redrawLayer();
+                    plotElevation();
+                })()
+            }
+        });
+
         /////////////////////////////////////////////
         // Callback for Remove buttons
         /////////////////////////////////////////////
@@ -1875,11 +1924,11 @@ TABS.mission_control.initialize = function (callback) {
                 }
             }
         });
-        
-        
+
+
         /////////////////////////////////////////////
         // Callback for Save/load buttons
-        /////////////////////////////////////////////       
+        /////////////////////////////////////////////
         $('#loadFileMissionButton').on('click', function () {
             if (markers.length && !confirm(chrome.i18n.getMessage('confirm_delete_all_points'))) return;
             removeAllWaypoints();
@@ -1912,7 +1961,7 @@ TABS.mission_control.initialize = function (callback) {
             sendWaypointsToFC();
             GUI.log('End send point');
             $('#saveMissionButton').removeClass('disabled');
-            
+
         });
 
         $('#loadEepromMissionButton').on('click', function () {
@@ -1921,7 +1970,7 @@ TABS.mission_control.initialize = function (callback) {
             GUI.log(chrome.i18n.getMessage('eeprom_load_ok'));
             MSP.send_message(MSPCodes.MSP_WP_MISSION_LOAD, [0], getWaypointsFromFC);
         });
-        
+
         $('#saveEepromMissionButton').on('click', function () {
             $(this).addClass('disabled');
             GUI.log('Start send point');
@@ -1943,7 +1992,7 @@ TABS.mission_control.initialize = function (callback) {
             saveSettings();
             if (settings.safeRadiusSH != oldSafeRadiusSH  && $('#showHideSafehomeButton').is(":visible")) {
                 cleanSafehomeLayers();
-                renderSafehomesOnMap(); 
+                renderSafehomesOnMap();
                 $('#SafeHomeSafeDistance').text(settings.safeRadiusSH);
             }
             closeSettingsPanel();
@@ -1953,7 +2002,7 @@ TABS.mission_control.initialize = function (callback) {
             loadSettings();
             closeSettingsPanel();
         });
-        
+
 
 
         updateTotalInfo();
@@ -2075,7 +2124,7 @@ TABS.mission_control.initialize = function (callback) {
                     map.getView().setCenter(coord);
                     map.getView().setZoom(16);
                 }
-                
+
                 redrawLayers();
                 updateHome();
                 updateTotalInfo();
@@ -2095,14 +2144,14 @@ TABS.mission_control.initialize = function (callback) {
 
         var data = {
             'version': { $: { 'value': '2.3-pre8' } },
-            'mwp': { $: { 'cx': (Math.round(center[0] * 10000000) / 10000000), 
-                          'cy': (Math.round(center[1] * 10000000) / 10000000), 
+            'mwp': { $: { 'cx': (Math.round(center[0] * 10000000) / 10000000),
+                          'cy': (Math.round(center[1] * 10000000) / 10000000),
                           'home-x' : HOME.getLonMap(),
                           'home-y' : HOME.getLatMap(),
                           'zoom': zoom } },
             'missionitem': []
         };
-        
+
         mission.get().forEach(function (waypoint) {
             var point = { $: {
                         'no': waypoint.getNumber()+1,
@@ -2116,7 +2165,7 @@ TABS.mission_control.initialize = function (callback) {
                     } };
             data.missionitem.push(point);
         });
-        
+
         var builder = new window.xml2js.Builder({ 'rootName': 'mission', 'renderOpts': { 'pretty': true, 'indent': '\t', 'newline': '\n' } });
         var xml = builder.buildObject(data);
         fs.writeFile(filename, xml, (err) => {
@@ -2148,7 +2197,7 @@ TABS.mission_control.initialize = function (callback) {
             updateTotalInfo();
         }, 2000);
     }
-    
+
     function sendWaypointsToFC() {
         MISSION_PLANER.reinit();
         MISSION_PLANER.copy(mission);
@@ -2169,26 +2218,68 @@ TABS.mission_control.initialize = function (callback) {
     }
 
 
-    
+
     function updateTotalInfo() {
         if (CONFIGURATOR.connectionValid) {
             $('#availablePoints').text(mission.getCountBusyPoints() + '/' + mission.getMaxWaypoints());
             $('#missionValid').html(mission.getValidMission() ? chrome.i18n.getMessage('armingCheckPass') : chrome.i18n.getMessage('armingCheckFail'));
         }
-    }   
-    
+    }
+
 
     function updateFilename(filename) {
         $('#missionFilename').text(filename);
         $('#infoMissionFilename').show();
     }
-    
+
     function changeSwitchery(element, checked) {
       if ( ( element.is(':checked') && checked == false ) || ( !element.is(':checked') && checked == true ) ) {
         element.parent().find('.switcherymid').trigger('click');
       }
     }
-    
+
+    /* reset = true : changes WP Altitude value back to previous value if setting below ground level.
+     ^ reset = false : changes WP Altitude to value required to give ground clearance = default Altitude setting */
+    function checkAltElevSanity(reset) {
+        if (globalSettings.mapProviderType != 'bing') {
+            selectedMarker.setAlt(Number($('#pointAlt').val()));
+            return;
+        }
+
+        const elevationAtWP = Number($('#elevationValueAtWP').text());
+        let groundClearance = "NO HOME";
+        if (selectedMarker.getP3()) {
+            if (Number($('#pointAlt').val()) < 100 * elevationAtWP) {
+                if (reset) {
+                    alert("Altitude below ground level. Change ignored");
+                    $('#pointAlt').val(selectedMarker.getAlt());
+                } else {
+                    alert("Altitude below ground level, setting to default");
+                    let altitude = Number($('#MPdefaultPointAlt').val()) + 100 * elevationAtWP;
+                    $('#pointAlt').val(altitude);
+                }
+            }
+            groundClearance = Number($('#pointAlt').val()) / 100 - elevationAtWP;
+        } else if (homeMarkers.length & HOME.getAlt() != "N/A") {
+            let elevationAtHome = HOME.getAlt();
+            if ((Number($('#pointAlt').val()) / 100 + elevationAtHome) < elevationAtWP) {
+                if (reset) {
+                    alert("Altitude below ground level. Change ignored");
+                    $('#pointAlt').val(selectedMarker.getAlt());
+                } else {
+                    alert("Altitude below ground level, setting to default");
+                    let altitude = Number($('#MPdefaultPointAlt').val()) + 100 * (elevationAtWP - elevationAtHome);
+                    $('#pointAlt').val(altitude);
+                }
+            }
+            groundClearance = Number($('#pointAlt').val()) / 100 + (elevationAtHome - elevationAtWP);
+        }
+        selectedMarker.setAlt(Number($('#pointAlt').val()));
+        let altitudeMeters = parseInt(selectedMarker.getAlt()) / 100;
+        $('#altitudeInMeters').text(` ${altitudeMeters}m`);
+        $('#groundClearanceValueAtWP').text(` ${groundClearance}`);
+    }
+
     function plotElevation() {
         if ($('#missionPlanerElevation').is(":visible")) {
             if (mission.get().length == 0) {

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1793,7 +1793,6 @@ TABS.mission_control.initialize = function (callback) {
                         if (P3Value != selectedMarker.getP3()) {
                             if ($('#pointP3').prop("checked")) {
                                 if (altitude < 0) {
-                                    alert(chrome.i18n.getMessage('MissionPlannerAltitudeSetDefault'));
                                     altitude = settings.alt;
                                 }
                                 selectedMarker.setAlt(altitude + elevationAtWP * 100);
@@ -1801,11 +1800,12 @@ TABS.mission_control.initialize = function (callback) {
                                 selectedMarker.setAlt(altitude - Number(elevationAtWP) * 100);
                             }
                         }
+                        const returnAltitude = checkAltElevSanity(false, selectedMarker.getAlt(), elevationAtWP, selectedMarker.getP3());
+                        selectedMarker.setAlt(returnAltitude);
                         $('#pointAlt').val(selectedMarker.getAlt());
                         altitudeMeters = app.ConvertCentimetersToMeters(selectedMarker.getAlt());
                         $('#altitudeInMeters').text(` ${altitudeMeters}m`);
-                        const returnAltitude = checkAltElevSanity(false, selectedMarker.getAlt(), elevationAtWP, selectedMarker.getP3());
-                        selectedMarker.setAlt(returnAltitude);
+
                         mission.updateWaypoint(selectedMarker);
                         mission.update();
                         redrawLayer();
@@ -2289,13 +2289,12 @@ TABS.mission_control.initialize = function (callback) {
 
         let groundClearance = "NO HOME";
         let altitude = checkAltitude;
-        if (selectedMarker != null && selectedMarker.getP3()) {
+        if (P3Datum) {
             if (checkAltitude < 100 * elevation) {
                 if (resetAltitude) {
                     alert(chrome.i18n.getMessage('MissionPlannerAltitudeChangeReset'));
                     altitude = selectedMarker.getAlt();
                 } else {
-                    alert(chrome.i18n.getMessage('MissionPlannerAltitudeSetDefault'));
                     altitude = settings.alt + 100 * elevation;
                 }
             }
@@ -2307,7 +2306,6 @@ TABS.mission_control.initialize = function (callback) {
                     alert(chrome.i18n.getMessage('MissionPlannerAltitudeChangeReset'));
                     altitude = selectedMarker.getAlt();
                 } else {
-                    alert(chrome.i18n.getMessage('MissionPlannerAltitudeSetDefault'));
                     altitude = settings.alt + 100 * (elevation - elevationAtHome);
                 }
             }
@@ -2316,6 +2314,7 @@ TABS.mission_control.initialize = function (callback) {
         $('#pointAlt').val(altitude);
         let altitudeMeters = parseInt(altitude) / 100;
         $('#altitudeInMeters').text(` ${altitudeMeters}m`);
+        document.getElementById('groundClearanceAtWP').style.color = groundClearance < (settings.alt / 100) ? "#FF0000" : "#303030";
         $('#groundClearanceValueAtWP').text(` ${groundClearance}`);
 
         return altitude;


### PR DESCRIPTION
PR introduces altitude/elevation sanity checking for waypoints plus several other related changes.

When elevation data is available (Bing map source used) WP altitude is checked during editing to ensure flight remains above ground level. If below ground level altitude changes are either reset (ignored) or changed to a value giving a ground clearance equal to the default relative altitude value.

Selecting the WP Sea Level Ref option has been changed to ensure ground clearance by adjusting the WP altitude as follows:
Option ON:  WP Altitude = previous Altitude setting + WP elevation
Option OFF: WP Altitude = previous Altitude setting - WP elevation

If elevation data is available ground elevation is now always shown in the WP edit box regardless of altitude Sea Level Ref setting. A ground clearance field has also been added.

Option added in Home table to change elevation DEM earth model datum between sealevel or ellipsoid.

Sea level Ref (P3 setting) logic changed so it doesn't reset when the WP action type is changed, keeps the current value.

Updating of lat, long values in WP edit box during WP dragging corrected so values only change when a selected WP is dragged. Values remain unchanged if an unselected WP is dragged (Since data in WP edit box only relevant to selected WP).