### PR TITLE
tiny typographical error messages.json

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3966,7 +3966,7 @@
         "message": "I2C Speed"
     },
     "configurationI2cSpeedHelp": {
-        "message": "I2C speed should be kept at the highest level that allows for all connected devices to work. Default 400kHz is a save value and it is suggested to switch to 800kHz in case of Multirotors."
+        "message": "I2C speed should be kept at the highest level that allows for all connected devices to work. Default 400kHz is a safe value and it is suggested to switch to 800kHz in case of Multirotors."
     },
     "i2cSpeedSuggested800khz": {
         "message": "Please switch to 800kHz if connected hardware allows for it"


### PR DESCRIPTION
herrrp & derrrp, happy now mooiweertje? I know u don't like me making changes to my own local builds or as you put it "stealing code" so for this most valueable contribution your welcome!

save-->safe

To everyone else: sorry to waste ur time with a pull request for this minor non-functional change, but I was amused.

<         "message": "I2C speed should be kept at the highest level that allows for all connected devices to work. Default 400kHz is a save value and it is suggested to switch to 800kHz in case of Multirotors."
---
>         "message": "I2C speed should be kept at the highest level that allows for all connected devices to work. Default 400kHz is a safe value and it is suggested to switch to 800kHz in case of Multirotors."