### PR TITLE
Mission control Home fixes

### DIFF
--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2172,7 +2172,7 @@ TABS.mission_control.initialize = function (callback) {
                 }
 
                 redrawLayers();
-                if (!(HOME.getLatMap() == 0 && HOME.getLonMap() == 0) {
+                if (!(HOME.getLatMap() == 0 && HOME.getLonMap() == 0)) {
                     updateHome();
                 }
                 updateTotalInfo();


### PR DESCRIPTION
Fixes an issue with mission Home setting an elevation when the Home position hasn't actually been properly set but is instead using default Lat and Lon values of 0, 0. Also fixes a bogus Home point being set in the sea off Africa when a mission file is loaded that doesn't have any Home position set or has it set to 0, 0 because no Home had been set when the file was saved.