### PR TITLE
Added ordering for operations in programming

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -1045,222 +1045,266 @@ var FC = {
         return {
             0: {
                 name: "True",
+                operandType: "Active",
                 hasOperand: [false, false],
                 output: "boolean"
             },
             1: {
                 name: "Equal",
+                operandType: "Comparison",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             2: {
                 name: "Greater Than",
+                operandType: "Comparison",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             3: {
                 name: "Lower Than",
+                operandType: "Comparison",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             4: {
                 name: "Low",
+                operandType: "RC Switch Check",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             5: {
                 name: "Mid",
+                operandType: "RC Switch Check",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             6: {
                 name: "High",
+                operandType: "RC Switch Check",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             7: {
                 name: "AND",
+                operandType: "Logic",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             8: {
                 name: "OR",
+                operandType: "Logic",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             9: {
                 name: "XOR",
+                operandType: "Logic",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             10: {
                 name: "NAND",
+                operandType: "Logic",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             11: {
                 name: "NOR",
+                operandType: "Logic",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             12: {
                 name: "NOT",
+                operandType: "Logic",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             13: {
-                name: "STICKY",
+                name: "Sticky",
+                operandType: "Switches",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             14: {
-                name: "ADD",
+                name: "Basic: Add",
+                operandType: "Maths",
                 hasOperand: [true, true],
                 output: "raw"
             },
             15: {
-                name: "SUB",
+                name: "Basic: Subtract",
+                operandType: "Maths",
                 hasOperand: [true, true],
                 output: "raw"
             },
             16: {
-                name: "MUL",
+                name: "Basic: Multiply",
+                operandType: "Maths",
                 hasOperand: [true, true],
                 output: "raw"
             },
             17: {
-                name: "DIV",
+                name: "Basic: Divide",
+                operandType: "Maths",
                 hasOperand: [true, true],
                 output: "raw"
             },
             40: {
-                name: "MOD",
+                name: "Modulo",
+                operandType: "Maths",
                 hasOperand: [true, true],
                 output: "raw"
             },
             18: {
-                name: "GVAR SET",
+                name: "Set GVAR",
+                operandType: "Variables",
                 hasOperand: [true, true],
                 output: "none"
             },
             19: {
-                name: "GVAR INC",
+                name: "Increase GVAR",
+                operandType: "Variables",
                 hasOperand: [true, true],
                 output: "none"
             },
             20: {
-                name: "GVAR DEC",
+                name: "Decrease GVAR",
+                operandType: "Variables",
                 hasOperand: [true, true],
                 output: "none"
             },
             21: {
-                name: "IO PORT SET",
+                name: "Set IO Port",
+                operandType: "Set Flight Parameter",
                 hasOperand: [true, true],
                 output: "none"
             },
             22: {
-                name: "OVERRIDE ARMING SAFETY",
+                name: "Override Arming Safety",
+                operandType: "Set Flight Parameter",
                 hasOperand: [false, false],
                 output: "boolean"
             },
             23: {
-                name: "OVERRIDE THROTTLE SCALE",
+                name: "Override Throttle Scale",
+                operandType: "Set Flight Parameter",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             29: {
-                name: "OVERRIDE THROTTLE",
+                name: "Override Throttle",
+                operandType: "Set Flight Parameter",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             24: {
-                name: "SWAP ROLL & YAW",
+                name: "Swap Roll & Yaw",
+                operandType: "Set Flight Parameter",
                 hasOperand: [false, false],
                 output: "boolean"
             },
             25: {
-                name: "SET VTX POWER LEVEL",
+                name: "Set VTx Power Level",
+                operandType: "Set Flight Parameter",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             30: {
-                name: "SET VTX BAND",
+                name: "Set VTx Band",
+                operandType: "Set Flight Parameter",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             31: {
-                name: "SET VTX CHANNEL",
+                name: "Set VTx Channel",
+                operandType: "Set Flight Parameter",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             26: {
-                name: "INVERT ROLL",
+                name: "Invert Roll",
+                operandType: "Set Flight Parameter",
                 hasOperand: [false, false],
                 output: "boolean"
             },
             27: {
-                name: "INVERT PITCH",
+                name: "Invert Pitch",
+                operandType: "Set Flight Parameter",
                 hasOperand: [false, false],
                 output: "boolean"
             },
             28: {
-                name: "INVERT YAW",
+                name: "Invert Yaw",
+                operandType: "Set Flight Parameter",
                 hasOperand: [false, false],
                 output: "boolean"
             },
             32: {
-                name: "SET OSD LAYOUT",
+                name: "Set OSD Layout",
+                operandType: "Set Flight Parameter",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             33: {
-                name: "SIN",
+                name: "Trigonometry: Sine",
+                operandType: "Maths",
                 hasOperand: [true, true],
                 output: "raw"
             },
             34: {
-                name: "COS",
+                name: "Trigonometry: Cosine",
+                operandType: "Maths",
                 hasOperand: [true, true],
                 output: "raw"
             },
             35: {
-                name: "TAN",
+                name: "Trigonometry: Tangent",
+                operandType: "Maths",
                 hasOperand: [true, true],
                 output: "raw"
             },
             36: {
-                name: "MAP INPUT",
+                name: "Map Input",
+                operandType: "Maths",
                 hasOperand: [true, true],
                 output: "raw"
             },
             37: {
-                name: "MAP OUTPUT",
+                name: "Map Output",
+                operandType: "Maths",
                 hasOperand: [true, true],
                 output: "raw"
             },
             38: {
-                name: "RC CHANNEL OVERRIDE",
+                name: "Override RC Channel",
+                operandType: "Set Flight Parameter",
                 hasOperand: [true, true],
                 output: "boolean"
             },
 
             41: {
-                name: "LOITER RADIUS OVERRIDE",
+                name: "Override Loiter Radius",
+                operandType: "Set Flight Parameter",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             42: {
-                name: "SET PROFILE",
+                name: "Set Profile",
+                operandType: "Set Flight Parameter",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             43: {
-                name: "MIN",
+                name: "Use Lowest Value",
+                operandType: "Comparison",
                 hasOperand: [true, true],
                 output: "raw"
             },
             44: {
-                name: "MAX",
+                name: "Use Highest Value",
+                operandType: "Comparison",
                 hasOperand: [true, true],
                 output: "raw"
             },

--- a/js/fc.js
+++ b/js/fc.js
@@ -1087,43 +1087,43 @@ var FC = {
             },
             7: {
                 name: "AND",
-                operandType: "Logic",
+                operandType: "Logic Switches",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             8: {
                 name: "OR",
-                operandType: "Logic",
+                operandType: "Logic Switches",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             9: {
                 name: "XOR",
-                operandType: "Logic",
+                operandType: "Logic Switches",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             10: {
                 name: "NAND",
-                operandType: "Logic",
+                operandType: "Logic Switches",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             11: {
                 name: "NOR",
-                operandType: "Logic",
+                operandType: "Logic Switches",
                 hasOperand: [true, true],
                 output: "boolean"
             },
             12: {
                 name: "NOT",
-                operandType: "Logic",
+                operandType: "Logic Switches",
                 hasOperand: [true, false],
                 output: "boolean"
             },
             13: {
                 name: "Sticky",
-                operandType: "Switches",
+                operandType: "Logic Switches",
                 hasOperand: [true, true],
                 output: "boolean"
             },

--- a/js/logicCondition.js
+++ b/js/logicCondition.js
@@ -256,16 +256,55 @@ let LogicCondition = function (enabled, activatorId, operation, operandAType, op
         $row.find('.logic_cell__operation').html("<select class='logic_element__operation' ></select>");
         let $t = $row.find('.logic_element__operation');
         
-        for (let k in FC.getLogicOperators()) {
-            if (FC.getLogicOperators().hasOwnProperty(k)) {
-                let o = FC.getLogicOperators()[k];
-                if (self.getOperation() == parseInt(k, 10)) {
-                    $t.append('<option value="' + k + '" selected>' + o.name + '</option>');
-                } else {
-                    $t.append('<option value="' + k + '">' + o.name + '</option>');
-                }
+        let lcOperators = [];
+
+        for (let lcID in FC.getLogicOperators()) {
+            if (FC.getLogicOperators().hasOwnProperty(lcID)) {
+                let op = FC.getLogicOperators()[lcID];
+                lcOperators[parseInt(lcID, 10)] = {
+                    id: parseInt(lcID, 10),
+                    name: op.name,
+                    operandType: op.operandType,
+                    hasOperand: op.hasOperand,
+                    output: op.output
+                };
             }
         }
+
+        lcOperators.sort((a, b) => {
+            let lcAT = a.operandType.toLowerCase(),
+                lcBT = b.operandType.toLowerCase(), 
+                lcAN = a.name.toLowerCase(),
+                lcBN = b.name.toLowerCase();
+            
+            if (lcAT == lcBT) {
+                return (lcAN < lcBN) ? -1 : (lcAN > lcBN) ? 1 : 0;
+            } else  {
+                return (lcAT < lcBT) ? -1 : 1;
+            }
+        });
+
+        let section = "";
+
+        lcOperators.forEach( val => {
+            if (section != val.operandType) {
+                if (section != "") {
+                    $t.append('</optgroup>');
+                }
+
+                section = val.operandType;
+                $t.append('<optgroup label="** ' + val.operandType + ' **">');
+            }
+
+            if (self.getOperation() == val.id) {
+                $t.append('<option value="' + val.id + '" selected>' + val.name + '</option>');
+            } else {
+                $t.append('<option value="' + val.id + '">' + val.name + '</option>');
+            }
+        });
+
+        $t.append('</optgroup>');
+
         $t.change(self.onOperatorChange);
 
         self.renderOperand(0);


### PR DESCRIPTION
I've added some ordering for the operations select boxes on the programming page. IDs aren't changed or affected, this is purely visual. New operations can be added in the same way as before, just carrying on with the next available ID. The only addition is the  `operandType` parameter in the `LogicOperators` object. You just need to set that with the section the new operation appears in.

![image](https://user-images.githubusercontent.com/17590174/152874735-a6ebb5bf-122f-4eed-ae59-93ecbc5a92ea.png)

This is the complete list of operations. I've changed a lot of the EVERYTHING IN CAPS operations, to make them look more user friendly. I'm open to suggestions for different sections and comments. What's everyone's thoughts?

![image](https://user-images.githubusercontent.com/17590174/152875673-97c58d87-c3b1-4fba-a2d1-dc3c53b56b0f.png)
