### PR TITLE
Convert GPS time zone to hours

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -262,6 +262,8 @@ var Settings = (function () {
             'msec-nc' : 'ms', // Milliseconds, but not converted.
             'dsec' : 'ds',
             'sec' : 's',
+            'mins' : 'm',
+            'hours' : 'h',
             // Angles
             'deg' : '&deg;',
             'decideg' : 'deci&deg;',
@@ -304,6 +306,8 @@ var Settings = (function () {
             'msec-nc' : 'Milliseconds',
             'dsec' : 'Deciseconds',
             'sec' : 'Seconds',
+            'mins' : 'Minutes',
+            'hours' : 'Hours',
             // Angles
             'deg' : 'Degrees',
             'decideg' : 'DeciDegrees',
@@ -377,6 +381,9 @@ var Settings = (function () {
             'dsec' : {
                 'sec' : 10
             },
+            'mins' : {
+                'hours' : 60
+            },
             'decideg' : {
                 'deg' : 10
             },
@@ -402,6 +409,7 @@ var Settings = (function () {
                 'v-cms' : 'fts',
                 'msec' : 'sec',
                 'dsec' : 'sec',
+                'mins' : 'hours',
                 'decadegps' : 'degps',
                 'decideg' : 'deg',
                 'decideg-lrg' : 'deg',
@@ -415,6 +423,7 @@ var Settings = (function () {
                 'v-cms' : 'ms',
                 'msec' : 'sec',
                 'dsec' : 'sec',
+                'mins' : 'hours',
                 'decadegps' : 'degps',
                 'decideg' : 'deg',
                 'decideg-lrg' : 'deg',
@@ -431,6 +440,7 @@ var Settings = (function () {
                 'decideg-lrg' : 'deg',
                 'msec' : 'sec',
                 'dsec' : 'sec',
+                'mins' : 'hours',
                 'decidegc' : 'degc',
             },
             3:{ //UK
@@ -444,6 +454,7 @@ var Settings = (function () {
                 'decideg-lrg' : 'deg',
                 'msec' : 'sec',
                 'dsec' : 'sec',
+                'mins' : 'hours',
                 'decidegc' : 'degc',
             },
             4: { //General aviation
@@ -457,11 +468,13 @@ var Settings = (function () {
                 'decideg-lrg' : 'deg',
                 'msec' : 'sec',
                 'dsec' : 'sec',
+                'mins' : 'hours',
                 'decidegc' : 'degc',
             },
             default: { //show base units
                 'decadegps' : 'degps',
                 'decideg-lrg' : 'deg',
+                'mins' : 'hours',
             }
         };
 

--- a/tabs/gps.html
+++ b/tabs/gps.html
@@ -42,7 +42,7 @@
                             <label for="gps_use_galileo"><span data-i18n="configurationGPSUseGalileo"></span></label>
                         </div>
                         <div class="number">
-                            <input type="number" id="tzOffset" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-1440" max="1440" />
+                            <input type="number" id="tzOffset" data-setting="tz_offset" data-unit="mins" data-setting-multiplier="1" step="1" min="-1440" max="1440" />
                             <label for="tzOffset"><span data-i18n="tzOffset"></span></label>
                             <div for="tzOffset" class="helpicon cf_tip" data-i18n_title="tzOffsetHelp"></div>
                         </div>


### PR DESCRIPTION
...because it's easier and more standardised than setting minutes for time zone.

![image](https://user-images.githubusercontent.com/17590174/180624943-c5090732-223a-42f7-84f8-bcafe398e45e.png)
![image](https://user-images.githubusercontent.com/17590174/180624948-95044b84-3498-4d21-8ef2-39ff41ec4a56.png)
