### PR TITLE
Fixed units bug

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -242,6 +242,7 @@ var Settings = (function () {
             'cmss' : 'cm/s/s',
             // Time
             'msec' : 'ms',
+            'msec-nc' : 'ms', // Milliseconds, but not converted.
             'dsec' : 'ds',
             'sec' : 's',
             // Angles
@@ -308,6 +309,9 @@ var Settings = (function () {
                 'ms' : 100,
                 'hftmin' : 50.8,
                 'fts' : 30.48
+            },
+            'msec-nc' : {
+                'msec-nc' : 1
             },
             'msec' : {
                 'sec' : 1000

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -17,7 +17,7 @@
                         </div>
 
                         <div class="number">
-                            <input type="number" id="launchIdleDelay" data-unit="ms" data-setting="nav_fw_launch_idle_motor_delay" data-setting-multiplier="1" step="1" min="0" max="60000" />
+                            <input type="number" id="launchIdleDelay" data-unit="msec" data-setting="nav_fw_launch_idle_motor_delay" data-setting-multiplier="1" step="1" min="0" max="60000" />
                             <label for="launchIdleDelay"><span data-i18n="configurationLaunchIdleDelay"></span></label>
                             <div for="launchIdleDelay" class="helpicon cf_tip" data-i18n_title="configurationLaunchIdleDelayHelp"></div>
                         </div>
@@ -38,22 +38,22 @@
                             <div for="launchAccel" class="helpicon cf_tip" data-i18n_title="configurationLaunchAccelHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="launchDetectTime" data-unit="ms" data-setting="nav_fw_launch_detect_time" data-setting-multiplier="1" step="1" min="10" max="1000" />
+                            <input type="number" id="launchDetectTime" data-unit="msec" data-setting="nav_fw_launch_detect_time" data-setting-multiplier="1" step="1" min="10" max="1000" />
                             <label for="launchDetectTime"><span data-i18n="configurationLaunchDetectTime"></span></label>
                             <div for="launchDetectTime" class="helpicon cf_tip" data-i18n_title="configurationLaunchDetectTimeHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="launchMotorDelay" data-unit="ms" data-setting="nav_fw_launch_motor_delay" data-setting-multiplier="1" step="1" min="0" max="5000" />
+                            <input type="number" id="launchMotorDelay" data-unit="msec" data-setting="nav_fw_launch_motor_delay" data-setting-multiplier="1" step="1" min="0" max="5000" />
                             <label for="launchMotorDelay"><span data-i18n="configurationLaunchMotorDelay"></span></label>
                             <div for="launchMotorDelay" class="helpicon cf_tip" data-i18n_title="configurationLaunchMotorDelayHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="launchMinTime" data-unit="ms" data-setting="nav_fw_launch_min_time" data-setting-multiplier="1" step="1" min="0" max="60000" />
+                            <input type="number" id="launchMinTime" data-unit="msec" data-setting="nav_fw_launch_min_time" data-setting-multiplier="1" step="1" min="0" max="60000" />
                             <label for="launchMinTime"><span data-i18n="configurationLaunchMinTime"></span></label>
                             <div for="launchMinTime" class="helpicon cf_tip" data-i18n_title="configurationLaunchMinTimeHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="launchSpinupTime" data-unit="ms" data-setting="nav_fw_launch_spinup_time" data-setting-multiplier="1" step="1" min="0" max="1000" />
+                            <input type="number" id="launchSpinupTime" data-unit="msec" data-setting="nav_fw_launch_spinup_time" data-setting-multiplier="1" step="1" min="0" max="1000" />
                             <label for="launchSpinupTime"><span data-i18n="configurationLaunchSpinupTime"></span></label>
                             <div for="launchSpinupTime" class="helpicon cf_tip" data-i18n_title="configurationLaunchSpinupTimeHelp"></div>
                         </div>
@@ -68,7 +68,7 @@
                             <div for="launchClimbAngle" class="helpicon cf_tip" data-i18n_title="configurationLaunchClimbAngleHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="launchTimeout" data-unit="ms" data-setting="nav_fw_launch_timeout" data-setting-multiplier="1" step="1" min="0" max="60000" />
+                            <input type="number" id="launchTimeout" data-unit="msec" data-setting="nav_fw_launch_timeout" data-setting-multiplier="1" step="1" min="0" max="60000" />
                             <label for="launchTimeout"><span data-i18n="configurationLaunchTimeout"></span></label>
                             <div for="launchTimeout" class="helpicon cf_tip" data-i18n_title="configurationLaunchTimeoutHelp"></div>
                         </div>
@@ -78,7 +78,7 @@
                             <div for="launchMaxAltitude" class="helpicon cf_tip" data-i18n_title="configurationLaunchMaxAltitudeHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="launchEndTime" data-unit="ms" data-setting="nav_fw_launch_end_time" data-setting-multiplier="1" step="1" min="0" max="5000" />
+                            <input type="number" id="launchEndTime" data-unit="msec" data-setting="nav_fw_launch_end_time" data-setting-multiplier="1" step="1" min="0" max="5000" />
                             <label for="launchEndTime"><span data-i18n="configurationLaunchEndTime"></span></label>
                             <div for="launchEndTime" class="helpicon cf_tip" data-i18n_title="configurationLaunchEndTimeHelp"></div>
                         </div>
@@ -278,7 +278,7 @@
                         </div>
 
                         <div class="number">
-                            <input id="brakingTimeout" type="number" data-unit="ms" data-setting="nav_mc_braking_timeout" data-setting-multiplier="1" step="1" min="100" max="5000" />
+                            <input id="brakingTimeout" type="number" data-unit="msec" data-setting="nav_mc_braking_timeout" data-setting-multiplier="1" step="1" min="100" max="5000" />
                             <label for="brakingTimeout"><span data-i18n="brakingTimeout"></span></label>
                             <div for="brakingTimeout" class="helpicon cf_tip" data-i18n_title="brakingTimeoutTip"></div>
                         </div>
@@ -290,7 +290,7 @@
                         </div>
 
                         <div class="number">
-                            <input id="brakingBoostTimeout" type="number" data-unit="ms" data-setting="nav_mc_braking_boost_timeout" data-setting-multiplier="1" step="1" min="0" max="5000" />
+                            <input id="brakingBoostTimeout" type="number" data-unit="msec" data-setting="nav_mc_braking_boost_timeout" data-setting-multiplier="1" step="1" min="0" max="5000" />
                             <label for="brakingBoostTimeout"><span data-i18n="brakingBoostTimeout"></span></label>
                             <div for="brakingBoostTimeout" class="helpicon cf_tip" data-i18n_title="brakingBoostTimeoutTip"></div>
                         </div>

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -38,12 +38,12 @@
                             <div for="launchAccel" class="helpicon cf_tip" data-i18n_title="configurationLaunchAccelHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="launchDetectTime" data-unit="msec" data-setting="nav_fw_launch_detect_time" data-setting-multiplier="1" step="1" min="10" max="1000" />
+                            <input type="number" id="launchDetectTime" data-unit="msec-nc" data-setting="nav_fw_launch_detect_time" data-setting-multiplier="1" step="1" min="10" max="1000" />
                             <label for="launchDetectTime"><span data-i18n="configurationLaunchDetectTime"></span></label>
                             <div for="launchDetectTime" class="helpicon cf_tip" data-i18n_title="configurationLaunchDetectTimeHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="launchMotorDelay" data-unit="msec" data-setting="nav_fw_launch_motor_delay" data-setting-multiplier="1" step="1" min="0" max="5000" />
+                            <input type="number" id="launchMotorDelay" data-unit="msec-nc" data-setting="nav_fw_launch_motor_delay" data-setting-multiplier="1" step="1" min="0" max="5000" />
                             <label for="launchMotorDelay"><span data-i18n="configurationLaunchMotorDelay"></span></label>
                             <div for="launchMotorDelay" class="helpicon cf_tip" data-i18n_title="configurationLaunchMotorDelayHelp"></div>
                         </div>
@@ -53,7 +53,7 @@
                             <div for="launchMinTime" class="helpicon cf_tip" data-i18n_title="configurationLaunchMinTimeHelp"></div>
                         </div>
                         <div class="number">
-                            <input type="number" id="launchSpinupTime" data-unit="msec" data-setting="nav_fw_launch_spinup_time" data-setting-multiplier="1" step="1" min="0" max="1000" />
+                            <input type="number" id="launchSpinupTime" data-unit="msec-nc" data-setting="nav_fw_launch_spinup_time" data-setting-multiplier="1" step="1" min="0" max="1000" />
                             <label for="launchSpinupTime"><span data-i18n="configurationLaunchSpinupTime"></span></label>
                             <div for="launchSpinupTime" class="helpicon cf_tip" data-i18n_title="configurationLaunchSpinupTimeHelp"></div>
                         </div>

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -538,7 +538,7 @@
                     <tr>
                         <th data-i18n="pidTuning_FW_TPATimeConstant"></th>
                         <td>
-                            <div class="pidTuning_number"><input id="tpaTimeConstant" type="number" class="rate-tpa_input" data-setting="fw_tpa_time_constant" data-unit="ms" /></div>
+                            <div class="pidTuning_number"><input id="tpaTimeConstant" type="number" class="rate-tpa_input" data-setting="fw_tpa_time_constant" data-unit="msec" /></div>
                             <div for="tpaTimeConstant" class="helpicon cf_tip" data-i18n_title="pidTuning_FW_TPATimeConstantHelp"></div>
                         </td>
                     </tr>


### PR DESCRIPTION
Milliseconds set as metres/sec. Now fixed.

@DzikuVx RC2 please. This will cause a multiplication error for people who use alternate units. On default it is just visual.