### PR TITLE
Added idle delay to Advanced Tuning

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -932,6 +932,12 @@
     "configurationLaunchIdleThrHelp": {
         "message": "Idle throttle - throttle to be set before launch sequence is initiated. If set below minimum throttle it will force motor stop or at idle throttle (depending if the MOTOR_STOP is enabled). If set above minimum throttle it will force throttle to this value (if MOTOR_STOP is enabled it will be handled according to throttle stick position). Default: 1000 [1000-2000]"
     },
+    "configurationLaunchIdleDelay": {
+        "message": "Idle Throttle Delay"
+    },
+    "configurationLaunchIdleDelayHelp": {
+        "message": "Set a time delay between raising the throttle for the launch, and the motor starting at idle throttle. Default: 0 [0-60000]"
+    },
     "configurationLaunchMotorDelay": {
         "message": "Motor Delay"
     },

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -12,7 +12,7 @@
                     <div class="spacer_box settings">
                         <div class="number">
                             <input type="number" id="launchIdleThr" data-unit="us" data-setting="nav_fw_launch_idle_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
-                            <label for="launchIdleThr">D <span data-i18n="configurationLaunchIdleThr"></span></label>
+                            <label for="launchIdleThr"><span data-i18n="configurationLaunchIdleThr"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="configurationLaunchIdleThrHelp"></div>
                         </div>
 

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -12,9 +12,16 @@
                     <div class="spacer_box settings">
                         <div class="number">
                             <input type="number" id="launchIdleThr" data-unit="us" data-setting="nav_fw_launch_idle_thr" data-setting-multiplier="1" step="1" min="1000" max="2000" />
-                            <label for="launchIdleThr"><span data-i18n="configurationLaunchIdleThr"></span></label>
+                            <label for="launchIdleThr">D <span data-i18n="configurationLaunchIdleThr"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="configurationLaunchIdleThrHelp"></div>
                         </div>
+
+                        <div class="number">
+                            <input type="number" id="launchIdleDelay" data-unit="ms" data-setting="nav_fw_launch_idle_motor_delay" data-setting-multiplier="1" step="1" min="0" max="60000" />
+                            <label for="launchIdleDelay"><span data-i18n="configurationLaunchIdleDelay"></span></label>
+                            <div class="helpicon cf_tip" data-i18n_title="configurationLaunchIdleDelayHelp"></div>
+                        </div>
+
                         <div class="number">
                             <input type="number" id="launchMaxAngle" data-unit="deg" data-setting="nav_fw_launch_max_angle" data-setting-multiplier="1" step="1" min="5" max="180" />
                             <label for="launchMaxAngle"><span data-i18n="configurationLaunchMaxAngle"></span></label>


### PR DESCRIPTION
This is a very useful setting. It is strange that it was missing; especially when it is changed far more often than nav_fw_launch_detect_time.

![image](https://user-images.githubusercontent.com/17590174/166639155-a0369fc5-2f41-43c4-b179-6c40e831950e.png)
