### PR TITLE
Fix defaults dialog bug when clicking Keep current settings

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -13,6 +13,7 @@ helper.defaultsDialog = (function () {
 
     let data = [{
         "title": 'Mini Quad with 3"-7" propellers',
+        "id": 2,
         "notRecommended": false,
         "reboot": true,
         "settings": [
@@ -578,6 +579,7 @@ helper.defaultsDialog = (function () {
     },
     {
         "title": 'Rovers & Boats',
+        "id": 1,
         "notRecommended": false,
         "reboot": true,
         "settings": [
@@ -641,6 +643,7 @@ helper.defaultsDialog = (function () {
     },
     {
         "title": 'Keep current settings (Not recommended)',
+        "id": 0,
         "notRecommended": true,
         "reboot": false,
         "settings": [
@@ -720,6 +723,11 @@ helper.defaultsDialog = (function () {
 
         let selectedDefaultPreset = data[$(event.currentTarget).data("index")];
         if (selectedDefaultPreset && selectedDefaultPreset.settings) {
+
+            if (selectedDefaultPreset.id == 0) {
+                // Close applying preset dialog if keeping current settings.
+                savingDefaultsModal.close(); 
+            }
 
             mspHelper.loadBfConfig(function () {
                 privateScope.setFeaturesBits(selectedDefaultPreset)


### PR DESCRIPTION
Fixes the bug where clicking "Keep current settings" will stop configurators working until reboot.