### PR TITLE
Battery cells in logic conditions

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -1324,6 +1324,7 @@ var FC = {
                     34: "GPS Valid Fix",
                     35: "Loiter Radius [cm]",
                     36: "Active Profile",
+                    37: "Battery cells",
                 }
             },
             3: {


### PR DESCRIPTION
Added battery cells in logic conditions.
Configurator side of https://github.com/iNavFlight/inav/pull/7814

This element could be added after the battery elements, but all the values of the elements must be increased by one, breaking the compability with the previous configurators. So this is added at the end.
