### PR TITLE
Hide switch indicators settings when DJI is used

### DIFF
--- a/tabs/osd.html
+++ b/tabs/osd.html
@@ -243,7 +243,7 @@
                         </label>
                     </div>
                 </div>
-                <div class="gui_box grey switch-indicator-container"> 
+                <div class="gui_box grey switch-indicator-container">
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title" data-i18n="osd_switch_indicator_settings"></div>
                     </div>

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -493,6 +493,7 @@ OSD.DjiElements =  {
         "Timers",
         "VTX",
         "CRSF",
+        "SwitchIndicators",
         "GVars",
         "PIDs",
         "PIDOutputs",
@@ -2571,6 +2572,8 @@ OSD.GUI.updateDjiView = function(on) {
                 $(element).hide();
             }
         });
+
+        $('.switch-indicator-container').hide();
     } else {
         $(OSD.DjiElements.emptyGroups).each(function(index, groupName) {
             $('#osdGroup' + groupName).show();
@@ -2583,6 +2586,8 @@ OSD.GUI.updateDjiView = function(on) {
         $('.settings-container, .alarms-container').find('.settings').children()
             .show()
             .removeClass('no-bottom');
+        
+        $('.switch-indicator-container').show();
     }
     OSD.GUI.updateDjiMessageElements($('#useCraftnameForMessages').is(':checked'));
 };


### PR DESCRIPTION
On `Hide unused elements`:
- Remove switch indicators settings
- Tidy removal of switch indicator elements