### PR TITLE
Enhance and extend units conversion

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2126,7 +2126,7 @@
         "message": "<strong>Note:</strong> When Stage 2 is DISABLED, the fallback setting <strong>Auto</strong> is used instead of the user settings for all flightchannels (Roll, Pitch, Yaw and Throttle)."
     },
     "failsafeDelayItem": {
-        "message": "Guard time for activation after signal lost [1 = 0.1 sec.]"
+        "message": "Guard time for activation after signal lost [For deciseconds (ds): 1 = 0.1 sec.]"
     },
     "failsafeDelayHelp": {
         "message": "Time for stage 1 to wait for recovery"
@@ -2135,7 +2135,7 @@
         "message": "Throttle value used while landing"
     },
     "failsafeOffDelayItem": {
-        "message": "Delay for turning off the Motors during Failsafe [1 = 0.1 sec.]"
+        "message": "Delay for turning off the Motors during Failsafe [For deciseconds (ds):1 = 0.1 sec.]"
     },
     "failsafeOffDelayHelp": {
         "message": "Time to stay in landing mode untill the motors are turned off and the craft is disarmed"
@@ -2894,16 +2894,16 @@
         "message": "Fly Time (minutes)"
     },
     "osd_alt_alarm": {
-        "message": "Altitude (meters)"
+        "message": "Altitude"
     },
     "osd_dist_alarm": {
-        "message": "Distance (meters)"
+        "message": "Distance"
     },
     "osdAlarmDIST_HELP": {
         "message": "The distance to home indicator will flash when the distance is greater than this value. Zero disables this alarm."
     },
     "osd_neg_alt_alarm": {
-        "message": "Negative Altitude (meters)"
+        "message": "Negative Altitude"
     },
     "osdAlarmMAX_NEG_ALTITUDE_HELP": {
         "message": "The altitude indicator will flash when altitude is negative and its absolute value is greater than this alarm. Useful when taking off from elevated places. Zero disables this alarm."

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const GulpClient = require("gulp");
+
 var Settings = (function () {
     let self = {};
 
@@ -27,6 +29,8 @@ var Settings = (function () {
                     return;
                 }
                 parent.show();
+
+                input.prop('title', 'CLI: ' + input.data('setting'));
 
                 if (input.prop('tagName') == 'SELECT' || s.setting.table) {
                     if (input.attr('type') == 'checkbox') {
@@ -69,9 +73,9 @@ var Settings = (function () {
                     input.val(s.value.toFixed(2));
                 } else {
                     var multiplier = parseFloat(input.data('setting-multiplier') || 1);
-                    input.attr('type', 'number');
-                    input.val((s.value / multiplier).toFixed(Math.log10(multiplier)));
 
+                    input.val((s.value / multiplier).toFixed(Math.log10(multiplier)));
+                    input.attr('type', 'number');
                     if (typeof s.setting.min !== 'undefined' && s.setting.min !== null) {
                         input.attr('min', (s.setting.min / multiplier).toFixed(Math.log10(multiplier)));
                     }
@@ -136,22 +140,39 @@ var Settings = (function () {
 
         //display names for the units
         const unitDisplayDames = {
+            // Misc
             'us' : "uS",
-            'deg' : '&deg;',
-            'cdeg' : 'centi&deg;',
-            'cmss' : 'cm/s/s',
-            'cm' : 'cm',
-            'cms' : 'cm/s',
-            'm' : 'm',
-            'ms' : 'ms',
-            'mps' : 'm/s',
-            'kmh' : 'Km/h',
-            'sec' : 's',
-            'kt' : 'Kt',
-            'ft' : 'ft',
-            'mph' : 'mph',
             'cw' : 'cW',
-            'percent' : '%'
+            'percent' : '%',
+            'cmss' : 'cm/s/s',
+            // Time
+            'msec' : 'ms',
+            'dsec' : 'ds',
+            'sec' : 's',
+            // Angles
+            'deg' : '&deg;',
+            'decideg' : 'deci&deg;',
+            // Temperature
+            'decidegc' : 'deci&deg;C',
+            'degc' : '&deg;C',
+            'degf' : '&deg;F',
+            // Speed
+            'cms' : 'cm/s',
+            'v-cms' : 'cm/s',
+            'ms' : 'm/s',
+            'kmh' : 'Km/h',
+            'mph' : 'mph',
+            'hftmin' : 'x100 ft/min',
+            'fts' : 'ft/s',
+            'kt' : 'Kt',
+            // Distance
+            'cm' : 'cm',
+            'm' : 'm',
+            'km' : 'Km',
+            'm-lrg' : 'm', // Metres, but converted to larger units
+            'ft' : 'ft',
+            'mi' : 'mi',
+            'nm' : 'NM'
         }
 
 
@@ -169,17 +190,38 @@ var Settings = (function () {
                 'm' : 100, 
                 'ft' : 30.48
             },
-            'cms' : {
+            'm' : {
+                'm' : 1,
+                'ft' : 0.3048
+            },
+            'm-lrg' : {
+                'km' : 1000,
+                'mi' : 1609.344,
+                'nm' : 1852
+            },
+            'cms' : { // Horizontal speed
                 'kmh' : 27.77777777777778, 
                 'kt': 51.44444444444457, 
                 'mph' : 44.704,
-                'mps' : 100
+                'ms' : 100
             },
-            'ms' : {
+            'v-cms' : { // Vertical speed
+                'ms' : 100,
+                'hftmin' : 50.8,
+                'fts' : 30.48
+            },
+            'msec' : {
                 'sec' : 1000
             },
-            'cdeg' : {
+            'dsec' : {
+                'sec' : 10
+            },
+            'decideg' : {
                 'deg' : 10
+            },
+            'decidegc' : {
+                'degc' : 10,
+                'degf' : 'FAHREN'
             },
         };
 
@@ -187,33 +229,58 @@ var Settings = (function () {
         const conversionTable = {
             0: { //imperial
                 'cm' : 'ft',
+                'm' : 'ft',
+                'm-lrg' : 'mi',
                 'cms' : 'mph',
-                'cdeg' : 'deg',
-                'ms' : 'sec'
+                'v-cms' : 'fts',
+                'msec' : 'sec',
+                'dsec' : 'sec',
+                'decideg' : 'deg',
+                'decidegc' : 'degf',
             },
-            1: {//metric
+            1: { //metric
                 'cm': 'm',
+                'm' : 'm',
+                'm-lrg' : 'km',
                 'cms' : 'kmh',
-                'ms' : 'sec',
-                'cdeg' : 'deg'
+                'v-cms' : 'ms',
+                'msec' : 'sec',
+                'dsec' : 'sec',
+                'decideg' : 'deg',
+                'decidegc' : 'degc',
             },
             2: { //metric with MPH
                 'cm': 'm',
+                'm' : 'm',
+                'm-lrg' : 'km',
                 'cms' : 'mph',
-                'cdeg' : 'deg',
-                'ms' : 'sec'
+                'v-cms' : 'ms',
+                'decideg' : 'deg',
+                'msec' : 'sec',
+                'dsec' : 'sec',
+                'decidegc' : 'degc',
             },
             3:{ //UK
                 'cm' : 'ft',
+                'm' : 'ft',
+                'm-lrg' : 'mi',
                 'cms' : 'mph',
-                'cdeg' : 'deg',
-                'ms' : 'sec'
+                'v-cms' : 'fts',
+                'decideg' : 'deg',
+                'msec' : 'sec',
+                'dsec' : 'sec',
+                'decidegc' : 'degc',
             },
             4: { //General aviation
                 'cm' : 'ft',
+                'm' : 'ft',
+                'm-lrg' : 'nm',
                 'cms': 'kt',
-                'cdeg' : 'deg',
-                'ms' : 'sec'
+                'v-cms' : 'hftmin',
+                'decideg' : 'deg',
+                'msec' : 'sec',
+                'dsec' : 'sec',
+                'decidegc' : 'degc',
             },
             default:{}//show base units
         };
@@ -239,18 +306,31 @@ var Settings = (function () {
         // Update the step, min, and max; as we have the multiplier here.
         if (element.attr('type') == 'number') {
             element.attr('step', ((multiplier != 1) ? '0.01' : '1'));
-            element.attr('min', (element.attr('min') / multiplier).toFixed(2));
-            element.attr('max', (element.attr('max') / multiplier).toFixed(2));
+            if (multiplier != 'FAHREN') {
+                element.attr('min', (element.attr('min') / multiplier).toFixed(2));
+                element.attr('max', (element.attr('max') / multiplier).toFixed(2));
+            }
         }
 
         // Update the input with a new formatted unit
-        const convertedValue = Number((oldValue / multiplier).toFixed(2));
-        const newValue = Number.isInteger(convertedValue) ? Math.round(convertedValue) : convertedValue;
+        let newValue = "";
+        if (multiplier == 'FAHREN') {
+            element.attr('min', toFahrenheit(element.attr('min')).toFixed(2));
+            element.attr('max', toFahrenheit(element.attr('max')).toFixed(2));
+            newValue = toFahrenheit(oldValue).toFixed(2);
+        } else {
+            const convertedValue = Number((oldValue / multiplier).toFixed(2));
+            newValue = Number.isInteger(convertedValue) ? Math.round(convertedValue) : convertedValue;
+        }
         element.val(newValue);
         element.data('setting-multiplier', multiplier);
 
         // Now wrap the input in a display that shows the unit
         element.wrap(`<div data-unit="${unitDisplayDames[unitName]}" class="unit_wrapper unit"></div>`);
+
+        function toFahrenheit(decidegC) {
+            return (decidegC / 10) * 1.8 + 32;
+        };
     }
 
     self.saveInput = function(input) {
@@ -271,8 +351,13 @@ var Settings = (function () {
         } else if(setting.type == 'string') {
             value = input.val();
         } else {
-            var multiplier = parseFloat(input.data('setting-multiplier') || 1);
-            value = parseFloat(input.val()) * multiplier;
+            var multiplier = input.data('setting-multiplier') || 1;
+            if (multiplier == 'FAHREN') {
+                value = Math.round(((parseFloat(input.val())-32) / 1.8) * 10);
+            } else {
+                multiplier = parseFloat(multiplier);
+                value = Math.round(parseFloat(input.val()) * multiplier);
+            }
         }
         return mspHelper.setSetting(settingName, value);
     };

--- a/main.css
+++ b/main.css
@@ -2221,11 +2221,19 @@ ol li {
     position: relative;
 }
 
+.unit_wrapper input {
+    margin-right: 0 !important;
+}
+
+.unit_wrapper ~ label, select ~ label, input ~ label {
+    margin-left: 10px;
+}
+
 /* Position the unit to the right of the wrapper */
 .unit_wrapper::after {
     position: absolute;
     top: 2px;
-    right: .7em;
+    right: .5em;
     transition: all .05s ease-in-out;
 }
 
@@ -2233,13 +2241,13 @@ ol li {
      for arrow buttons will appear to the right of number inputs */
 .unit_wrapper:hover::after,
 .unit_wrapper:focus-within::after {
-    right: 1.3em;
+    right: 1.0em;
 }
 
 /* Handle Firefox (arrows always shown) */
 @supports (-moz-appearance:none) {
     .unit_wrapper::after {
-        right: 1.3em;
+        right: 1.0em;
     }
 }
 

--- a/src/css/tabs/configuration.css
+++ b/src/css/tabs/configuration.css
@@ -28,12 +28,12 @@
     text-align: left;
     border: 1px solid silver;
     border-radius: 3px;
-    margin-right: 11px;
     font-size: 12px;
     font-weight: normal;
 }
 
 .config-section .number input,
+.config-section .checkbox input,
 .tab-configuration .number input {
     width: 106px;
 }
@@ -221,7 +221,7 @@ hr {
 
 .config-section label {
     position: absolute;
-    left: 118px;
+    left: 108px;
 }
 
 .config-section .radio label {

--- a/src/css/tabs/failsafe.css
+++ b/src/css/tabs/failsafe.css
@@ -26,7 +26,6 @@
     text-align: left;
     border: 1px solid silver;
     border-radius: 3px;
-    margin-right: 11px;
     font-size: 12px;
     font-weight: normal;
 }
@@ -253,10 +252,12 @@
     height: 90px;
 }
 
-.tab-failsafe .minimumDistance {
-    width: 100px !important;
-    padding-left: 3px;
-    margin-right: 11px;
+.tab-failsafe input {
+   width: 75px !important;
+}
+
+.tab-failsafe select {
+    width: 79px;
 }
 
 @media only screen and (max-width: 1055px) , only screen and (max-device-width: 1055px) {

--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -271,7 +271,6 @@
     text-align: left;
     border: 1px solid silver;
     border-radius: 3px;
-    margin-right: 11px;
     margin-bottom: 5px;
     font-size: 12px;
     font-weight: normal;

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -477,21 +477,19 @@ button {
 }
 
 .tab-osd .settings input {
-    width: 55px;
+    width: 75px;
     padding-left: 3px;
     height: 18px;
     line-height: 20px;
     text-align: left;
     border: 1px solid silver;
     border-radius: 3px;
-    margin-right: 11px;
     font-size: 11px;
     font-weight: normal;
 }
 
 .tab-osd .settings select {
     width: 75px;
-    margin-right: 11px;
 }
 
 .tab-osd .settings .switchery {

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -302,7 +302,6 @@
     text-align: left;
     border: 1px solid silver;
     border-radius: 3px;
-    margin-right: 11px;
     font-weight: normal;
 }
 

--- a/src/css/tabs/transponder.css
+++ b/src/css/tabs/transponder.css
@@ -12,7 +12,6 @@
     text-align: left;
     border: 1px solid silver;
     border-radius: 3px;
-    margin-right: 11px;
     font-size: 12px;
     font-weight: normal;
 }

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -149,7 +149,7 @@
                         </div>
 
                         <div class="number">
-                            <input id="pitchToThrottleThreshold" type="number" data-unit="cdeg" data-setting="nav_fw_pitch2thr_threshold" data-setting-multiplier="1" step="1" min="0" max="900" />
+                            <input id="pitchToThrottleThreshold" type="number" data-unit="decideg" data-setting="nav_fw_pitch2thr_threshold" data-setting-multiplier="1" step="1" min="0" max="900" />
                             <label for="pitchToThrottleThreshold"><span data-i18n="pitchToThrottleThreshold"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="pitchToThrottleThresholdHelp"></div>
                         </div>
@@ -393,13 +393,13 @@
                     </div>
                     <div class="spacer_box">
                         <div class="number">
-                            <input type="number" id="navManualClimbRate" data-unit="cms" data-setting="nav_manual_climb_rate" data-setting-multiplier="1" step="1" min="10" max="2000" />
+                            <input type="number" id="navManualClimbRate" data-unit="v-cms" data-setting="nav_manual_climb_rate" data-setting-multiplier="1" step="1" min="10" max="2000" />
                             <label for="navManualClimbRate"><span data-i18n="navManualClimbRate"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="navManualClimbRateHelp"></div>
                         </div>
 
                         <div class="number">
-                            <input type="number" id="navAutoClimbRate" data-unit="cms" data-setting="nav_auto_climb_rate" data-setting-multiplier="1" step="1" min="10" max="2000" />
+                            <input type="number" id="navAutoClimbRate" data-unit="v-cms" data-setting="nav_auto_climb_rate" data-setting-multiplier="1" step="1" min="10" max="2000" />
                             <label for="navAutoClimbRate"><span data-i18n="navAutoClimbRate"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="navAutoClimbRateHelp"></div>
                         </div>
@@ -427,14 +427,14 @@
                     </div>
                 </div>
 
-                <div class="config-setion gui_box grey">
+                <div class="config-section gui_box grey">
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title" data-i18n="autoLandingSettings"></div>
                     </div>
                     <div class="spacer_box">
 
                         <div class="number">
-                            <input id="landMaxAltVspd" type="number" data-unit="cms" data-setting="nav_land_maxalt_vspd" data-setting-multiplier="1" step="1" min="100" max="2000" />
+                            <input id="landMaxAltVspd" type="number" data-unit="v-cms" data-setting="nav_land_maxalt_vspd" data-setting-multiplier="1" step="1" min="100" max="2000" />
                             <label for="landMaxAltVspd"><span data-i18n="landMaxAltVspd"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="landMaxAltVspdHelp"></div>
                         </div>
@@ -446,7 +446,7 @@
                         </div>
 
                         <div class="number">
-                            <input id="landMinAltVspd" type="number" data-unit="cms" data-setting="nav_land_minalt_vspd" data-setting-multiplier="1" step="1" min="50" max="500" />
+                            <input id="landMinAltVspd" type="number" data-unit="v-cms" data-setting="nav_land_minalt_vspd" data-setting-multiplier="1" step="1" min="50" max="500" />
                             <label for="landMinAltVspd"><span data-i18n="landMinAltVspd"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="landMinAltVspdHelp"></div>
                         </div>

--- a/tabs/failsafe.html
+++ b/tabs/failsafe.html
@@ -7,9 +7,8 @@
             </div>
             <div class="spacer_box">
                 <div class="number">
-                    <label> <input type="number" name="failsafe_delay" min="0" max="200" /> <span
-                            data-i18n="failsafeDelayItem"></span>
-                    </label>
+                     <input type="number" name="failsafe_delay" data-unit="dsec" data-setting="failsafe_delay" min="0" max="200" />
+                     <label><span data-i18n="failsafeDelayItem"></span></label>
                     <div class="helpicon cf_tip" data-i18n_title="failsafeDelayHelp"></div>
                 </div>
                 <!-- radio buttons  -->
@@ -25,14 +24,12 @@
                     </div>
                     <div class="proceduresettings">
                         <div class="number">
-                            <label> <input type="number" name="failsafe_throttle" min="0" max="2000" /> <span
-                                    data-i18n="failsafeThrottleItem"></span>
-                            </label>
+                            <input type="number" name="failsafe_throttle" data-setting="failsafe_throttle" data-unit="us" min="0" max="2000" />
+                            <label><span data-i18n="failsafeThrottleItem"></span></label>
                         </div>
                         <div class="number">
-                            <label> <input type="number" name="failsafe_off_delay" min="0" max="200" /> <span
-                                    data-i18n="failsafeOffDelayItem"></span>
-                            </label>
+                            <input type="number" name="failsafe_off_delay" data-setting="failsafe_off_delay" data-unit="dsec" min="0" max="200" />
+                            <label><span data-i18n="failsafeOffDelayItem"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="failsafeOffDelayHelp"></div>
                         </div>
                     </div>
@@ -58,14 +55,13 @@
                 </div>
 
                 <div class="number" id="failsafe_min_distance_elements">
-                    <label> <input class="minimumDistance" type="number" name="failsafe_min_distance" id="failsafe_min_distance" min="0" max="65000" /> <span
-                            data-i18n="failsafeMinDistanceItem"></span>
-                    </label>
+                    <input class="minimumDistance" id="failsafe_min_distance" type="number" data-unit="cm" data-setting="failsafe_min_distance" data-setting-multiplier="1" step="1" min="0" max="65000" />
+                    <label for="failsafe_min_distance"><span data-i18n="failsafeMinDistanceItem"></span></label>
                     <div class="helpicon cf_tip" data-i18n_title="failsafeMinDistanceHelp"></div>
                 </div>
 
                 <div class="select" id="failsafe_min_distance_procedure_elements">
-                    <select class="minimumDistance" id="failsafe_min_distance_procedure"></select>
+                    <select id="failsafe_min_distance_procedure" class="minimumDistance" data-setting="failsafe_min_distance_procedure"></select>
                     <label for="failsafe_min_distance_procedure"> <span data-i18n="failsafeMinDistanceProcedureItem"></span></label>
                     <div class="helpicon cf_tip" data-i18n_title="failsafeMinDistanceProcedureHelp"></div>
                 </div>

--- a/tabs/failsafe.js
+++ b/tabs/failsafe.js
@@ -9,42 +9,154 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         googleAnalytics.sendAppView('Failsafe');
     }
 
+    // Can get rid of this when MSPHelper supports strings (fixed in #7734, awaiting merge)
     function load_failssafe_config() {
-        MSP.send_message(MSPCodes.MSP_FAILSAFE_CONFIG, false, false, load_config);
+        MSP.send_message(MSPCodes.MSP_FAILSAFE_CONFIG, false, false, load_html);
     }
 
-    function load_config() {
+    /* function load_config() {
         MSP.send_message(MSPCodes.MSP_BF_CONFIG, false, false, load_misc);
     }
 
     function load_misc() {
         MSP.send_message(MSPCodes.MSP_MISC, false, false, load_html);
-    }
+    }*/
 
     function load_html() {
-        GUI.load("./tabs/failsafe.html", process_html);
+        GUI.load("./tabs/failsafe.html", Settings.processHtml(function() {
+            GUI.simpleBind();
+
+            // translate to user-selected language
+            localize();
+
+            // for some odd reason chrome 38+ changes scroll according to the touched select element
+            // i am guessing this is a bug, since this wasn't happening on 37
+            // code below is a temporary fix, which we will be able to remove in the future (hopefully)
+            $('#content').scrollTop((scrollPosition) ? scrollPosition : 0);
+
+            // set stage 2 failsafe procedure
+            $('input[type="radio"].procedure').change(function () {
+                var element = $(this),
+                    checked = element.is(':checked'),
+                    id = element.attr('id');
+                switch (id) {
+                    case 'drop':
+                        if (checked) {
+                            $('input[name="failsafe_throttle"]').prop("disabled", true);
+                            $('input[name="failsafe_off_delay"]').prop("disabled", true);
+                        }
+                        break;
+
+                    case 'land':
+                        if (checked) {
+                            $('input[name="failsafe_throttle"]').prop("disabled", false);
+                            $('input[name="failsafe_off_delay"]').prop("disabled", false);
+                        }
+                        break;
+                }
+            });
+
+            // switch (MSPHelper.getSetting('failsafe_procedure')) {  // Use once #7734 is merged
+            switch (FAILSAFE_CONFIG.failsafe_procedure) {
+                default:
+                case 0:
+                    element = $('input[id="land"]');
+                    element.prop('checked', true);
+                    element.change();
+                    break;
+                case 1:
+                    element = $('input[id="drop"]');
+                    element.prop('checked', true);
+                    element.change();
+                    break;
+                case 2:
+                    element = $('input[id="rth"]');
+                    element.prop('checked', true);
+                    element.change();
+                    break;
+                case 3:
+                    element = $('input[id="nothing"]');
+                    element.prop('checked', true);
+                    element.change();
+                    break;
+            }
+
+            // Adjust Minimum Distance values when checkbox is checked/unchecked
+            $('#failsafe_use_minimum_distance').change(function() {
+                if ($(this).is(':checked')) {
+                    // No default distance added due to conversions
+                    $('#failsafe_min_distance_elements').show();
+                    $('#failsafe_min_distance_procedure_elements').show();
+                } else {
+                    // If they uncheck it, clear the distance to 0, which disables this feature
+                    $('#failsafe_min_distance').val(0);
+                    $('#failsafe_min_distance_elements').hide();
+                    $('#failsafe_min_distance_procedure_elements').hide();
+                }
+            });
+
+            // Set initial state of controls according to data
+            if ( $('#failsafe_min_distance').val() > 0) {
+                $('#failsafe_use_minimum_distance').prop('checked', true);
+                $('#failsafe_min_distance_elements').show();
+                $('#failsafe_min_distance_procedure_elements').show();
+            } else {
+                $('#failsafe_use_minimum_distance').prop('checked', false);
+                $('#failsafe_min_distance_elements').hide();
+                $('#failsafe_min_distance_procedure_elements').hide();
+            }
+
+            $('a.save').click(function () {
+                if ($('input[id="land"]').is(':checked')) {
+                    FAILSAFE_CONFIG.failsafe_procedure = 0;
+                } else if ($('input[id="drop"]').is(':checked')) {
+                    FAILSAFE_CONFIG.failsafe_procedure = 1;
+                } else if ($('input[id="rth"]').is(':checked')) {
+                    FAILSAFE_CONFIG.failsafe_procedure = 2;
+                } else if ($('input[id="nothing"]').is(':checked')) {
+                    FAILSAFE_CONFIG.failsafe_procedure = 3;
+                }
+        
+                MSP.send_message(MSPCodes.MSP_SET_FAILSAFE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FAILSAFE_CONFIG), false, savePhaseTwo);
+            });
+
+            GUI.content_ready(callback);
+        }));
     }
 
     load_failssafe_config();
 
-    function process_html() {
+    function savePhaseTwo() {
+        Settings.saveInputs().then(function () {
+            var self = this;
+            MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
+            setTimeout(function () {
+                $(self).html(oldText);
+            }, 2000);
+            reboot();
+        });
+    }
 
-        // translate to user-selected language
-        localize();
+    function reboot() {
+        //noinspection JSUnresolvedVariable
+        GUI.log(chrome.i18n.getMessage('configurationEepromSaved'));
+        GUI.tab_switch_cleanup(function () {
+            MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitialize);
+        });
+    }
 
-        var $failsafeUseMinimumDistanceCheckbox = $('#failsafe_use_minimum_distance');
-        var $failsafeMinDistanceElements = $('#failsafe_min_distance_elements')
-        var $failsafeMinDistance = $('#failsafe_min_distance')
-        var $failsafeMinDistanceProcedureElements = $('#failsafe_min_distance_procedure_elements')
-        var $failsafeMinDistanceProcedure = $('#failsafe_min_distance_procedure');
+    function reinitialize() {
+        //noinspection JSUnresolvedVariable
+        GUI.log(chrome.i18n.getMessage('deviceRebooting'));
+        GUI.handleReconnect($('.tab_failsafe a'));
+    }
+
+    /*function process_html() {
 
         // generate labels for assigned aux modes
         var element;
 
-        // for some odd reason chrome 38+ changes scroll according to the touched select element
-        // i am guessing this is a bug, since this wasn't happening on 37
-        // code below is a temporary fix, which we will be able to remove in the future (hopefully)
-        $('#content').scrollTop((scrollPosition) ? scrollPosition : 0);
+        
 
         $('input[name="failsafe_throttle"]').val(FAILSAFE_CONFIG.failsafe_throttle);
         $('input[name="failsafe_off_delay"]').val(FAILSAFE_CONFIG.failsafe_off_delay);
@@ -52,77 +164,11 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         $('input[name="failsafe_delay"]').val(FAILSAFE_CONFIG.failsafe_delay);
         $('input[name="failsafe_min_distance"]').val(FAILSAFE_CONFIG.failsafe_min_distance);
 
-        // set stage 2 failsafe procedure
-        $('input[type="radio"].procedure').change(function () {
-            var element = $(this),
-                checked = element.is(':checked'),
-                id = element.attr('id');
-            switch (id) {
-                case 'drop':
-                    if (checked) {
-                        $('input[name="failsafe_throttle"]').prop("disabled", true);
-                        $('input[name="failsafe_off_delay"]').prop("disabled", true);
-                    }
-                    break;
+        
 
-                case 'land':
-                    if (checked) {
-                        $('input[name="failsafe_throttle"]').prop("disabled", false);
-                        $('input[name="failsafe_off_delay"]').prop("disabled", false);
-                    }
-                    break;
-            }
-        });
+        
 
-        switch (FAILSAFE_CONFIG.failsafe_procedure) {
-            default:
-            case 0:
-                element = $('input[id="land"]');
-                element.prop('checked', true);
-                element.change();
-                break;
-            case 1:
-                element = $('input[id="drop"]');
-                element.prop('checked', true);
-                element.change();
-                break;
-            case 2:
-                element = $('input[id="rth"]');
-                element.prop('checked', true);
-                element.change();
-                break;
-            case 3:
-                element = $('input[id="nothing"]');
-                element.prop('checked', true);
-                element.change();
-                break;
-        }
-
-        // Adjust Minimum Distance values when checkbox is checked/unchecked
-        $failsafeUseMinimumDistanceCheckbox.change(function() {
-            if ($(this).is(':checked')) {
-                // 20 meters seems like a reasonable default for a minimum distance
-                $failsafeMinDistance.val(2000);
-                $failsafeMinDistanceElements.show();
-                $failsafeMinDistanceProcedureElements.show();
-            } else {
-                // If they uncheck it, clear the distance to 0, which disables this feature
-                $failsafeMinDistance.val(0);
-                $failsafeMinDistanceElements.hide();
-                $failsafeMinDistanceProcedureElements.hide();
-            }
-        });
-
-        // Set initial state of controls according to data
-        if (FAILSAFE_CONFIG.failsafe_min_distance > 0) {
-            $failsafeUseMinimumDistanceCheckbox.prop('checked', true);
-            $failsafeMinDistanceElements.show();
-            $failsafeMinDistanceProcedureElements.show();
-        } else {
-            $failsafeUseMinimumDistanceCheckbox.prop('checked', false);
-            $failsafeMinDistanceElements.hide();
-            $failsafeMinDistanceProcedureElements.hide();
-        }
+        
 
         // Alternate, minimum distance failsafe procedure
         GUI.fillSelect($failsafeMinDistanceProcedure, FC.getFailsafeProcedure(), FAILSAFE_CONFIG.failsafe_min_distance_procedure);
@@ -177,7 +223,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         });
 
         GUI.content_ready(callback);
-    }
+    }*/
 };
 
 TABS.failsafe.cleanup = function (callback) {

--- a/tabs/osd.html
+++ b/tabs/osd.html
@@ -123,17 +123,17 @@
                             <span data-i18n="osd_time_alarm"></span>
                         </label>
                         <label for="osd_alt_alarm">
-                            <input id="osd_alt_alarm" data-setting="osd_alt_alarm" data-setting-multiplier="1" type="number" data-step="1" />
+                            <input id="osd_alt_alarm" data-setting="osd_alt_alarm" data-unit="m" data-setting-multiplier="1" type="number" data-step="1" />
                             <span data-i18n="osd_alt_alarm"></span>
                         </label>
                         <div class="helpicon cf_tip" data-i18n_title="osdAlarmMAX_NEG_ALTITUDE_HELP"></div>
                         <label for="osd_neg_alt_alarm">
-                            <input id="osd_neg_alt_alarm" data-setting="osd_neg_alt_alarm" data-setting-multiplier="1" type="number" data-step="1" />
+                            <input id="osd_neg_alt_alarm" data-setting="osd_neg_alt_alarm" data-unit="m" data-setting-multiplier="1" type="number" data-step="1" />
                             <span data-i18n="osd_neg_alt_alarm"></span>
                         </label>
                         <div class="helpicon cf_tip" data-i18n_title="osdAlarmDIST_HELP"></div>
                         <label for="osd_dist_alarm">
-                            <input id="osd_dist_alarm" data-setting="osd_dist_alarm" data-setting-multiplier="1" type="number" data-step="1" />
+                            <input id="osd_dist_alarm" data-setting="osd_dist_alarm" data-unit="m-lrg" data-setting-multiplier="1" type="number" data-step="1" />
                             <span data-i18n="osd_dist_alarm"></span>
                         </label>
                         <div class="helpicon cf_tip" data-i18n_title="osdAlarmGFORCE_HELP"></div>
@@ -157,27 +157,27 @@
                             <span data-i18n="osd_current_alarm"></span>
                         </label>
                         <label for="imu_temp_alarm_min">
-                            <input id="imu_temp_alarm_min" data-setting="osd_imu_temp_alarm_min" data-setting-multiplier="10" type="number" data-step="0.5" />
+                            <input id="imu_temp_alarm_min" data-setting="osd_imu_temp_alarm_min" data-unit="decidegc" data-setting-multiplier="1" type="number" data-step="0.5" />
                             <span data-i18n="osd_imu_temp_alarm_min"></span>
                         </label>
                         <label for="imu_temp_alarm_max">
-                            <input id="imu_temp_alarm_max" data-setting="osd_imu_temp_alarm_max" data-setting-multiplier="10" type="number" data-step="0.5" />
+                            <input id="imu_temp_alarm_max" data-setting="osd_imu_temp_alarm_max" data-unit="decidegc" data-setting-multiplier="1" type="number" data-step="0.5" />
                             <span data-i18n="osd_imu_temp_alarm_max"></span>
                         </label>
                         <label for="baro_temp_alarm_min">
-                            <input id="baro_temp_alarm_min" data-setting="osd_baro_temp_alarm_min" data-setting-multiplier="10" type="number" data-step="0.5" />
+                            <input id="baro_temp_alarm_min" data-setting="osd_baro_temp_alarm_min" data-unit="decidegc" data-setting-multiplier="1" type="number" data-step="0.5" />
                             <span data-i18n="osd_baro_temp_alarm_min"></span>
                         </label>
                         <label for="baro_temp_alarm_max">
-                            <input id="baro_temp_alarm_max" data-setting="osd_baro_temp_alarm_max" data-setting-multiplier="10" type="number" data-step="0.5" />
+                            <input id="baro_temp_alarm_max" data-setting="osd_baro_temp_alarm_max" data-unit="decidegc" data-setting-multiplier="1" type="number" data-step="0.5" />
                             <span data-i18n="osd_baro_temp_alarm_max"></span>
                         </label>
                         <label for="esc_temp_alarm_min">
-                            <input id="esc_temp_alarm_min" data-setting="osd_esc_temp_alarm_min" data-setting-multiplier="10" type="number" data-step="0.5" />
+                            <input id="esc_temp_alarm_min" data-setting="osd_esc_temp_alarm_min" data-unit="decidegc" data-setting-multiplier="1" type="number" data-step="0.5" />
                             <span data-i18n="osd_esc_temp_alarm_min"></span>
                         </label>
                         <label for="esc_temp_alarm_max">
-                            <input id="esc_temp_alarm_max" data-setting="osd_esc_temp_alarm_max" data-setting-multiplier="10" type="number" data-step="0.5" />
+                            <input id="esc_temp_alarm_max" data-setting="osd_esc_temp_alarm_max" data-unit="decidegc" data-setting-multiplier="1" type="number" data-step="0.5" />
                             <span data-i18n="osd_esc_temp_alarm_max"></span>
                         </label>
                         <div class="helpicon cf_tip" data-i18n_title="osdalarmLQ_HELP"></div>


### PR DESCRIPTION
1. Fixed rounding error
2. Fixed error that displayed centi° for nav_fw_pitch2thr_threshold. It should have been deci°. The calculation was fine (10 x multiplier). Only the label was wrong.
3. Added conversions for:
a) vertical speed
b) metres
c) temperature
4. Added support on Failsafe and OSD pages
5. Sorted out alignment issues, due to different implementations on different pages
6. Hovering over a field shows the CLI command

This should now take care of all places that need unit conversion, other than **Mission Control**.

## Examples
### Advanced Tuning
![image](https://user-images.githubusercontent.com/17590174/153721332-8000f183-4351-4306-a8fd-d294a1178860.png)
Alignment all looks fine. Note the speeds in the **General Navigation Settings** and **Automatic landing settings** are now in metres per second for vertical speeds. This matches the units used in the OSD for the digital vario. Imperial is feet per second and GA is 100 feet per second.

### Failsafe
![image](https://user-images.githubusercontent.com/17590174/153721411-9acaf980-2c55-4fbc-9a4f-51efe71a88aa.png)
Looks the same, but quite a lot has changed. All data except for the procedure checkboxes no uses the _data-setting_ method. This will be able to be fully converted one PR [#7734 ](https://github.com/iNavFlight/inav/pull/7734) is merged. As that has the changes required to handle string over the _data-setting_ method.

### OSD
![image](https://user-images.githubusercontent.com/17590174/153721634-afc57876-47ab-4c4a-ae13-d9a7f5936c0c.png)
Just the alarms here. I chose to keep **Fly Time** as minutes. But I could change it to be hours with non-default units if people wish. You may also notice that the imperial temperatures are in Fahrenheit.

As always, open to comments or suggestions.

Half-Fixes #1428 