### PR TITLE
Resolving issue #1319 - Serial port is not visible on some Windows versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jquery-ui-npm": "1.12.0",
     "marked": "^0.3.17",
     "minimist": "^1.2.0",
-    "nw": "^0.45.6-sdk",
+    "nw": "^0.61.0-sdk",
     "nw-dialog": "^1.0.7",
     "openlayers": "^4.6.5",
     "plotly": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jquery-ui-npm": "1.12.0",
     "marked": "^0.3.17",
     "minimist": "^1.2.0",
-    "nw": "^0.50.3-sdk",
+    "nw": "^0.45.6-sdk",
     "nw-dialog": "^1.0.7",
     "openlayers": "^4.6.5",
     "plotly": "^1.0.6",


### PR DESCRIPTION
Issue #1319 reported serial port is not visible on Windows with some languages (notably Korean).

I found the issue is resolved by downgrading the nw.js version from the current 0.50.3 to the version 0.42.2 used in 2.x.

I further tested various nw.js versions, as follow:

nw.js ver / Chrome vers / Working
0.49.2 / 86.0.4240.111 / FALSE
0.47.3 / 84.0.4147.125 / FALSE
0.46.4 / 83.0.4103.116 / FALSE
0.45.6 / 81.0.4044.138 / TRUE

I suspect that Chrome messed up serial.getDevice() for some versions after 81.

The latest nw.js version worked is 0.45.6, on Windows 10 Pro (20H2), language set to Korean.
This trick worked for all INAV 3.x and 4.0 versions.

Unless INAV configurator has an explicit reason for bumping up the nw.js version, I'd like to recommend using v0.45.6, which will prevent the further occasion of this issue.