### PR TITLE
Fixed bug when removing a range

### DIFF
--- a/tabs/auxiliary.js
+++ b/tabs/auxiliary.js
@@ -181,6 +181,7 @@ TABS.auxiliary.initialize = function (callback) {
 
         $(rangeElement).find('a.deleteRange').click(function () {
             var rangeElement = $(this).data('rangeElement');
+            modeElement.removeClass('inRange');
             rangeElement.remove();
         });
 


### PR DESCRIPTION
This bug affected removing ranges that were in-range. The in-range status was not removed. This fixes that.