### PR TITLE
Update check now obeys settings checkbox

### DIFF
--- a/main.js
+++ b/main.js
@@ -147,7 +147,11 @@ $(document).ready(function () {
          }
     });
 
-    appUpdater.checkRelease(chrome.runtime.getManifest().version);
+    chrome.storage.local.get('update_notify', function(result) {
+        if (typeof result.update_notify === 'undefined' || result.update_notify) {
+            appUpdater.checkRelease(chrome.runtime.getManifest().version);
+        }
+    });
 
     // log library versions in console to make version tracking easier
     console.log('Libraries: jQuery - ' + $.fn.jquery + ', d3 - ' + d3.version + ', three.js - ' + THREE.REVISION);


### PR DESCRIPTION
Fixes #1497

The **Receive desktop notification when application updates** checkbox should allow people to receive or not receive update available notifications. Currently the update notification box will always appear, regardless of the state of the checkbox. This PR fixes that.

![image](https://user-images.githubusercontent.com/17590174/162064820-9456fafd-cbce-4e0f-9ff5-c4dd71f1f218.png)

[Demo](https://youtu.be/bxf0QTAuEjI)