### PR TITLE
Removed multiple units in the Advanced Tuning tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -871,79 +871,79 @@
         "message": "Fixed Wing Auto Launch Settings"
     },
     "configurationLaunchVelocity": {
-        "message": "Threshold Velocity [cm/s]"
+        "message": "Threshold Velocity"
     },
     "configurationLaunchVelocityHelp": {
         "message": "Forward velocity threshold for swing-launch detection. Default: 300 [100-10000]"
     },
     "configurationLaunchAccel": {
-        "message": "Threshold Acceleration [cm/s/s]"
+        "message": "Threshold Acceleration"
     },
     "configurationLaunchAccelHelp": {
         "message": "Forward acceleration threshold for bungee launch or throw launch, 1G = 981 cm/s/s. Default: 1863 [1000-20000]"
     },
     "configurationLaunchMaxAngle": {
-        "message": "Max Throw Angle [&deg;]"
+        "message": "Max Throw Angle"
     },
     "configurationLaunchMaxAngleHelp": {
         "message": "Max throw angle (pitch/roll combined) to consider launch successful. Set to 180 to disable completely. Default: 45 [5-180]"
     },
     "configurationLaunchDetectTime": {
-        "message": "Detect Time [ms]"
+        "message": "Detect Time"
     },
     "configurationLaunchDetectTimeHelp": {
         "message": "Time for which thresholds have to breached to consider launch happened. Default: 40 [10-1000]"
     },
     "configurationLaunchThr": {
-        "message": "Launch Throttle [uS]"
+        "message": "Launch Throttle"
     },
     "configurationLaunchThrHelp": {
         "message": "Launch throttle - throttle to be set during launch sequence. Default: 1700 [1000-2000]"
     },
     "configurationLaunchIdleThr": {
-        "message": "Idle Throttle [uS]"
+        "message": "Idle Throttle"
     },
     "configurationLaunchIdleThrHelp": {
         "message": "Idle throttle - throttle to be set before launch sequence is initiated. If set below minimum throttle it will force motor stop or at idle throttle (depending if the MOTOR_STOP is enabled). If set above minimum throttle it will force throttle to this value (if MOTOR_STOP is enabled it will be handled according to throttle stick position). Default: 1000 [1000-2000]"
     },
     "configurationLaunchMotorDelay": {
-        "message": "Motor Delay [ms]"
+        "message": "Motor Delay"
     },
     "configurationLaunchMotorDelayHelp": {
         "message": "Delay between detected launch and launch sequence start and throttling up. Default: 500 [0-5000]"
     },
     "configurationLaunchSpinupTime": {
-        "message": "Motor Spinup Time [ms]"
+        "message": "Motor Spinup Time"
     },
     "configurationLaunchSpinupTimeHelp": {
         "message": "Time to bring power from minimum throttle to nav_fw_launch_thr, to avoid big stress on ESC and large torque from propeller. Default: 100 [0-1000]"
     },
     "configurationLaunchMinTime": {
-        "message": "Minimum Launch Time [ms]"
+        "message": "Minimum Launch Time"
     },
     "configurationLaunchMinTimeHelp": {
         "message": "Allow launch mode to execute at least this time [ms] and ignore stick movements. Default: 0 [0-60000]"
     },
     "configurationLaunchTimeout": {
-        "message": "Launch Timeout [ms]"
+        "message": "Launch Timeout"
     },
     "configurationLaunchTimeoutHelp": {
         "message": "Maximum time for launch sequence to be executed. After this time LAUNCH mode will be turned off and regular flight mode will take over. Default: 5000 [0-60000]"
     },
     "configurationLaunchEndTime": {
-        "message": "End Transition Time [ms]"
+        "message": "End Transition Time"
     },
     "configurationLaunchEndTimeHelp": {
         "message": "Smooth transition time at the end of the launch (ms). This is added to the Launch Timeout. Default: 2000 [0-5000]"
     },
     "configurationLaunchMaxAltitude": {
-        "message": "Maximum Altitude [cm]"
+        "message": "Maximum Altitude"
     },
     "configurationLaunchMaxAltitudeHelp": {
         "message": "Altitude at which LAUNCH mode will be turned off and regular flight mode will take over. Default: 0 [0-60000]"
     },
     "configurationLaunchClimbAngle": {
-        "message": "Climb Angle [&deg;]"
+        "message": "Climb Angle"
     },
     "configurationLaunchClimbAngleHelp": {
         "message": "Climb angle (attitude of model, not climb slope) for launch sequence (degrees), is also restrained by global max_angle_inclination_pit. Default: 18 [5-45]"
@@ -2507,16 +2507,16 @@
         "message": "User Control Mode"
     },
     "posholdDefaultSpeed": {
-        "message": "Default navigation speed [cm/s]"
+        "message": "Default navigation speed"
     },
     "posholdDefaultSpeedHelp": {
         "message": "Default speed during RTH, also used for WP navigation if no speed set for WP leg. Limited to Max. navigation speed"
     },
     "posholdMaxSpeed": {
-        "message": "Max. navigation speed [cm/s]"
+        "message": "Max. navigation speed"
     },
     "posholdMaxManualSpeed": {
-        "message": "Max. CRUISE speed [cm/s]"
+        "message": "Max. CRUISE speed"
     },
     "posholdMaxManualSpeedHelp": {
         "message": "Maximum horizonal velocity allowed for pilot manual control during POSHOLD/CRUISE mode"
@@ -2528,7 +2528,7 @@
         "message": "Max. ALTHOLD climb rate [cm/s]"
     },
     "posholdMaxBankAngle": {
-        "message": "Multirotor max. banking angle [degrees]"
+        "message": "Multirotor max. banking angle"
     },
     "posholdMaxBankAngleHelp": {
         "message": "Maximum banking angle in navigation modes. Constrained by maximum ROLL angle in PID tuning tab."
@@ -2585,7 +2585,7 @@
         "message": "Automatic landing settings"
     },
     "minRthDistance": {
-        "message": "Min. RTH distance [cm]"
+        "message": "Min. RTH distance"
     },
     "minRthDistanceHelp": {
         "message": "If UAV is within this distance from the home point, it will land instead of RTH then land"
@@ -2615,19 +2615,19 @@
         "message": "RTH altitude mode"
     },
     "rthAbortThreshold": {
-        "message": "RTH abort threshold [cm]"
+        "message": "RTH abort threshold"
     },
     "rthAbortThresholdHelp": {
         "message": "RTH sanity checking feature will notice if the distance to home is increasing during RTH and if it exceeds the threshold defined by this parameter, instead of continuing RTH the UAV will enter emergency landing. Default is 500m which is safe enough for both multirotors and airplanes."
     },
     "rthAltitude": {
-        "message": "RTH altitude [cm]"
+        "message": "RTH altitude"
     },
     "rthAltitudeHelp": {
         "message": "Used in Extra, Fixed and 'At Least' RTH altitude modes"
     },
     "rthHomeAltitudeLabel": {
-        "message": "RTH Home altitude [cm]"
+        "message": "RTH Home altitude"
     },
     "rthHomeAltitudeHelp": {
         "message": "Used when not landing at the home point. Upon arriving at home, the plane will loiter and change altitude to the RTH Home Altitude. Default is 0, which is feature disabled."
@@ -2654,7 +2654,7 @@
         "message": "<strong>Final approach altitude</strong>. Altitude under which the aircraft will go down at <strong>Final landing speed</strong> until touchdown"
     },
     "emergencyDescentRate": {
-        "message": "Emergency landing speed [cm/s]"
+        "message": "Emergency landing speed"
     },
     "cruiseThrottle": {
         "message": "Cruise throttle"
@@ -2678,31 +2678,31 @@
         "message": "Max. throttle"
     },
     "maxBankAngle": {
-        "message": "Max. navigation bank angle [degrees]"
+        "message": "Max. navigation bank angle"
     },
     "maxBankAngleHelp": {
         "message": "Maximum banking angle in navigation modes. Constrained by maximum ROLL angle in PID tuning tab."
     },
     "maxClimbAngle": {
-        "message": "Max. navigation climb angle [degrees]"
+        "message": "Max. navigation climb angle"
     },
     "maxClimbAngleHelp": {
         "message": "Maximum climb angle in navigation modes. Constrained by maximum PITCH angle in PID tuning tab."
     },
     "navManualClimbRate": {
-        "message": "Max. Alt-hold climb rate [cm/s]"
+        "message": "Max. Alt-hold climb rate"
     },
     "navManualClimbRateHelp": {
         "message": "Maximum climb/descent rate firmware is allowed when processing pilot input for ALTHOLD control mode [cm/s]"
     },
     "navAutoClimbRate": {
-        "message": "Max. navigation climb rate [cm/s]"
+        "message": "Max. navigation climb rate"
     },
     "navAutoClimbRateHelp": {
         "message": "Maximum climb/descent rate that UAV is allowed to reach during navigation modes. [cm/s]"
     },
     "maxDiveAngle": {
-        "message": "Max. navigation dive angle [degrees]"
+        "message": "Max. navigation dive angle"
     },
     "maxDiveAngleHelp": {
         "message": "Maximum dive angle in navigation modes. Constrained by maximum PITCH angle in PID tuning tab."
@@ -2720,13 +2720,13 @@
         "message": "How smoothly the autopilot adjusts the throttle level in response to pitch angle changes [0-9]."
     },
     "pitchToThrottleThreshold": {
-        "message": "Instantaneous throttle adjustment threshold [centidegrees]"
+        "message": "Instantaneous throttle adjustment threshold"
     },
     "pitchToThrottleThresholdHelp": {
         "message": "The autopilot will instantly adjust the throttle level without smoothing according to pitch to throttle if the pitch angle is more this many centidegrees from the filtered value."
     },
     "loiterRadius": {
-        "message": "Loiter radius [cm]"
+        "message": "Loiter radius"
     },
     "loiterDirectionLabel": {
         "message": "Loiter direction"
@@ -2744,25 +2744,25 @@
         "message": "Battery Estimation Settings"
     },
     "idlePower": {
-        "message": "Idle power [cW]"
+        "message": "Idle power"
     },
     "idlePowerHelp": {
         "message": "Power draw at zero throttle used for remaining flight time/distance estimation in 0.01W unit"
     },
     "cruisePower": {
-        "message": "Cruise power [cW]"
+        "message": "Cruise power"
     },
     "cruisePowerHelp": {
         "message": "Power draw at cruise throttle used for remaining flight time/distance estimation in 0.01W unit"
     },
     "cruiseSpeed": {
-        "message": "Cruise speed [cm/s]"
+        "message": "Cruise speed"
     },
     "cruiseSpeedHelp": {
         "message": "Speed for the plane/wing at cruise throttle used for remaining flight time/distance estimation in cm/s"
     },
     "rthEnergyMargin": {
-        "message": "RTH energy margin [%]"
+        "message": "RTH energy margin"
     },
     "rthEnergyMarginHelp": {
         "message": "Energy margin wanted after getting home (percent of battery energy capacity). Use for the remaining flight time/distance calculation."
@@ -2774,13 +2774,13 @@
         "message": "Waypoint Navigation Settings"
     },
     "waypointRadius": {
-        "message": "Waypoint radius [cm]"
+        "message": "Waypoint radius"
     },
     "waypointRadiusHelp": {
         "message": "This sets the distance away from a waypoint that triggers the waypoint as reached."
     },
     "waypointSafeDistance": {
-        "message": "Waypoint safe distance [cm]."
+        "message": "Waypoint safe distance"
     },
     "waypointSafeDistanceHelp": {
         "message": "The maximum distance between the home point and the first waypoint."
@@ -3677,49 +3677,49 @@
         "message": "Distance to home"
     },
     "brakingSpeedThreshold": {
-        "message": "Min. speed threshold [cm/s]"
+        "message": "Min. speed threshold"
     },
     "brakingSpeedThresholdTip": {
         "message": "Braking will be enabled only if actual speed if higher than threshold"
     },
     "brakingDisengageSpeed": {
-        "message": "Braking disengage speed [cm/s]"
+        "message": "Braking disengage speed"
     },
     "brakingDisengageSpeedTip": {
         "message": "Braking will end when speed goes below this value"
     },
     "brakingTimeout": {
-        "message": "Max. braking duration [ms]"
+        "message": "Max. braking duration"
     },
     "brakingTimeoutTip": {
         "message": "Safety measure. This is the longest period of time braking can be active."
     },
     "brakingBoostFactor": {
-        "message": "Boost factor [%]"
+        "message": "Boost factor"
     },
     "brakingBoostFactorTip": {
         "message": "Defines how strong the braking boost will be. 100% means the navigation engine is allowed to double the banking speed and acceleration"
     },
     "brakingBoostTimeout": {
-        "message": "Max. braking boost duration [ms]"
+        "message": "Max. braking boost duration"
     },
     "brakingBoostTimeoutTip": {
         "message": "Safety measure. This is the longest period of time braking boost can be active."
     },
     "brakingBoostSpeedThreshold": {
-        "message": "Boost min. speed threshold [cm/s]"
+        "message": "Boost min. speed threshold"
     },
     "brakingBoostSpeedThresholdTip": {
         "message": "Braking boost will be enabled only if actual speed if higher than threshold"
     },
     "brakingBoostDisengageSpeed": {
-        "message": "Braking boost disengage speed [cm/s]"
+        "message": "Braking boost disengage speed"
     },
     "brakingBoostDisengageSpeedTip": {
         "message": "Braking boost will end when speed goes below this value"
     },
     "brakingBankAngle": {
-        "message": "Max. bank angle [degrees]"
+        "message": "Max. bank angle"
     },
     "brakingBankAngleTip": {
         "message": "Max bank angle allowed during braking phase"

--- a/js/settings.js
+++ b/js/settings.js
@@ -215,7 +215,7 @@ var Settings = (function () {
             if (conversionTable[uiUnitValue]){
                 const fromUnits = conversionTable[uiUnitValue];
                 if (fromUnits[inputUnit]){
-                    cost multiplier = unitRatioTable[inputUnit][fromUnits[inputUnit]];
+                    const multiplier = unitRatioTable[inputUnit][fromUnits[inputUnit]];
                     return {'multiplier':multiplier, 'unitName':fromUnits[inputUnit]};
                 }
             }

--- a/js/settings.js
+++ b/js/settings.js
@@ -63,7 +63,7 @@ var Settings = (function () {
                     } else {
                         input.attr('step', "0.01");
                     }
-                    
+
                     input.attr('min', s.setting.min);
                     input.attr('max', s.setting.max);
                     input.val(s.value.toFixed(2));
@@ -104,19 +104,18 @@ var Settings = (function () {
         const getUnitDisplayTypeValue = () => {
             // Try and match the values 
             switch (configUnitType) {
+                case UnitType.none:
+                    return  5;
+                    break;
+                case UnitType.metric:
+                    return 0;
+                    break;
+                case UnitType.imperial:
+                    return 1;
+                    break;
                 case UnitType.OSD: // Match the OSD value on the UI
                     return globalSettings.osdUnits;
                     break;
-                case UnitType.imperial:
-                    return 0; // Imperial OSD Value
-                    break;
-                case UnitType.metric:
-                    return 1; // Metric + MPH OSD Value
-                    break;
-                case UnitType.none:
-                default:
-                    // Something went wrong
-                    return -1;
             }
         }
 
@@ -126,48 +125,104 @@ var Settings = (function () {
 
         const oldValue = element.val();
 
+        //display names for the units
+        const unitDisplayDames = {
+            'us' : "uS",
+            'deg' : '&deg;',
+            'cdeg' : 'centi&deg;',
+            'cmss' : 'cm/s/s',
+            'cm' : 'cm',
+            'cms' : 'cm/s',
+            'm' : 'm',
+            'ms' : 'ms',
+            'mps' : 'm/s',
+            'kmh' : 'Km/h',
+            'sec' : 's',
+            'kt' : 'Kt',
+            'ft' : 'ft',
+            'mph' : 'mph',
+            'cw' : 'cW',
+            'percent' : '%'
+        }
+
+
         // Ensure we can do conversions
-        if (configUnitType === UnitType.none || uiUnitValue === -1 || !inputUnit || !oldValue || !element) {
+        if (uiUnitValue === -1 || !inputUnit || !oldValue || !element) {
             return;
         }
 
-        // Used to convert between a value and a value matching the int
-        // unit display value. Eg 1 = Metric 
-        // units. We use the OSD unit values here for easy
-        const conversionTable = {    
-            1: {
-                'cm':  { multiplier: 100, unitName: 'm' },
-                'cms': { multiplier: 27.77777777777778, unitName: 'Km/h' }
+        //this is used to get the factor in which we multiply
+        //to get the correct conversion, the first index is the from
+        //unit and the second is the too unit
+        //unitConversionTable[toUnit][fromUnit] -> factor
+        const unitConversionTable = {
+            'cm' : {
+                'm' : 100, 
+                'ft' : 30.48
             },
-            2: {
-                'cm':  { multiplier: 100, unitName: 'm' },
-            },          
-            4: {
-                'cms': { multiplier: 51.44444444444457, unitName: 'Kt' }
+            'cms' : {
+                'kmh' : 27.77777777777778, 
+                'kt': 51.44444444444457, 
+                'mph' : 44.704,
+                'mps' : 100
             },
-            default: {
-                'cm':  { multiplier: 30.48, unitName: 'ft' },
-                'cms': { multiplier: 44.704, unitName: 'mph' },
-                'ms':  { multiplier: 1000, unitName: 'sec' }                
+            'ms' : {
+                'sec' : 1000
             },
-        }
+            'cdeg' : {
+                'deg' : 10
+            },
+        };
 
-        // Small closure to try and get the multiplier 
-        // needed from the conversion table
+        //this holds which units get converted in which unit systems
+        const conversionTable = {
+            0: {//metric
+                'cm': 'm',
+                'cms' : 'kmh',
+                'ms' : 'sec',
+                'cdeg' : 'deg'
+            },
+            1: { //imperial
+                'cm' : 'ft',
+                'cms' : 'mph',
+                'cdeg' : 'deg',
+                'ms' : 'sec'
+            },
+            2: { //metric with MPH
+                'cm': 'm',
+                'cms' : 'mph',
+                'cdeg' : 'deg',
+                'ms' : 'sec'
+            },
+            3:{ //UK
+                'cm' : 'ft',
+                'cms' : 'mph',
+                'cdeg' : 'deg',
+                'ms' : 'sec'
+            },
+            4: { //General aviation
+                'cm' : 'ft',
+                'cms': 'kt',
+                'cdeg' : 'deg',
+                'ms' : 'sec'
+            },
+            5:{} //default units
+        };
+
+        //this returns the factor in which to multiply to convert a unit
         const getUnitMultiplier = () => {
-            if(conversionTable[uiUnitValue] && conversionTable[uiUnitValue][inputUnit]) {
-                return conversionTable[uiUnitValue][inputUnit];
+            if (conversionTable[uiUnitValue]){
+                const fromUnits = conversionTable[uiUnitValue];
+                if (fromUnits[inputUnit]){
+                    const multiplier = unitConversionTable[inputUnit][fromUnits[inputUnit]];
+                    return {'multiplier':multiplier, 'unitName':fromUnits[inputUnit]};
+                }
             }
-            
-            return conversionTable['default'][inputUnit];
+            return {multiplier:1, unitName:inputUnit};         
         }
 
         // Get the default multi obj or the custom       
         const multiObj = getUnitMultiplier();
-
-        if(!multiObj) {
-            return;
-        }
 
         const multiplier = multiObj.multiplier;
         const unitName = multiObj.unitName;
@@ -186,7 +241,7 @@ var Settings = (function () {
         element.data('setting-multiplier', multiplier);
 
         // Now wrap the input in a display that shows the unit
-        element.wrap(`<div data-unit="${unitName}" class="unit_wrapper unit"></div>`);
+        element.wrap(`<div data-unit="${unitDisplayDames[unitName]}" class="unit_wrapper unit"></div>`);
     }
 
     self.saveInput = function(input) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -104,9 +104,6 @@ var Settings = (function () {
         const getUnitDisplayTypeValue = () => {
             // Try and match the values 
             switch (configUnitType) {
-                case UnitType.none:
-                    return  5;
-                    break;
                 case UnitType.metric:
                     return 0;
                     break;
@@ -115,6 +112,10 @@ var Settings = (function () {
                     break;
                 case UnitType.OSD: // Match the OSD value on the UI
                     return globalSettings.osdUnits;
+                    break;
+                case UnitType.none:
+                default:
+                    return -1;
                     break;
             }
         }
@@ -147,7 +148,7 @@ var Settings = (function () {
 
 
         // Ensure we can do conversions
-        if (uiUnitValue === -1 || !inputUnit || !oldValue || !element) {
+        if (!inputUnit || !oldValue || !element) {
             return;
         }
 
@@ -155,7 +156,7 @@ var Settings = (function () {
         //to get the correct conversion, the first index is the from
         //unit and the second is the too unit
         //unitConversionTable[toUnit][fromUnit] -> factor
-        const unitConversionTable = {
+        const unitRatioTable = {
             'cm' : {
                 'm' : 100, 
                 'ft' : 30.48
@@ -206,7 +207,7 @@ var Settings = (function () {
                 'cdeg' : 'deg',
                 'ms' : 'sec'
             },
-            5:{} //default units
+            default:{}//show base units
         };
 
         //this returns the factor in which to multiply to convert a unit
@@ -214,11 +215,11 @@ var Settings = (function () {
             if (conversionTable[uiUnitValue]){
                 const fromUnits = conversionTable[uiUnitValue];
                 if (fromUnits[inputUnit]){
-                    const multiplier = unitConversionTable[inputUnit][fromUnits[inputUnit]];
+                    cost multiplier = unitRatioTable[inputUnit][fromUnits[inputUnit]];
                     return {'multiplier':multiplier, 'unitName':fromUnits[inputUnit]};
                 }
             }
-            return {multiplier:1, unitName:inputUnit};         
+            return {multiplier:1, unitName:inputUnit};
         }
 
         // Get the default multi obj or the custom       

--- a/js/settings.js
+++ b/js/settings.js
@@ -104,10 +104,10 @@ var Settings = (function () {
         const getUnitDisplayTypeValue = () => {
             // Try and match the values 
             switch (configUnitType) {
-                case UnitType.metric:
+                case UnitType.imperial:
                     return 0;
                     break;
-                case UnitType.imperial:
+                case UnitType.metric:
                     return 1;
                     break;
                 case UnitType.OSD: // Match the OSD value on the UI

--- a/js/settings.js
+++ b/js/settings.js
@@ -177,17 +177,17 @@ var Settings = (function () {
 
         //this holds which units get converted in which unit systems
         const conversionTable = {
-            0: {//metric
-                'cm': 'm',
-                'cms' : 'kmh',
-                'ms' : 'sec',
-                'cdeg' : 'deg'
-            },
-            1: { //imperial
+            0: { //imperial
                 'cm' : 'ft',
                 'cms' : 'mph',
                 'cdeg' : 'deg',
                 'ms' : 'sec'
+            },
+            1: {//metric
+                'cm': 'm',
+                'cms' : 'kmh',
+                'ms' : 'sec',
+                'cdeg' : 'deg'
             },
             2: { //metric with MPH
                 'cm': 'm',

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -11,12 +11,12 @@
                     </div>
                     <div class="spacer_box settings">
                         <div class="number">
-                            <input type="number" id="launchIdleThr" data-setting="nav_fw_launch_idle_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
+                            <input type="number" id="launchIdleThr" data-unit="us" data-setting="nav_fw_launch_idle_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
                             <label for="launchIdleThr"><span data-i18n="configurationLaunchIdleThr"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="configurationLaunchIdleThrHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="launchMaxAngle" data-setting="nav_fw_launch_max_angle" data-setting-multiplier="1" step="1" min="5" max="180" />
+                            <input type="number" id="launchMaxAngle" data-unit="deg" data-setting="nav_fw_launch_max_angle" data-setting-multiplier="1" step="1" min="5" max="180" />
                             <label for="launchMaxAngle"><span data-i18n="configurationLaunchMaxAngle"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="configurationLaunchMaxAngleHelp"></div>
                         </div>
@@ -26,7 +26,7 @@
                             <div class="helpicon cf_tip" data-i18n_title="configurationLaunchVelocityHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="launchAccel" data-setting="nav_fw_launch_accel" data-setting-multiplier="1" step="1" min="1000" max="20000" />
+                            <input type="number" id="launchAccel" data-unit="cmss" data-setting="nav_fw_launch_accel" data-setting-multiplier="1" step="1" min="1000" max="20000" />
                             <label for="launchAccel"><span data-i18n="configurationLaunchAccel"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="configurationLaunchAccelHelp"></div>
                         </div>
@@ -51,12 +51,12 @@
                             <div class="helpicon cf_tip" data-i18n_title="configurationLaunchSpinupTimeHelp"></div>
                         </div>
                          <div class="number">
-                            <input type="number" id="launchThr" data-setting="nav_fw_launch_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
+                            <input type="number" id="launchThr" data-unit="us" data-setting="nav_fw_launch_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
                             <label for="launchThr"><span data-i18n="configurationLaunchThr"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="configurationLaunchThrHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="launchClimbAngle" data-setting="nav_fw_launch_climb_angle" data-setting-multiplier="1" step="1" min="0" max="45" />
+                            <input type="number" id="launchClimbAngle" data-unit="deg" data-setting="nav_fw_launch_climb_angle" data-setting-multiplier="1" step="1" min="0" max="45" />
                             <label for="launchClimbAngle"><span data-i18n="configurationLaunchClimbAngle"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="configurationLaunchClimbAngleHelp"></div>
                         </div>
@@ -84,12 +84,12 @@
                     </div>
                     <div class="spacer_box">
                         <div class="number">
-                            <input type="number" id="idlePower" data-setting="idle_power" data-setting-multiplier="1" step="1" min="0" max="65535" />
+                            <input type="number" id="idlePower" data-unit="cw" data-setting="idle_power" data-setting-multiplier="1" step="1" min="0" max="65535" />
                             <label for="idlePower"><span data-i18n="idlePower"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="idlePowerHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="cruisePower" data-setting="cruise_power" data-setting-multiplier="1" step="1" min="0" max="4294967295" />
+                            <input type="number" id="cruisePower" data-unit="cw" data-setting="cruise_power" data-setting-multiplier="1" step="1" min="0" max="4294967295" />
                             <label for="cruisePower"><span data-i18n="cruisePower"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="cruisePowerHelp"></div>
                         </div>
@@ -99,7 +99,7 @@
                             <div class="helpicon cf_tip" data-i18n_title="cruiseSpeedHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="rthEnergyMargin" data-setting="rth_energy_margin" data-setting-multiplier="1" step="1" min="0" max="100" />
+                            <input type="number" id="rthEnergyMargin" data-unit="percent" data-setting="rth_energy_margin" data-setting-multiplier="1" step="1" min="0" max="100" />
                             <label for="rthEnergyMargin"><span data-i18n="rthEnergyMargin"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="rthEnergyMarginHelp"></div>
                         </div>
@@ -116,7 +116,7 @@
                     <div class="spacer_box">
 
                         <div class="number">
-                            <input id="cruiseThrottle" type="number" data-setting="nav_fw_cruise_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
+                            <input id="cruiseThrottle" type="number" data-unit="us" data-setting="nav_fw_cruise_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
                             <label for="cruiseThrottle"><span data-i18n="cruiseThrottle"></span></label>
                         </div>
 
@@ -133,12 +133,12 @@
                         </div>
 
                         <div class="number">
-                            <input id="minThrottle" type="number" data-setting="nav_fw_min_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
+                            <input id="minThrottle" type="number" data-unit="us" data-setting="nav_fw_min_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
                             <label for="minThrottle"><span data-i18n="minThrottle"></span></label>
                         </div>
 
                         <div class="number">
-                            <input id="maxThrottle" type="number" data-setting="nav_fw_max_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
+                            <input id="maxThrottle" type="number" data-unit="us" data-setting="nav_fw_max_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
                             <label for="maxThrottle"><span data-i18n="maxThrottle"></span></label>
                         </div>
 
@@ -149,7 +149,7 @@
                         </div>
 
                         <div class="number">
-                            <input id="pitchToThrottleThreshold" type="number" data-setting="nav_fw_pitch2thr_threshold" data-setting-multiplier="1" step="1" min="0" max="900" />
+                            <input id="pitchToThrottleThreshold" type="number" data-unit="cdeg" data-setting="nav_fw_pitch2thr_threshold" data-setting-multiplier="1" step="1" min="0" max="900" />
                             <label for="pitchToThrottleThreshold"><span data-i18n="pitchToThrottleThreshold"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="pitchToThrottleThresholdHelp"></div>
                         </div>
@@ -161,19 +161,19 @@
                         </div>
 
                         <div class="number">
-                            <input id="maxBankAngle" type="number" data-setting="nav_fw_bank_angle" data-setting-multiplier="1" step="1" min="5" max="80" />
+                            <input id="maxBankAngle" type="number" data-unit="deg" data-setting="nav_fw_bank_angle" data-setting-multiplier="1" step="1" min="5" max="80" />
                             <label for="maxBankAngle"><span data-i18n="maxBankAngle"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="maxBankAngleHelp"></div>
                         </div>
 
                         <div class="number">
-                            <input id="maxClimbAngle" type="number" data-setting="nav_fw_climb_angle" data-setting-multiplier="1" step="1" min="5" max="80" />
+                            <input id="maxClimbAngle" type="number" data-unit="deg" data-setting="nav_fw_climb_angle" data-setting-multiplier="1" step="1" min="5" max="80" />
                             <label for="maxClimbAngle"><span data-i18n="maxClimbAngle"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="maxClimbAngleHelp"></div>
                         </div>
 
                         <div class="number">
-                            <input id="maxDiveAngle" type="number" data-setting="nav_fw_dive_angle" data-setting-multiplier="1" step="1" min="5" max="80" />
+                            <input id="maxDiveAngle" type="number" data-unit="deg" data-setting="nav_fw_dive_angle" data-setting-multiplier="1" step="1" min="5" max="80" />
                             <label for="maxDiveAngle"><span data-i18n="maxDiveAngle"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="maxDiveAngleHelp"></div>
                         </div>
@@ -230,7 +230,7 @@
                             <div class="helpicon cf_tip" data-i18n_title="posholdMaxManualSpeedHelp"></div>
                         </div>
                         <div class="number">
-                            <input id="max-bank-angle" type="number" data-setting="nav_mc_bank_angle" data-setting-multiplier="1" step="1" min="15" max="45" />
+                            <input id="max-bank-angle" type="number" data-unit="deg" data-setting="nav_mc_bank_angle" data-setting-multiplier="1" step="1" min="15" max="45" />
                             <label for="max-bank-angle"><span data-i18n="posholdMaxBankAngle"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="posholdMaxBankAngleHelp"></div>
                         </div>
@@ -239,7 +239,7 @@
                             <label for="use-mid-throttle"><span data-i18n="posholdHoverMidThrottle"></span></label>
                         </div>
                         <div class="number">
-                            <input id="hover-throttle" type="number" data-setting="nav_mc_hover_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
+                            <input id="hover-throttle" type="number" data-unit="us" data-setting="nav_mc_hover_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
                             <label for="hover-throttle"><span data-i18n="posholdHoverThrottle"></span></label>
                         </div>
                         <div class="checkbox">
@@ -301,7 +301,7 @@
                         </div>
 
                         <div class="number">
-                            <input id="brakingBankAngle" type="number" data-setting="nav_mc_braking_bank_angle" data-setting-multiplier="1" step="1" min="15" max="60" />
+                            <input id="brakingBankAngle" type="number" data-unit="deg" data-setting="nav_mc_braking_bank_angle" data-setting-multiplier="1" step="1" min="15" max="60" />
                             <label for="brakingBankAngle"><span data-i18n="brakingBankAngle"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="brakingBankAngleTip"></div>
                         </div>
@@ -434,25 +434,25 @@
                     <div class="spacer_box">
 
                         <div class="number">
-                            <input id="landMaxAltVspd" type="number" data-setting="nav_land_maxalt_vspd" data-setting-multiplier="1" step="1" min="100" max="2000" />
+                            <input id="landMaxAltVspd" type="number" data-unit="cms" data-setting="nav_land_maxalt_vspd" data-setting-multiplier="1" step="1" min="100" max="2000" />
                             <label for="landMaxAltVspd"><span data-i18n="landMaxAltVspd"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="landMaxAltVspdHelp"></div>
                         </div>
 
                         <div class="number">
-                            <input id="landSlowdownMaxAlt" type="number" data-setting="nav_land_slowdown_maxalt" data-setting-multiplier="1" step="1" min="500" max="4000" />
+                            <input id="landSlowdownMaxAlt" type="number" data-unit="cm" data-setting="nav_land_slowdown_maxalt" data-setting-multiplier="1" step="1" min="500" max="4000" />
                             <label for="landSlowdownMaxAlt"><span data-i18n="landSlowdownMaxAlt"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="landSlowdownMaxAltHelp"></div>
                         </div>
 
                         <div class="number">
-                            <input id="landMinAltVspd" type="number" data-setting="nav_land_minalt_vspd" data-setting-multiplier="1" step="1" min="50" max="500" />
+                            <input id="landMinAltVspd" type="number" data-unit="cms" data-setting="nav_land_minalt_vspd" data-setting-multiplier="1" step="1" min="50" max="500" />
                             <label for="landMinAltVspd"><span data-i18n="landMinAltVspd"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="landMinAltVspdHelp"></div>
                         </div>
 
                         <div class="number">
-                            <input id="landSlowdownMinAlt" type="number" data-setting="nav_land_slowdown_minalt" data-setting-multiplier="1" step="1" min="50" max="1000" />
+                            <input id="landSlowdownMinAlt" type="number" data-unit="cm" data-setting="nav_land_slowdown_minalt" data-setting-multiplier="1" step="1" min="50" max="1000" />
                             <label for="landSlowdownMinAlt"><span data-i18n="landSlowdownMinAlt"></span></label>
                         </div>
 


### PR DESCRIPTION
There can be multiple units in the Advanced Tuning tab, firstly the units at the end of the description next to the input, and the units which appear when you change the units for the configurator. This can be confusing for people.
I have removed the units from the descriptions. Added tags to the inputs denoting the unit type. Changed some code in the settings file which goes through all the inputs and shows the appropriate unit. Converting between units still works.
This is my first contribution to this/any public project, Thanks.