### PR TITLE
Moved font select/upload box

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -2820,6 +2820,8 @@ TABS.osd.initialize = function (callback) {
         OSD.GUI.jbox = new jBox('Modal', {
             width: 708,
             height: 240,
+            position: {y:'bottom'},
+            offset: {y:-50},
             closeButton: 'title',
             animation: false,
             attach: $('#fontmanager'),


### PR DESCRIPTION
Moved the font select/upload box down. This allows the OSD preview window to still be visible in most cases.

![image](https://user-images.githubusercontent.com/17590174/164548811-0eb16bc9-a1fc-4ae0-a7eb-be32e6f2683d.png)
