### PR TITLE
Adds min and max limits to all numerical fields

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -71,6 +71,14 @@ var Settings = (function () {
                     var multiplier = parseFloat(input.data('setting-multiplier') || 1);
                     input.attr('type', 'number');
                     input.val((s.value / multiplier).toFixed(Math.log10(multiplier)));
+
+                    if (s.setting.min) {
+                        input.attr('min', (s.setting.min / multiplier).toFixed(Math.log10(multiplier)));
+                    }
+
+                    if (s.setting.max) {
+                        input.attr('max', (s.setting.max / multiplier).toFixed(Math.log10(multiplier)));
+                    }
                 }
 
                 // If data is defined, We want to convert this value into 


### PR DESCRIPTION
This adds min and max limits to all numerical fields; if they use the data-setting method. This doesn't cover the old MSP fields.

Fixes #1427