### PR TITLE
Re-arrange and change labels for landing.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2600,25 +2600,25 @@
         "message": "Used when not landing at the home point. Upon arriving at home, the plane will loiter and change altitude to the RTH Home Altitude. Default is 0, which is feature disabled."
     },
     "landMaxAltVspd": {
-        "message": "<strong>Initial landing speed</strong> until <strong>Slow down altitude</strong> is reached"
+        "message": "The craft will start to descend at this speed, once it reaches the <strong>Home</strong> location."
     },
     "landMaxAltVspdHelp": {
         "message": "After RTH if autolanding is enabled the aircraft will start to descend at this speed until reaching <strong>Slow down altitude</strong>"
     },
     "landSlowdownMaxAlt": {
-        "message": "<strong>Slow down altitude</strong>. Altitude bellow which the aircraft will start to slow down"
+        "message": "When the craft has descended to <i>this</i> altitude. It will begin to slow down for landing."
     },
     "landSlowdownMaxAltHelp": {
         "message": "When the aircraft reaches this altitude it will start to slow down linearly between the <strong>Initial landing speed</strong> and <strong>Final landing speed</strong> to reach it at <strong>Final approach altitude</strong>"
     },
+    "landSlowdownMinAlt": {
+        "message": "When the craft has descended to <i>this</i> altitude, it will have slowed to the touch down speed."
+    },
     "landMinAltVspd": {
-        "message": "<strong>Final landing speed</strong>. Speed the aircraft will take until touchdown when the <strong>Final approach altitutde</strong> is reached"
+        "message": "This is the touch down speed."
     },
     "landMinAltVspdHelp": {
         "message": "The aircraft vertical speed target will be this value when the aircraft reaches the <strong>Final approach altitude</strong> after having slowed down linearly from the <strong>Slow down altitude</strong> at <strong>Initial landing speed</strong>"
-    },
-    "landSlowdownMinAlt": {
-        "message": "<strong>Final approach altitude</strong>. Altitude under which the aircraft will go down at <strong>Final landing speed</strong> until touchdown"
     },
     "emergencyDescentRate": {
         "message": "Emergency landing speed"

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -432,30 +432,25 @@
                         <div class="spacer_box_title" data-i18n="autoLandingSettings"></div>
                     </div>
                     <div class="spacer_box">
-
                         <div class="number">
                             <input id="landMaxAltVspd" type="number" data-unit="v-cms" data-setting="nav_land_maxalt_vspd" data-setting-multiplier="1" step="1" min="100" max="2000" />
                             <label for="landMaxAltVspd"><span data-i18n="landMaxAltVspd"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="landMaxAltVspdHelp"></div>
                         </div>
-
                         <div class="number">
                             <input id="landSlowdownMaxAlt" type="number" data-unit="cm" data-setting="nav_land_slowdown_maxalt" data-setting-multiplier="1" step="1" min="500" max="4000" />
                             <label for="landSlowdownMaxAlt"><span data-i18n="landSlowdownMaxAlt"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="landSlowdownMaxAltHelp"></div>
                         </div>
-
+                        <div class="number">
+                            <input id="landSlowdownMinAlt" type="number" data-unit="cm" data-setting="nav_land_slowdown_minalt" data-setting-multiplier="1" step="1" min="50" max="1000" />
+                            <label for="landSlowdownMinAlt"><span data-i18n="landSlowdownMinAlt"></span></label>
+                        </div>
                         <div class="number">
                             <input id="landMinAltVspd" type="number" data-unit="v-cms" data-setting="nav_land_minalt_vspd" data-setting-multiplier="1" step="1" min="50" max="500" />
                             <label for="landMinAltVspd"><span data-i18n="landMinAltVspd"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="landMinAltVspdHelp"></div>
                         </div>
-
-                        <div class="number">
-                            <input id="landSlowdownMinAlt" type="number" data-unit="cm" data-setting="nav_land_slowdown_minalt" data-setting-multiplier="1" step="1" min="50" max="1000" />
-                            <label for="landSlowdownMinAlt"><span data-i18n="landSlowdownMinAlt"></span></label>
-                        </div>
-
                         <div class="number">
                             <input id="emergencyDescentRate" type="number" data-unit="cms" data-setting="nav_emerg_landing_speed" data-setting-multiplier="1" step="1" min="100" max="2000" />
                             <label for="emergencyDescentRate"><span data-i18n="emergencyDescentRate"></span></label>


### PR DESCRIPTION
This changes the labels and order of fields in the landing section of advanced tuning. These new labels should make it easier for pilots to understand what is happening.

![image](https://user-images.githubusercontent.com/17590174/157398849-8b3281ad-bc3c-4992-a489-d4da772afff1.png)
