### PR TITLE
Block configurator until defaults have been applied

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -37,6 +37,9 @@
     "deviceReady": {
         "message": "Device - <span style=\"color: #37a8db\">Ready</span>"
     },
+    "savingDefaults": {
+        "message": "Device - <span style=\"color: red\">Saving default settings</span>"
+    },
     "fcNotConnected": {
         "message": "Not connected"
     },

--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var helper = helper || {};
+var savingDefaultsModal;
 
 helper.defaultsDialog = (function () {
 
@@ -694,6 +695,7 @@ helper.defaultsDialog = (function () {
                         GUI.tab_switch_cleanup(function () {
                             MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, function () {
                                 //noinspection JSUnresolvedVariable
+                                savingDefaultsModal.close();
                                 GUI.log(chrome.i18n.getMessage('deviceRebooting'));
                                 GUI.handleReconnect();
                             });
@@ -705,13 +707,25 @@ helper.defaultsDialog = (function () {
     };
 
     privateScope.onPresetClick = function (event) {
+        savingDefaultsModal = new jBox('Modal', {
+            width: 400,
+            height: 100,
+            animation: false,
+            closeOnClick: false,
+            closeOnEsc: false,
+            content: $('#modal-saving-defaults')
+        }).open();
+
         $container.hide();
+
         let selectedDefaultPreset = data[$(event.currentTarget).data("index")];
         if (selectedDefaultPreset && selectedDefaultPreset.settings) {
 
             mspHelper.loadBfConfig(function () {
                 privateScope.setFeaturesBits(selectedDefaultPreset)
             });
+        } else {
+            savingDefaultsModal.close(); 
         }
     };
 

--- a/main.css
+++ b/main.css
@@ -2155,6 +2155,16 @@ select {
     text-align: center;
 }
 
+#modal-saving-defaults {
+    /* width: 100%; */
+    height: 90px;
+    background: url(../images/loading-bars.svg) no-repeat center 100%;
+}
+
+#modal-saving-defaults div {
+    text-align: center;
+}
+
 .subtab__header {
     padding: 0;
     height: auto;

--- a/main.html
+++ b/main.html
@@ -296,6 +296,9 @@
     <div id="modal-reconnect" class="is-hidden">
         <div data-i18n="deviceRebooting"></div>
     </div>
+    <div id="modal-saving-defaults" class="is-hidden">
+        <div data-i18n="savingDefaults"></div>
+    </div>
     <div id="defaults-wrapper" style="display: none">
         <div class="defaults-dialog__background"></div>
         <div class="defaults-dialog__content">


### PR DESCRIPTION
Currently, after clicking the chosen default on the defaults dialog, the box disappears and people can click away and change settings. This is obviously bad. This change fixes that. Configurator is locked until the reboot occurs.

[Demo of the change working](https://youtu.be/LyNAuGmqyxE)

I have set 5.0 as the milestone. But, it may be worth fast tracking this in to 4.0. What do you think @DzikuVx 