### PR TITLE
Added selectable precision to the OSD RPM

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2798,6 +2798,12 @@
     "osd_plus_code_short": {
         "message" : "Plus Code Remove Leading Digits"
     },
+    "osd_esc_rpm_precision": {
+      "message": "ESC RPM precision"
+    },
+    "osd_esc_rpm_precision_help": {
+        "message": "The number of digits shown in the RPM display. If the RPM is higher than the number of digits, it will be shown in thousand RPM with as many decimal places as allowed."
+      },
     "osd_crosshairs_style": {
         "message" : "Crosshairs Style"
     },

--- a/tabs/osd.html
+++ b/tabs/osd.html
@@ -75,6 +75,11 @@
                                     <select class="update_preview" data-setting="osd_plus_code_short" data-live="true"></select>
                                     <span data-i18n="osd_plus_code_short"></span> 
                                 </label>
+                                <div class="helpicon cf_tip" data-i18n_title="osd_esc_rpm_precision_help"></div>
+                                <label>
+                                    <select class="update_preview" data-setting="osd_esc_rpm_precision" data-live="true"></select>
+                                    <span data-i18n="osd_esc_rpm_precision"></span> 
+                                </label>
                                 <label>
                                     <select class="update_preview" data-setting="osd_crosshairs_style" data-live="true"></select>
                                     <span data-i18n="osd_crosshairs_style"></span>

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -900,7 +900,10 @@ OSD.constants = {
                     name: 'ESC_RPM',
                     id: 106,
                     min_version: '2.3.0',
-                    preview: FONT.symbol(SYM.RPM) + '983',
+                    preview: function(){
+                        let rpmPreview = '112974'.substr((6 - parseInt(Settings.getInputValue('osd_esc_rpm_precision'))));
+                        return FONT.symbol(SYM.RPM) + rpmPreview;
+                    } 
                 },
                 {
                     name: 'GLIDESLOPE',


### PR DESCRIPTION
I've added selectable precision to the ESC RPM, as shown in the OSD. The default is 3, which is the same as the current RPM display.

![image](https://user-images.githubusercontent.com/17590174/137776354-dd451841-4c32-41f4-bc9d-d2ec6c5dcad6.png)

Require configurator change https://github.com/iNavFlight/inav/pull/7515