### PR TITLE
Made the Hide Unused PIDs button fit the available space

### DIFF
--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -252,6 +252,10 @@
     width: calc(100% - 10px);
 }
 
+.show.unusedPIDsHidden {
+    width: 130px;
+}
+
 .tab-pid_tuning .helpicon {
     margin-top: -1px;
 }

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -140,9 +140,11 @@ TABS.pid_tuning.initialize = function (callback) {
           if($(this).text() == "Show all PIDs") {
             $('.tab-pid_tuning table.pid_tuning').show();
             $(this).text('Hide unused PIDs');
+            $('.show').addClass('unusedPIDsHidden');
           } else {
             hideUnusedPids(CONFIG.activeSensors);
             $(this).text('Show all PIDs');
+            $('.show').removeClass('unusedPIDsHidden');
           }
         });
 


### PR DESCRIPTION
There was an issue where clicking the Show Unused PIDs button left the screen looking messy. This fixes that.

![image](https://user-images.githubusercontent.com/17590174/147392180-81124fa8-a0d2-4008-a4bc-f8728eef7e8c.png)
Show all PIDs button

![image](https://user-images.githubusercontent.com/17590174/147392186-99d6f15a-cab7-4e80-b03e-89a2662961e4.png)
Hide Unused PIDs button before the change

![image](https://user-images.githubusercontent.com/17590174/147392194-91c572a2-321e-4cba-9e42-87c4c328e2fe.png)
Hide Unused PIDs button after the change