### PR TITLE
Mission control bug fix

### DIFF
--- a/js/waypointCollection.js
+++ b/js/waypointCollection.js
@@ -72,7 +72,7 @@ let WaypointCollection = function () {
     };
 
     self.isEmpty = function () {
-        return data == [];
+        return data.length == 0;
     };
 
     self.flush = function () {

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -975,8 +975,8 @@ TABS.mission_control.initialize = function (callback) {
                     map.addLayer(addWaypointMarker(element));
                 }
             });
+            repaintLine4Waypoints(mission);
         }
-        repaintLine4Waypoints(mission);
     }
 
     function redrawLayer() {


### PR DESCRIPTION
Fixes an unseen error (only apparent if you look at the console).

`return data == []` appears to always returns false even when the array length is 0.

`repaintLine4Waypoints(mission);` shouldn't be called when there's < 2 WPs in the mission.