### PR TITLE
Add button to re-select defaults

### DIFF
--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -244,11 +244,9 @@
 .show {
     width:110px;
     float:right;
-    margin-right:3px;
 }
 
 .show a {
-    margin-left: 10px;
     width: calc(100% - 10px);
 }
 
@@ -328,6 +326,7 @@
 .tab-pid_tuning .resetbt {
     width: 140px;
     float: right;
+    margin-right:10px;
 }
 
 .tab-pid_tuning .right {

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -12,12 +12,12 @@
             <div class="cf_column right" style="margin-top: -6px;">
                 <div class="default_btn show">
                     <a href="#" id="showAllPids">Show all PIDs</a>
-                </div>
-                <div class="default_btn resetbt">
-                    <a href="#" id="resetPIDs">Reset PID Controller</a>
                 </div> 
                 <div class="default_btn resetbt">
                     <a href="#" id="resetDefaults">Select New Defaults</a>
+                </div>
+                <div class="default_btn resetbt">
+                    <a href="#" id="resetPIDs">Reset PID Controller</a>
                 </div>
             </div>
             <div class="tab_subtitle" style="margin-top: 1em;">PID gains</div>

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -15,6 +15,9 @@
                 </div>
                 <div class="default_btn resetbt">
                     <a href="#" id="resetPIDs">Reset PID Controller</a>
+                </div> 
+                <div class="default_btn resetbt">
+                    <a href="#" id="resetDefaults">Select New Defaults</a>
                 </div>
             </div>
             <div class="tab_subtitle" style="margin-top: 1em;">PID gains</div>

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -151,6 +151,21 @@ TABS.pid_tuning.initialize = function (callback) {
 	        updateActivatedTab();
         });
 
+        $('#resetDefaults').on('click', function() {
+            mspHelper.setSetting("applied_defaults", 0, function() { 
+                mspHelper.saveToEeprom( function () {
+                    GUI.log(chrome.i18n.getMessage('configurationEepromSaved'));
+
+                    GUI.tab_switch_cleanup(function () {
+                        MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, function () {
+                            GUI.log(chrome.i18n.getMessage('deviceRebooting'));
+                            GUI.handleReconnect();
+                        });
+                    });
+                });
+            });
+        });
+
         pid_and_rc_to_form();
 
         let $magHoldYawRate                 = $("#magHoldYawRate");


### PR DESCRIPTION
This change adds a button to the PID Tuning tab to re-select the flight controller defaults.

![image](https://user-images.githubusercontent.com/17590174/147385002-b81cca4b-d473-4237-900f-a48d314da3f5.png)

[Video Demo](https://youtu.be/jSjj8hn-Ld4)
