### PR TITLE
Fix colours and labels bug in the mixer

### DIFF
--- a/js/model.js
+++ b/js/model.js
@@ -799,6 +799,22 @@ helper.mixer = (function (mixerList) {
         }
     }
 
+    publicScope.countSurfaceType = function(mixer, surface) {
+        let count = 0;
+
+        for (const i in mixer.servoMixer) {
+            if (mixer.servoMixer.hasOwnProperty(i)) {
+                const s = mixer.servoMixer[i];
+
+                if (s.getInput() === surface) {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
     return publicScope;
 })(mixerList);
 


### PR DESCRIPTION
I spotted a bug in the 5.0 mixer where adding additional inputs where more than 1 exists on the aircraft, messed up the output number on the image preview and colouring in the table. This fixes that. It's also future proof. If there is a default mixer in the future with 4 ailerons, for example, this will still work.

The bug
![image](https://user-images.githubusercontent.com/17590174/168397765-b265cb55-1fdf-470f-b8c0-28e8e1f47dd3.png)

After the fix
![image](https://user-images.githubusercontent.com/17590174/168397889-026a9f13-b659-43c1-baee-7b2767845958.png)
