### PR TITLE
Updated fixed wing mixer to improve the ease of use

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3571,9 +3571,6 @@
     "platformConfiguration": {
         "message": "Platform configuration"
     },
-    "platformHasFlaps": {
-        "message": "Has flaps"
-    },
     "mixerPreset": {
         "message": "Mixer preset"
     },

--- a/js/fc.js
+++ b/js/fc.js
@@ -999,7 +999,7 @@ var FC = {
             'RC Channel 8',         // 11
             'Gimbal Pitch',         // 12
             'Gimbal Roll',          // 13
-            'Flaps',                // 14
+            'Flaperon Mode',        // 14
             'RC Channel 9',         // 15
             'RC Channel 10',        // 16
             'RC Channel 11',        // 17

--- a/js/model.js
+++ b/js/model.js
@@ -2,10 +2,12 @@
 
 const SERVO_GIMBAL_PITCH = 0,
     SERVO_GIMBAL_ROLL = 1,
-    SERVO_ELEVATOR = 2,
-    SERVO_FLAPPERON_1 = 3,
-    SERVO_FLAPPERON_2 = 4,
-    SERVO_RUDDER = 5,
+    SERVO_ELEVATOR = 1,
+    SERVO_ELEVON_1 = 1,
+    SERVO_ELEVON_2 = 2,
+    SERVO_FLAPPERON_1 = 2,
+    SERVO_FLAPPERON_2 = 3,
+    SERVO_RUDDER = 4,
     SERVO_BICOPTER_LEFT = 4,
     SERVO_BICOPTER_RIGHT = 5,
     SERVO_DUALCOPTER_LEFT = 4,
@@ -162,10 +164,10 @@ const mixerList = [
             new MotorMixRule(1.0, 0.0, 0.0, 0.0),
         ],
         servoMixer: [
-            new ServoMixRule(SERVO_FLAPPERON_1, INPUT_STABILIZED_ROLL,  50, 0),
-            new ServoMixRule(SERVO_FLAPPERON_1, INPUT_STABILIZED_PITCH, 50, 0),
-            new ServoMixRule(SERVO_FLAPPERON_2, INPUT_STABILIZED_ROLL, -50, 0),
-            new ServoMixRule(SERVO_FLAPPERON_2, INPUT_STABILIZED_PITCH, 50, 0),
+            new ServoMixRule(SERVO_ELEVON_1, INPUT_STABILIZED_ROLL,  50, 0),
+            new ServoMixRule(SERVO_ELEVON_1, INPUT_STABILIZED_PITCH, 50, 0),
+            new ServoMixRule(SERVO_ELEVON_2, INPUT_STABILIZED_ROLL, -50, 0),
+            new ServoMixRule(SERVO_ELEVON_2, INPUT_STABILIZED_PITCH, 50, 0),
         ]
     },     // 8
     {
@@ -181,10 +183,10 @@ const mixerList = [
             new MotorMixRule(1.0, 0.0, 0.0, -0.1)
         ],
         servoMixer: [
-            new ServoMixRule(SERVO_FLAPPERON_1, INPUT_STABILIZED_ROLL,  50, 0),
-            new ServoMixRule(SERVO_FLAPPERON_1, INPUT_STABILIZED_PITCH, 50, 0),
-            new ServoMixRule(SERVO_FLAPPERON_2, INPUT_STABILIZED_ROLL, -50, 0),
-            new ServoMixRule(SERVO_FLAPPERON_2, INPUT_STABILIZED_PITCH, 50, 0),
+            new ServoMixRule(SERVO_ELEVON_1, INPUT_STABILIZED_ROLL,  50, 0),
+            new ServoMixRule(SERVO_ELEVON_1, INPUT_STABILIZED_PITCH, 50, 0),
+            new ServoMixRule(SERVO_ELEVON_2, INPUT_STABILIZED_ROLL, -50, 0),
+            new ServoMixRule(SERVO_ELEVON_2, INPUT_STABILIZED_PITCH, 50, 0),
         ]
     },     // 27
     {
@@ -289,6 +291,7 @@ const mixerList = [
         enabled: true,
         legacy: true,
         platform: PLATFORM_AIRPLANE,
+        hasFlaps: true,
         motorMixer: [
             new MotorMixRule(1.0, 0.0, 0.0, 0.0),
             new MotorMixRule(1.0, 0.0, 0.0, 0.0),
@@ -296,9 +299,9 @@ const mixerList = [
         servoMixer: [
             new ServoMixRule(SERVO_ELEVATOR,    INPUT_STABILIZED_PITCH, 100, 0),
             new ServoMixRule(SERVO_FLAPPERON_1, INPUT_STABILIZED_ROLL,  100, 0),
-            new ServoMixRule(SERVO_FLAPPERON_1, INPUT_FEATURE_FLAPS,    100, 0),
+            /*new ServoMixRule(SERVO_FLAPPERON_1, INPUT_FEATURE_FLAPS,    100, 0),*/
             new ServoMixRule(SERVO_FLAPPERON_2, INPUT_STABILIZED_ROLL,  100, 0),
-            new ServoMixRule(SERVO_FLAPPERON_2, INPUT_FEATURE_FLAPS,   -100, 0),
+            /*new ServoMixRule(SERVO_FLAPPERON_2, INPUT_FEATURE_FLAPS,   -100, 0),*/
             new ServoMixRule(SERVO_RUDDER,      INPUT_STABILIZED_YAW,   100, 0),
         ]
     },           // 14
@@ -448,6 +451,7 @@ const mixerList = [
         enabled: true,
         legacy: false,
         platform: PLATFORM_AIRPLANE,
+        hasFlaps: true,
         motorMixer: [
             new MotorMixRule(1.0, 0.0, 0.0, 0.3),
             new MotorMixRule(1.0, 0.0, 0.0, -0.3)
@@ -455,9 +459,9 @@ const mixerList = [
         servoMixer: [
             new ServoMixRule(SERVO_ELEVATOR,    INPUT_STABILIZED_PITCH, 100, 0),
             new ServoMixRule(SERVO_FLAPPERON_1, INPUT_STABILIZED_ROLL,  100, 0),
-            new ServoMixRule(SERVO_FLAPPERON_1, INPUT_FEATURE_FLAPS,    100, 0),
+            /*new ServoMixRule(SERVO_FLAPPERON_1, INPUT_FEATURE_FLAPS,    100, 0),*/
             new ServoMixRule(SERVO_FLAPPERON_2, INPUT_STABILIZED_ROLL,  100, 0),
-            new ServoMixRule(SERVO_FLAPPERON_2, INPUT_FEATURE_FLAPS,   -100, 0),
+            /*new ServoMixRule(SERVO_FLAPPERON_2, INPUT_FEATURE_FLAPS,   -100, 0),*/
             new ServoMixRule(SERVO_RUDDER,      INPUT_STABILIZED_YAW,   100, 0),
         ]
     },
@@ -469,16 +473,19 @@ const mixerList = [
         enabled: true,
         legacy: false,
         platform: PLATFORM_AIRPLANE,
+        hasFlaps: true,
         motorMixer: [
             new MotorMixRule(1.0, 0.0, 0.0, 0.0),
         ],
         servoMixer: [
+            new ServoMixRule(1, INPUT_STABILIZED_ROLL,  100, 0),
+            /*new ServoMixRule(1, INPUT_FEATURE_FLAPS,    100, 0),*/
             new ServoMixRule(2, INPUT_STABILIZED_ROLL,  100, 0),
-            new ServoMixRule(3, INPUT_STABILIZED_ROLL,  100, 0),
-            new ServoMixRule(4, INPUT_STABILIZED_PITCH, 50, 0),
-            new ServoMixRule(4, INPUT_STABILIZED_YAW,   -50, 0),
-            new ServoMixRule(5, INPUT_STABILIZED_PITCH, -50, 0),
-            new ServoMixRule(5, INPUT_STABILIZED_YAW,   -50, 0)
+            /*new ServoMixRule(2, INPUT_FEATURE_FLAPS,    100, 0),*/
+            new ServoMixRule(3, INPUT_STABILIZED_PITCH, 50, 0),
+            new ServoMixRule(3, INPUT_STABILIZED_YAW,   -50, 0),
+            new ServoMixRule(4, INPUT_STABILIZED_PITCH, -50, 0),
+            new ServoMixRule(4, INPUT_STABILIZED_YAW,   -50, 0)
         ]
     },
     {
@@ -493,11 +500,11 @@ const mixerList = [
             new MotorMixRule(1.0, 0.0, 0.0, 0.0),
         ],
         servoMixer: [
-            new ServoMixRule(2, INPUT_STABILIZED_ROLL,  100, 0),
-            new ServoMixRule(3, INPUT_STABILIZED_PITCH, 50, 0),
+            new ServoMixRule(1, INPUT_STABILIZED_ROLL,  100, 0),
+            new ServoMixRule(2, INPUT_STABILIZED_PITCH, 50, 0),
+            new ServoMixRule(2, INPUT_STABILIZED_YAW,   -50, 0),
+            new ServoMixRule(3, INPUT_STABILIZED_PITCH, -50, 0),
             new ServoMixRule(3, INPUT_STABILIZED_YAW,   -50, 0),
-            new ServoMixRule(4, INPUT_STABILIZED_PITCH, -50, 0),
-            new ServoMixRule(4, INPUT_STABILIZED_YAW,   -50, 0),
         ]
     },
     {
@@ -508,13 +515,16 @@ const mixerList = [
         enabled: true,
         legacy: false,
         platform: PLATFORM_AIRPLANE,
+        hasFlaps: true,
         motorMixer: [
             new MotorMixRule(1.0, 0.0, 0.0, 0.0),
         ],
         servoMixer: [
             new ServoMixRule(SERVO_ELEVATOR,    INPUT_STABILIZED_PITCH, 100, 0),
             new ServoMixRule(SERVO_FLAPPERON_1, INPUT_STABILIZED_ROLL,  100, 0),
+            /*new ServoMixRule(SERVO_FLAPPERON_1, INPUT_FEATURE_FLAPS,    100, 0),*/
             new ServoMixRule(SERVO_FLAPPERON_2, INPUT_STABILIZED_ROLL,  100, 0),
+            /*new ServoMixRule(SERVO_FLAPPERON_2, INPUT_FEATURE_FLAPS,    100, 0),*/
         ]
     },
     {

--- a/src/css/tabs/mixer.css
+++ b/src/css/tabs/mixer.css
@@ -84,6 +84,12 @@
 }
 
 .mixer_btn_add {
+    float: right;
+    margin: 15px 0 10px;
+}
+
+.mixer_btn_logic {
+    float: left;
     margin: 15px 0 10px;
 }
 

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -15,12 +15,6 @@
                                 <span data-i18n="platformType"></span>
                             </label>
                         </div>
-                        <div id="has-flaps-wrapper" class="checkbox">
-                            <input type="checkbox" id="has-flaps" class="toggle" />
-                            <label for="has-flaps">
-                                <span data-i18n="platformHasFlaps"></span>
-                            </label>
-                        </div>
                     </div>
                 </div>
             </div>
@@ -118,11 +112,11 @@
 
                     </tbody>
                 </table>
-                <div class="btn default_btn narrow pull-left mixer_btn_add">
-                    <a href="#" data-role="role-logic-conditions-open" data-i18n="tabLogicConditions"></a>
-                </div>
                 <div class="btn default_btn narrow pull-right green mixer_btn_add">
                     <a href="#" data-role="role-servo-add" data-i18n="servoMixerAdd"></a>
+                </div>
+                <div class="btn default_btn narrow pull-left mixer_btn_logic">
+                    <a href="#" data-role="role-logic-conditions-open" data-i18n="tabLogicConditions"></a>
                 </div>
             </div>
         </div>

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -124,6 +124,10 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
 
                 GUI.fillSelect($row.find(".mix-rule-input"), FC.getServoMixInputNames(), servoRule.getInput());
 
+                if (!MIXER_CONFIG.hasFlaps) {
+                    $row.find(".mix-rule-input").children('option[value="14"]').remove();
+                }
+
                 $row.find(".mix-rule-input").val(servoRule.getInput()).change(function () {
                     servoRule.setInput($(this).val());
                     updateFixedValueVisibility($row, $(this));
@@ -272,8 +276,6 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
 
         let $platformSelect = $('#platform-type'),
             platforms = helper.platform.getList(),
-            $hasFlapsWrapper = $('#has-flaps-wrapper'),
-            $hasFlaps = $('#has-flaps'),
             $mixerPreset = $('#mixer-preset'),
             $wizardButton = $("#mixer-wizard");
 
@@ -354,29 +356,11 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
             }
         }
 
-        $hasFlaps.prop("checked", MIXER_CONFIG.hasFlaps);
-        $hasFlaps.change(function () {
-            if ($(this).is(":checked")) {
-                MIXER_CONFIG.hasFlaps = 1;
-            } else {
-                MIXER_CONFIG.hasFlaps = 0;
-            }
-        });
-        $hasFlaps.change();
-
         $platformSelect.change(function () {
             MIXER_CONFIG.platformType = parseInt($platformSelect.val(), 10);
             currentPlatform = helper.platform.getById(MIXER_CONFIG.platformType);
 
             var $platformSelectParent = $platformSelect.parent('.select');
-
-            if (currentPlatform.flapsPossible) {
-                $hasFlapsWrapper.removeClass('is-hidden');
-                $platformSelectParent.removeClass('no-bottom-border');
-            } else {
-                $hasFlapsWrapper.addClass('is-hidden');
-                $platformSelectParent.addClass('no-bottom-border');
-            }
 
             fillMixerPreset();
             $mixerPreset.change();
@@ -390,6 +374,8 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
             currentMixerPreset = helper.mixer.getById(presetId);
 
             MIXER_CONFIG.appliedMixerPreset = presetId;
+
+            MIXER_CONFIG.hasFlaps = (currentMixerPreset.hasFlaps === true) ? true : false;
 
             if (currentMixerPreset.id == 3) {
                 $wizardButton.parent().removeClass("is-hidden");

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -375,8 +375,6 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
 
             MIXER_CONFIG.appliedMixerPreset = presetId;
 
-            MIXER_CONFIG.hasFlaps = (currentMixerPreset.hasFlaps === true) ? true : false;
-
             if (currentMixerPreset.id == 3) {
                 $wizardButton.parent().removeClass("is-hidden");
             } else {
@@ -416,6 +414,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         $('#load-mixer-button').click(function () {
             helper.mixer.loadServoRules(currentMixerPreset);
             helper.mixer.loadMotorRules(currentMixerPreset);
+            MIXER_CONFIG.hasFlaps = (currentMixerPreset.hasFlaps === true) ? true : false;
             renderServoMixRules();
             renderMotorMixRules();
             renderOutputMapping();


### PR DESCRIPTION
In this update, a couple of changes have been made.

1. Servo function indexing now starts at 1. Starting at 2 or 3 depending on the mixer was just confusing. Now they index properly.
2. Overhaul of the "flaps" options.

Firstly, they weren't even flaps, they were flaperons. So the definition was confusing. Also, the toggle to enable and disable the **flaperons** mode didn't really make sense. 

This change removes the "Use flaps" toggle. Instead, when a mix is loaded, it will enable or disable the **flaperons** mode. This is base on the individual mix, not the platform. As a flying wing uses the airplane platform, but cannot have flaperons. Neither can the V-tail with a single aileron servo. The option to add flaperons to the mixer is also removed when the mode is not active.

Speaking to quite a few RC pilots. They all seemed to remove the "FLAPS" rows from the mixer. It also seemed silly adding them by default when the mode was disabled too. Also, it was only added on 50% of the mix types that could use it. I have commented out the code in model.js that adds these rows. So reevoking it would be easy. I also added commented out rows on the models which could have flaperons, but the rows were not present.

[Here's a video demo](https://youtu.be/-i4U9AZmnB4)

![image](https://user-images.githubusercontent.com/17590174/147756840-6904b88b-d51f-400b-a8b7-b0caeac2e563.png)