### PR TITLE
Adding BLE Support (SpeedyBee, HM-1X)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,6 +87,8 @@ sources.js = [
     './js/msp/MSPchainer.js',
     './js/port_handler.js',
     './js/serial.js',
+    './js/serial_com.js',
+    './js/serial_ble.js',
     './js/servoMixRule.js',
     './js/motorMixRule.js',
     './js/logicCondition.js',

--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -227,5 +227,6 @@ var MSPCodes = {
     MSP2_INAV_FWUPDT_ROLLBACK_EXEC:     0x2037,
     
     MSP2_INAV_SAFEHOME:                 0x2038,
-    MSP2_INAV_SET_SAFEHOME:             0x2039
+    MSP2_INAV_SET_SAFEHOME:             0x2039,
+    MSP2_INAV_SET_MSP_OPTIONS:          0x203B
 };

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1516,7 +1516,9 @@ var mspHelper = (function (gui) {
             case MSPCodes.MSP2_INAV_SET_SAFEHOME:
                 console.log('Safehome points saved');
                 break;
-
+            case MSPCodes.MSP2_INAV_SET_MSP_OPTIONS:
+                console.log('Set MSP options');
+                break;
             default:
                 console.log('Unknown code detected: ' + dataHandler.code);
         } else {
@@ -3331,6 +3333,17 @@ var mspHelper = (function (gui) {
             callback();
         }
     };
+
+    self.setMSP_Options = function (callback) {
+        let buffer = [];
+        let delay = serialBle.deviceDescription.delay;
+        let chunkSize = serialBle.deviceDescription.chunkSize;
+        buffer.push(lowByte(chunkSize));
+        buffer.push(highByte(chunkSize));
+        buffer.push(lowByte(delay));
+        buffer.push(highByte(delay));
+        MSP.send_message(MSPCodes.MSP2_INAV_SET_MSP_OPTIONS, buffer, callback, false, MSP.constants.PROTOCOL_V2);
+    }
 
     return self;
 })(GUI);

--- a/js/port_handler.js
+++ b/js/port_handler.js
@@ -66,13 +66,17 @@ PortHandler.check = function () {
                 chrome.storage.local.get('last_used_port', function (result) {
                     // if last_used_port was set, we try to select it
                     if (result.last_used_port) {
-                        current_ports.forEach(function(port) {
-                            if (port == result.last_used_port) {
-                                console.log('Selecting last used port: ' + result.last_used_port);
+                        if (result.last_used_port == "ble") {
+                            $('#port').val(result.last_used_port);
+                        } else {
+                            current_ports.forEach(function(port) {
+                                if (port == result.last_used_port) {
+                                    console.log('Selecting last used port: ' + result.last_used_port);
 
-                                $('#port').val(result.last_used_port);
-                            }
-                        });
+                                    $('#port').val(result.last_used_port);
+                                }
+                            });
+                        }
                     } else {
                         console.log('Last used port wasn\'t saved "yet", auto-select disabled.');
                     }
@@ -175,6 +179,7 @@ PortHandler.update_port_select = function (ports) {
     }
 
     $('div#port-picker #port').append($("<option/>", {value: 'manual', text: 'Manual Selection', data: {isManual: true}}));
+    $('div#port-picker #port').append($("<option/>", {value: 'ble', text: 'BLE', data: {isBle: true}}));
 };
 
 PortHandler.port_detected = function(name, code, timeout, ignore_timeout) {

--- a/js/serial_ble.js
+++ b/js/serial_ble.js
@@ -1,0 +1,221 @@
+'use strict'
+
+// Dummy value
+const BLE_CONNECTION_ID = 0xFF;
+// BLE 20 bytes buffer
+const BLE_WRITE_BUFFER_LENGTH = 20;
+
+var serialBle = {
+    bleDevices: [
+        {
+            name: "HM-1X/HC-08",
+            serviceUuid:        '0000ffe0-0000-1000-8000-00805f9b34fb',
+            writeCharateristic: '0000ffe1-0000-1000-8000-00805f9b34fb', 
+            readCharateristic:  '0000ffe1-0000-1000-8000-00805f9b34fb',
+            delay:              70,
+            chunkSize:          180,
+        },
+        {
+            name: "Nordic Semiconductor NRF",
+            serviceUuid:        '6e400001-b5a3-f393-e0a9-e50e24dcca9e',
+            writeCharateristic: '6e400003-b5a3-f393-e0a9-e50e24dcca9e', 
+            readCharateristic:  '6e400002-b5a3-f393-e0a9-e50e24dcca9e',
+            delay:              70,
+            chunkSize:          180,
+        },
+        {
+            name: "SpeedyBee Type 2",
+            serviceUuid:        '0000abf0-0000-1000-8000-00805f9b34fb',
+            writeCharateristic: '0000abf1-0000-1000-8000-00805f9b34fb', 
+            readCharateristic:  '0000abf2-0000-1000-8000-00805f9b34fb',
+            delay:              10,
+            chunkSize:          0,
+        },
+        {
+            name: "SpeedyBee Type 1",
+            serviceUuid:        '00001000-0000-1000-8000-00805f9b34fb',
+            writeCharateristic: '00001001-0000-1000-8000-00805f9b34fb', 
+            readCharateristic:  '00001002-0000-1000-8000-00805f9b34fb',
+            delay:              10,
+            chunkSize:          0,
+        }
+    ],
+
+    readCharacteristic: null,
+    writeCharacteristic: null,
+    device: null,
+    deviceDescription: null,
+
+    connect: async function(callback) {
+
+        console.log("Request BLE Device");
+        await this.request()
+            .then(device => this.connectBle(device))
+            .then (_ => this.startNotification())
+            .catch(error => {
+                GUI.log("Error while opening BLE device: " + error)
+                if (GUI.connected_to || GUI.connecting_to) {
+                    $('a.connect').click();
+                } else {
+                    serial.disconnect();
+                }
+        });
+
+        this.registerOnRecieveCallback();
+
+        serial.onReceive.addListener(function (bytesReceived) {
+            serial.bytesReceived += bytesReceived.data.length;
+        });
+
+        callback({connectionId: BLE_CONNECTION_ID});
+
+        return Promise.resolve();
+    }, 
+
+    request: function() {
+        var ids = [];
+        this.bleDevices.forEach(device => {
+            ids.push(device.serviceUuid)
+        });
+        return navigator.bluetooth.requestDevice({
+            acceptAllDevices: true,
+            optionalServices: ids
+        }).then(device => {
+            serial.bitrate = 9600; // Dummy value
+            serial.connectionId = BLE_CONNECTION_ID; // BLE
+            serial.bytesReceived = 0;
+            serial.bytesSent = 0;
+            serial.failed = 0;
+            serial.openRequested = false;
+
+            console.log("Found BLE device: " + device.name);
+            this.device = device;
+            this.device.addEventListener('gattserverdisconnected', this.handleDisconnect);
+
+            return this.device;
+        });
+    },
+
+    handleDisconnect: function(event) {
+        let device = event.target;
+
+        GUI.log("BLE device disconnected, trying to reconnect.");
+
+        this.connect(device)
+            .then(_ => startNotifications())
+            .catch(error => log(error));
+    },
+
+    connectBle: function(device) {
+        if (device.gatt.connected && this.characteristic) {
+            return Promise.resolve(this.characteristic);
+        }
+        return device.gatt.connect()
+            .then(server => {
+                console.log("Connect to: " + device.name);
+                GUI.log("Connect to: " + device.name)    
+                return server.getPrimaryServices();
+            }).then(services => {
+                let connectedService = services.find(service => {
+                    this.deviceDescription = serialBle.bleDevices.find(device => device.serviceUuid == service.uuid);
+                    if (this.deviceDescription) {
+                        return true;
+                    }
+                });
+                if (!this.deviceDescription) {
+                    throw new Error("Unsupported device (service uuid mismatch). Got " + service.uuid);
+                }
+                GUI.log("BLE device type:  " + this.deviceDescription.name);
+                return connectedService.getCharacteristics();
+            }).then(characteristics => {
+                characteristics.find(characteristic => {
+                    if (characteristic.uuid == this.deviceDescription.writeCharateristic) {
+                        this.writeCharacteristic = characteristic;
+                    }
+                    if (characteristic.uuid == this.deviceDescription.readCharateristic) {
+                        this.readCharacteristic = characteristic;
+                    }
+                    if (this.writeCharacteristic && this.readCharacteristic) {
+                        return true;
+                    }
+                });
+                if (!this.writeCharacteristic) {
+                    throw new Error("No or unexpected write charateristic (shoud be " +  this.deviceDescription.writeCharateristic + ")");
+                }
+                if (!this.readCharacteristic) {
+                    throw new Error("No or unexpected read charateristic (shoud be " +  this.deviceDescription.readCharateristic + ")");
+                }
+                return Promise.resolve();
+            });          
+    },
+
+    startNotification: function() {
+
+        if (!this.readCharacteristic) {
+            throw new Error("No read charateristic");
+        }
+
+        if (!this.readCharacteristic.properties.notify) {
+            throw new Error("Read charateristic can't notify.");
+        }
+
+        return this.readCharacteristic.startNotifications()
+            .then(() => {
+                console.log("BLE notifications started.");
+        });
+    },
+
+    disconnect: function(funcRef) {
+        let ret = false;
+        if (serialBle.device) {
+            GUI.log("Disconnect from BLE device: " + serialBle.device.name);
+
+            serialBle.device.removeEventListener('gattserverdisconnected', serialBle.handleDisconnect);
+
+            if (serialBle.device.gatt.connected) {
+                serialBle.device.gatt.disconnect();
+                ret = true;
+            }
+            serialBle.device = null;
+            serialBle.writeCharacteristic = null; 
+            serialBle.readCharacteristic = null;
+            serialBle.deviceDescription = null; 
+        }
+        funcRef(ret);
+    },
+
+    registerOnRecieveCallback: function() {
+        serial.onReceive.register(function(listener) {          
+            function bleListener(event) {
+                let buffer = new Uint8Array(event.target.value.byteLength);
+                for (var i = 0; i < event.target.value.byteLength; i++) {
+                    buffer[i] = event.target.value.getUint8(i);
+                }
+
+                listener({
+                    connectionId: BLE_CONNECTION_ID,
+                    data: buffer
+                });
+            }
+            serialBle.readCharacteristic.addEventListener('characteristicvaluechanged', bleListener);
+        });
+    },
+
+    send: async function(id, data, callback) {;
+        if (!serialBle.writeCharacteristic) {
+            return;
+        }
+        let sendBytes = 0;
+        let inBuffer = new Uint8Array(data);
+        for (i = 0; i < inBuffer.length; i += BLE_WRITE_BUFFER_LENGTH) {
+            var length = BLE_WRITE_BUFFER_LENGTH;
+            if (i + BLE_WRITE_BUFFER_LENGTH > inBuffer.length) {
+                length = inBuffer.length % BLE_WRITE_BUFFER_LENGTH;
+            }
+            var outBuffer = inBuffer.subarray(i, i + length);
+            sendBytes += outBuffer.length;
+            await serialBle.writeCharacteristic.writeValue(outBuffer);   
+        }
+        callback({bytesSent: sendBytes})
+    }
+} 

--- a/js/serial_com.js
+++ b/js/serial_com.js
@@ -1,0 +1,173 @@
+'use strict'
+
+var serialCom = {
+    connect: function(path, options, callback) {
+        ret = false;
+        chrome.serial.connect(path, options, function (connectionInfo) {
+            if (chrome.runtime.lastError) {
+                console.error(chrome.runtime.lastError.message);
+            }          
+            
+            if (connectionInfo && !serial.openCanceled) {
+                
+                serial.connectionId = connectionInfo.connectionId;
+                serial.bitrate = connectionInfo.bitrate;
+                serial.bytesReceived = 0;
+                serial.bytesSent = 0;
+                serial.failed = 0;
+                serial.openRequested = false;
+
+                serial.onReceive.addListener(function log_bytesReceived(info) {
+                    serial.bytesReceived += info.data.byteLength;
+                });
+
+                serial.onReceiveError.addListener(function watch_for_on_receive_errors(info) {
+                    console.error(info);
+                    googleAnalytics.sendException('Serial: ' + info.error, false);
+
+                    switch (info.error) {
+                        case 'system_error': // we might be able to recover from this one
+                            if (!serial.failed++) {
+                                chrome.serial.setPaused(serial.connectionId, false, function () {
+                                    serial.getInfo(function (info) {
+                                        if (info) {
+                                            if (!info.paused) {
+                                                console.log('SERIAL: Connection recovered from last onReceiveError');
+                                                googleAnalytics.sendException('Serial: onReceiveError - recovered', false);
+
+                                                serial.failed = 0;
+                                            } else {
+                                                console.log('SERIAL: Connection did not recover from last onReceiveError, disconnecting');
+                                                GUI.log('Unrecoverable <span style="color: red">failure</span> of serial connection, disconnecting...');
+                                                googleAnalytics.sendException('Serial: onReceiveError - unrecoverable', false);
+
+                                                if (GUI.connected_to || GUI.connecting_to) {
+                                                    $('a.connect').click();
+                                                } else {
+                                                    serial.disconnect();
+                                                }
+                                            }
+                                        } else {
+                                            if (chrome.runtime.lastError) {
+                                                console.error(chrome.runtime.lastError.message);
+                                            }
+                                        }
+                                    });
+                                });
+                            }
+                            break;
+
+                        case 'break': // This occurs on F1 boards with old firmware during reboot
+                        case 'overrun':
+                        case 'frame_error': //Got disconnected
+                            // wait 50 ms and attempt recovery
+                            serial.error = info.error;
+                            setTimeout(function() {
+                                chrome.serial.setPaused(info.connectionId, false, function() {
+                                    serial.getInfo(function (info) {
+                                        if (info) {
+                                            if (info.paused) {
+                                                // assume unrecoverable, disconnect
+                                                console.log('SERIAL: Connection did not recover from ' + serial.error + ' condition, disconnecting');
+                                                GUI.log('Unrecoverable <span style="color: red">failure</span> of serial connection, disconnecting...');
+                                                googleAnalytics.sendException('Serial: ' + serial.error + ' - unrecoverable', false);
+    
+                                                if (GUI.connected_to || GUI.connecting_to) {
+                                                    $('a.connect').click();
+                                                } else {
+                                                    serial.disconnect();
+                                                }
+                                            }
+                                            else {
+                                                console.log('SERIAL: Connection recovered from ' + serial.error + ' condition');
+                                                googleAnalytics.sendException('Serial: ' + serial.error + ' - recovered', false);
+                                            }
+                                        }
+                                    });
+                                });
+                            }, 50);
+                            break;
+                            
+                        case 'timeout':
+                            // TODO
+                            break;
+                            
+                        case 'device_lost':
+                            if (GUI.connected_to || GUI.connecting_to) {
+                                $('a.connect').click();
+                            } else {
+                                serial.disconnect();
+                            }
+                            break;
+                            
+                        case 'disconnected':
+                            // TODO
+                            break;
+                    }
+                });
+                console.log('SERIAL: Connection opened with ID: ' + connectionInfo.connectionId + ', Baud: ' + connectionInfo.bitrate);
+                ret = connectionInfo;                
+            };
+            callback(ret);
+        });
+    },
+
+    disconnect: function(funcRef) {
+        chrome.serial.disconnect(serial.connectionId, function (result) {
+            if (chrome.runtime.lastError) {
+                console.error(chrome.runtime.lastError.message);
+            }
+
+            if (result) {
+                console.log('SERIAL: Connection with ID: ' + serial.connectionId + ' closed, Sent: ' + serial.bytesSent + ' bytes, Received: ' + serial.bytesReceived + ' bytes');
+            } else {
+                console.log('SERIAL: Failed to close connection with ID: ' + serial.connectionId + ' closed, Sent: ' + serial.bytesSent + ' bytes, Received: ' + serial.bytesReceived + ' bytes');
+                googleAnalytics.sendException('Serial: FailedToClose', false);
+            }
+            funcRef(result);
+        });
+    },
+    
+    getDevices: function (callback) {
+        chrome.serial.getDevices(function (devices_array) {
+            var devices = [];
+            devices_array.forEach(function (device) {
+                devices.push(device.path);
+            });
+
+            callback(devices);
+        });
+    },
+    
+    getInfo: function (connectionId, callback) {
+        chrome.serial.getInfo(connectionId, callback);
+    },
+
+    getControlSignals: function (connectionId, callback) {
+        chrome.serial.getControlSignals(connectionId, callback);
+    },
+
+    setControlSignals: function (connectionId, signals, callback) {
+        chrome.serial.setControlSignals(connectionId, signals, callback);
+    },
+
+    send: function(id, data, callback) {;
+        chrome.serial.send(id, data, function (sendInfo) {
+           callback(sendInfo);
+        });
+    },
+
+    registerOnRecieveCallback: function() {
+            serial.onReceive.register(function(listener){
+                chrome.serial.onReceive.addListener(listener)
+            });
+        },
+
+    addReceiveErrorListener: function(funcRef) {
+        chrome.serial.onReceiveError.addListener(funcRef);   
+    },
+
+    removeReceiveErrorListener: function(funcRef) {
+        chrome.serial.onReceiveError.removeListener(funcRef);  
+    }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -31,6 +31,7 @@
         "https://dev.virtualearth.net/",
         "serial",
         "usb",
+        "bluetooth",
         "storage",
         "fileSystem",
         "fileSystem.write",


### PR DESCRIPTION
Support for Bluetooth low Energy devices:

Supported are:
BLE to UART adapters: 
- HM-1X (HM-10, HM-11, -..)
- HC-08
- Nordic Semiconductor BLE Shield

SpeedyBee adapters and FCs with integrated Bluetooth.

Unfortunately, the Chrome BLE API is somewhat limited compared to Android. This results in the effect with the UART adapters, due to the buffers, that either the order of the bytes is messed up or even bytes are missing. Therefore, the FC must split large frames and send them one after the other with a certain delay.
There is a new MSP command for this: MSP2_INAV_SET_MSP_OPTIONS, with which the configurator can request transmission in chunks and a delay between the cunks, see here: 

The Speedybee adapters are not affected by this, they seem to have a large enough buffer.

#1001 