### PR TITLE
Updated mixer

### DIFF
--- a/js/model.js
+++ b/js/model.js
@@ -44,6 +44,7 @@ const
 
 // generate mixer
 const mixerList = [
+    // ** Multirotor
     {
         id: 1,
         name: 'Tricopter',
@@ -60,7 +61,7 @@ const mixerList = [
         servoMixer: [
             new ServoMixRule(SERVO_RUDDER, INPUT_STABILIZED_YAW, 100, 0),
         ]
-    },            // 1
+    }, // 1
     {
         id: 3,
         name: 'Quad X',
@@ -76,7 +77,7 @@ const mixerList = [
             new MotorMixRule(1.0, 1.0, -1.0, -1.0),          // FRONT_L
         ],
         servoMixer: []
-    },               // 3
+    }, // 3
     {
         id: 2,
         name: 'Quad +',
@@ -92,7 +93,7 @@ const mixerList = [
             new MotorMixRule(1.0, 0.0, -1.0, -1.0),         // FRONT
         ],
         servoMixer: []
-    },               // 2
+    }, // 2
     {
         id: 4,
         name: 'Bicopter',
@@ -103,18 +104,7 @@ const mixerList = [
         platform: PLATFORM_MULTIROTOR,
         motorMixer: [],
         servoMixer: []
-    },           // 4
-    {
-        id: 5,
-        name: 'Gimbal',
-        model: 'custom',
-        image: 'custom',
-        enabled: false,
-        legacy: true,
-        platform: PLATFORM_OTHER,
-        motorMixer: [],
-        servoMixer: []
-    },               // 5
+    }, // 4
     {
         id: 6,
         name: 'Y6',
@@ -132,7 +122,7 @@ const mixerList = [
             new MotorMixRule(1.0, 1.0, -0.666667, 1.0),     // UNDER_LEFT
         ],
         servoMixer: []
-    },                           // 6
+    }, // 6
     {
         id: 7,
         name: 'Hex +',
@@ -150,45 +140,7 @@ const mixerList = [
             new MotorMixRule(1.0, 0.0, 1.0, -1.0),          // REAR
         ],
         servoMixer: []
-    },               // 7
-    {
-        id: 8,
-        name: 'Flying Wing',
-        model: 'flying_wing',
-        image: 'flying_wing',
-        enabled: true,
-        legacy: true,
-        platform: PLATFORM_AIRPLANE,
-        motorMixer: [
-            new MotorMixRule(1.0, 0.0, 0.0, 0.0),
-            new MotorMixRule(1.0, 0.0, 0.0, 0.0),
-        ],
-        servoMixer: [
-            new ServoMixRule(SERVO_ELEVON_1, INPUT_STABILIZED_ROLL,  50, 0),
-            new ServoMixRule(SERVO_ELEVON_1, INPUT_STABILIZED_PITCH, 50, 0),
-            new ServoMixRule(SERVO_ELEVON_2, INPUT_STABILIZED_ROLL, -50, 0),
-            new ServoMixRule(SERVO_ELEVON_2, INPUT_STABILIZED_PITCH, 50, 0),
-        ]
-    },     // 8
-    {
-        id: 27,
-        name: 'Flying Wing with differential thrust',
-        model: 'flying_wing',
-        image: 'flying_wing',
-        enabled: true,
-        legacy: false,
-        platform: PLATFORM_AIRPLANE,
-        motorMixer: [
-            new MotorMixRule(1.0, 0.0, 0.0, 0.1),
-            new MotorMixRule(1.0, 0.0, 0.0, -0.1)
-        ],
-        servoMixer: [
-            new ServoMixRule(SERVO_ELEVON_1, INPUT_STABILIZED_ROLL,  50, 0),
-            new ServoMixRule(SERVO_ELEVON_1, INPUT_STABILIZED_PITCH, 50, 0),
-            new ServoMixRule(SERVO_ELEVON_2, INPUT_STABILIZED_ROLL, -50, 0),
-            new ServoMixRule(SERVO_ELEVON_2, INPUT_STABILIZED_PITCH, 50, 0),
-        ]
-    },     // 27
+    }, // 7
     {
         id: 9,
         name: 'Y4',
@@ -204,7 +156,7 @@ const mixerList = [
             new MotorMixRule(1.0, 1.0, -1.0, 0.0),          // FRONT_L CW
         ],
         servoMixer: []
-    },                           // 9
+    }, // 9
     {
         id: 10,
         name: 'Hex X',
@@ -222,7 +174,7 @@ const mixerList = [
             new MotorMixRule(1.0, 1.0, 0.0, 1.0),     // LEFT
         ],
         servoMixer: []
-    },                  // 10
+    }, // 10
     {
         id: 11,
         name: 'Octo X8',
@@ -242,7 +194,7 @@ const mixerList = [
             new MotorMixRule(1.0, 1.0, -1.0, 1.0),          // UNDER_FRONT_L
         ],
         servoMixer: []
-    },             // 11
+    }, // 11
     {
         id: 12,
         name: 'Octo Flat +',
@@ -262,7 +214,7 @@ const mixerList = [
             new MotorMixRule(1.0, 1.0, 0.0, -1.0),              // LEFT
         ],
         servoMixer: []
-    },     // 12
+    }, // 12
     {
         id: 13,
         name: 'Octo Flat X',
@@ -282,51 +234,7 @@ const mixerList = [
             new MotorMixRule(1.0, 1.0, 0.414178, -1.0),      // MIDREAR_L
         ],
         servoMixer: []
-    },     // 13
-    {
-        id: 14,
-        name: 'Airplane',
-        model: 'twin_plane',
-        image: 'airplane',
-        enabled: true,
-        legacy: true,
-        platform: PLATFORM_AIRPLANE,
-        hasFlaps: true,
-        motorMixer: [
-            new MotorMixRule(1.0, 0.0, 0.0, 0.0),
-            new MotorMixRule(1.0, 0.0, 0.0, 0.0),
-        ],
-        servoMixer: [
-            new ServoMixRule(SERVO_ELEVATOR,    INPUT_STABILIZED_PITCH, 100, 0),
-            new ServoMixRule(SERVO_FLAPPERON_1, INPUT_STABILIZED_ROLL,  100, 0),
-            /*new ServoMixRule(SERVO_FLAPPERON_1, INPUT_FEATURE_FLAPS,    100, 0),*/
-            new ServoMixRule(SERVO_FLAPPERON_2, INPUT_STABILIZED_ROLL,  100, 0),
-            /*new ServoMixRule(SERVO_FLAPPERON_2, INPUT_FEATURE_FLAPS,   -100, 0),*/
-            new ServoMixRule(SERVO_RUDDER,      INPUT_STABILIZED_YAW,   100, 0),
-        ]
-    },           // 14
-    {
-        id: 15,
-        name: 'Heli 120',
-        model: 'custom',
-        image: 'custom',
-        enabled: false,
-        legacy: true,
-        platform: PLATFORM_HELICOPTER,
-        motorMixer: [],
-        servoMixer: []
-    },             // 15
-    {
-        id: 16,
-        name: 'Heli 90',
-        model: 'custom',
-        image: 'custom',
-        enabled: false,
-        legacy: true,
-        platform: PLATFORM_HELICOPTER,
-        motorMixer: [],
-        servoMixer: []
-    },              // 16
+    }, // 13
     {
         id: 17,
         name: 'V-tail Quad',
@@ -360,18 +268,7 @@ const mixerList = [
             new MotorMixRule(1.0, 0.0, 0.0, 0.0),     // LEFT
         ],
         servoMixer: []
-    },                // 18
-    {
-        id: 19,
-        name: 'PPM to SERVO',
-        model: 'custom',
-        image: 'custom',
-        enabled: false,
-        legacy: true,
-        platform: PLATFORM_OTHER,
-        motorMixer: [],
-        servoMixer: []
-    },         // 19
+    }, // 18
     {
         id: 20,
         name: 'Dualcopter',
@@ -382,7 +279,7 @@ const mixerList = [
         platform: PLATFORM_MULTIROTOR,
         motorMixer: [],
         servoMixer: []
-    },           // 20
+    }, // 20
     {
         id: 21,
         name: 'Singlecopter',
@@ -393,7 +290,7 @@ const mixerList = [
         platform: PLATFORM_MULTIROTOR,
         motorMixer: [],
         servoMixer: []
-    },         // 21
+    }, // 21
     {
         id: 22,
         name: 'A-tail Quad',
@@ -420,18 +317,7 @@ const mixerList = [
         platform: PLATFORM_MULTIROTOR,
         motorMixer: [],
         servoMixer: []
-    },               // 23
-    {
-        id: 24,
-        name: 'Custom Airplane',
-        model: 'twin_plane',
-        image: 'airplane',
-        enabled: false,
-        legacy: true,
-        platform: PLATFORM_AIRPLANE,
-        motorMixer: [],
-        servoMixer: []
-    },      // 24
+    }, // 23
     {
         id: 25,
         name: 'Custom Tricopter',
@@ -442,7 +328,67 @@ const mixerList = [
         platform: PLATFORM_TRICOPTER,
         motorMixer: [],
         servoMixer: []
-    },      // 25
+    }, // 25
+
+    // ** Fixed Wing ** 
+    {
+        id: 8,
+        name: 'Flying Wing',
+        model: 'flying_wing',
+        image: 'flying_wing',
+        enabled: true,
+        legacy: true,
+        platform: PLATFORM_AIRPLANE,
+        motorMixer: [
+            new MotorMixRule(1.0, 0.0, 0.0, 0.0),
+        ],
+        servoMixer: [
+            new ServoMixRule(SERVO_ELEVON_1, INPUT_STABILIZED_ROLL,  50, 0),
+            new ServoMixRule(SERVO_ELEVON_1, INPUT_STABILIZED_PITCH, 50, 0),
+            new ServoMixRule(SERVO_ELEVON_2, INPUT_STABILIZED_ROLL, -50, 0),
+            new ServoMixRule(SERVO_ELEVON_2, INPUT_STABILIZED_PITCH, 50, 0),
+        ]
+    }, // 8
+    {
+        id: 27,
+        name: 'Flying Wing with differential thrust',
+        model: 'flying_wing',
+        image: 'flying_wing',
+        enabled: true,
+        legacy: false,
+        platform: PLATFORM_AIRPLANE,
+        motorMixer: [
+            new MotorMixRule(1.0, 0.0, 0.0, 0.1),
+            new MotorMixRule(1.0, 0.0, 0.0, -0.1)
+        ],
+        servoMixer: [
+            new ServoMixRule(SERVO_ELEVON_1, INPUT_STABILIZED_ROLL,  50, 0),
+            new ServoMixRule(SERVO_ELEVON_1, INPUT_STABILIZED_PITCH, 50, 0),
+            new ServoMixRule(SERVO_ELEVON_2, INPUT_STABILIZED_ROLL, -50, 0),
+            new ServoMixRule(SERVO_ELEVON_2, INPUT_STABILIZED_PITCH, 50, 0),
+        ]
+    }, // 27
+    {
+        id: 14,
+        name: 'Airplane',
+        model: 'twin_plane',
+        image: 'airplane',
+        enabled: true,
+        legacy: true,
+        platform: PLATFORM_AIRPLANE,
+        hasFlaps: true,
+        motorMixer: [
+            new MotorMixRule(1.0, 0.0, 0.0, 0.0),
+        ],
+        servoMixer: [
+            new ServoMixRule(SERVO_ELEVATOR,    INPUT_STABILIZED_PITCH, 100, 0),
+            new ServoMixRule(SERVO_FLAPPERON_1, INPUT_STABILIZED_ROLL,  100, 0),
+            /*new ServoMixRule(SERVO_FLAPPERON_1, INPUT_FEATURE_FLAPS,    100, 0),*/
+            new ServoMixRule(SERVO_FLAPPERON_2, INPUT_STABILIZED_ROLL,  100, 0),
+            /*new ServoMixRule(SERVO_FLAPPERON_2, INPUT_FEATURE_FLAPS,   -100, 0),*/
+            new ServoMixRule(SERVO_RUDDER,      INPUT_STABILIZED_YAW,   100, 0),
+        ]
+    }, // 14
     {
         id: 26,
         name: 'Airplane with differential thrust',
@@ -464,10 +410,10 @@ const mixerList = [
             /*new ServoMixRule(SERVO_FLAPPERON_2, INPUT_FEATURE_FLAPS,   -100, 0),*/
             new ServoMixRule(SERVO_RUDDER,      INPUT_STABILIZED_YAW,   100, 0),
         ]
-    },
+    }, // 26
     {
         id: 28,
-        name: 'Airplane V-tail (individual aileron servos)',
+        name: 'Airplane V-tail',
         model: 'vtail_plane',
         image: 'airplane_vtail',
         enabled: true,
@@ -487,7 +433,31 @@ const mixerList = [
             new ServoMixRule(4, INPUT_STABILIZED_PITCH, -50, 0),
             new ServoMixRule(4, INPUT_STABILIZED_YAW,   -50, 0)
         ]
-    },
+    }, // 28
+    {
+        id: 34,
+        name: 'Airplane V-tail with differential thrust',
+        model: 'vtail_plane',
+        image: 'airplane_vtail',
+        enabled: true,
+        legacy: false,
+        platform: PLATFORM_AIRPLANE,
+        hasFlaps: true,
+        motorMixer: [
+            new MotorMixRule(1.0, 0.0, 0.0, 0.3),
+            new MotorMixRule(1.0, 0.0, 0.0, -0.3)
+        ],
+        servoMixer: [
+            new ServoMixRule(1, INPUT_STABILIZED_ROLL,  100, 0),
+            /*new ServoMixRule(1, INPUT_FEATURE_FLAPS,    100, 0),*/
+            new ServoMixRule(2, INPUT_STABILIZED_ROLL,  100, 0),
+            /*new ServoMixRule(2, INPUT_FEATURE_FLAPS,    100, 0),*/
+            new ServoMixRule(3, INPUT_STABILIZED_PITCH, 50, 0),
+            new ServoMixRule(3, INPUT_STABILIZED_YAW,   -50, 0),
+            new ServoMixRule(4, INPUT_STABILIZED_PITCH, -50, 0),
+            new ServoMixRule(4, INPUT_STABILIZED_YAW,   -50, 0)
+        ]
+    }, // 34
     {
         id: 29,
         name: 'Airplane V-tail (single aileron servo)',
@@ -506,7 +476,7 @@ const mixerList = [
             new ServoMixRule(3, INPUT_STABILIZED_PITCH, -50, 0),
             new ServoMixRule(3, INPUT_STABILIZED_YAW,   -50, 0),
         ]
-    },
+    }, //29
     {
         id: 30,
         name: 'Airplane without rudder',
@@ -526,7 +496,44 @@ const mixerList = [
             new ServoMixRule(SERVO_FLAPPERON_2, INPUT_STABILIZED_ROLL,  100, 0),
             /*new ServoMixRule(SERVO_FLAPPERON_2, INPUT_FEATURE_FLAPS,    100, 0),*/
         ]
-    },
+    }, // 30
+    {
+        id: 24,
+        name: 'Custom Airplane',
+        model: 'twin_plane',
+        image: 'airplane',
+        enabled: false,
+        legacy: true,
+        platform: PLATFORM_AIRPLANE,
+        motorMixer: [],
+        servoMixer: []
+    }, // 24
+
+    // ** Helicopter **
+    {
+        id: 15,
+        name: 'Heli 120',
+        model: 'custom',
+        image: 'custom',
+        enabled: false,
+        legacy: true,
+        platform: PLATFORM_HELICOPTER,
+        motorMixer: [],
+        servoMixer: []
+    }, // 15
+    {
+        id: 16,
+        name: 'Heli 90',
+        model: 'custom',
+        image: 'custom',
+        enabled: false,
+        legacy: true,
+        platform: PLATFORM_HELICOPTER,
+        motorMixer: [],
+        servoMixer: []
+    }, // 16
+
+    // ** Other platforms **
     {
         id: 31,
         name: 'Rover',
@@ -556,8 +563,8 @@ const mixerList = [
         servoMixer: [
             new ServoMixRule(3, INPUT_STABILIZED_YAW,  100, 0),
         ]
-    }    
-    ,
+    },
+    // ** Misc **
     {
         id: 33,
         name: 'Other',
@@ -572,7 +579,29 @@ const mixerList = [
         servoMixer: [
             new ServoMixRule(3, INPUT_STABILIZED_YAW,  100, 0),
         ]
-    }                 
+    },
+    {
+        id: 5,
+        name: 'Gimbal',
+        model: 'custom',
+        image: 'custom',
+        enabled: false,
+        legacy: true,
+        platform: PLATFORM_OTHER,
+        motorMixer: [],
+        servoMixer: []
+    }, // 5
+    {
+        id: 19,
+        name: 'PPM to SERVO',
+        model: 'custom',
+        image: 'custom',
+        enabled: false,
+        legacy: true,
+        platform: PLATFORM_OTHER,
+        motorMixer: [],
+        servoMixer: []
+    }, // 19               
 ];
 
 const platformList = [

--- a/js/motorMixRule.js
+++ b/js/motorMixRule.js
@@ -7,9 +7,9 @@ var MotorMixRule = function (throttle, roll, pitch, yaw) {
 
     self.fromMsp = function (mspThrottle, mspRoll, mspPitch, mspYaw) {
         throttle = mspThrottle / 1000;
-        roll = (mspRoll / 1000) - 2;
-        pitch = (mspPitch / 1000) - 2;
-        yaw = (mspYaw / 1000) - 2;
+        roll = Math.round(((mspRoll / 1000) - 2) * 1000) / 1000;
+        pitch = Math.round(((mspPitch / 1000) - 2) * 1000) / 1000;
+        yaw = Math.round(((mspYaw / 1000) - 2) * 1000) / 1000;
     };
 
     self.isUsed = function () {

--- a/js/servoMixerRuleCollection.js
+++ b/js/servoMixerRuleCollection.js
@@ -99,5 +99,20 @@ let ServoMixerRuleCollection = function () {
         });
     }
 
+    self.getNextUnusedIndex = function() {
+        let nextTarget = 0;
+
+        for (let ruleIndex in data) {
+            if (data.hasOwnProperty(ruleIndex)) {
+                let target = data[ruleIndex].getTarget();
+                if (target > nextTarget) {
+                    nextTarget = target;
+                }
+            }
+        }
+
+        return nextTarget+1;
+    }
+
     return self;
 };

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -438,7 +438,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
 
         $("[data-role='role-servo-add']").click(function () {
             if (SERVO_RULES.hasFreeSlots()) {
-                SERVO_RULES.put(new ServoMixRule(0, 0, 100, 0));
+                SERVO_RULES.put(new ServoMixRule(SERVO_RULES.getNextUnusedIndex(), 0, 100, 0));
                 renderServoMixRules();
                 renderOutputMapping();
             }


### PR DESCRIPTION
- Tidied up the code a little and grouped mixer types in model.js.
- Removed second motor from all fixed wing mixers that aren't differential thrust. A bug was discovered that if an FC only has a single motor output, and 2 motors are set in the mixer, the motors won't work.
- Added mixer for V-Tail with differential thrust
- Enhanced the new servo button. Clicking it now selects the next available servo number, rather than just 0.