### PR TITLE
Updated Plane presets for better AHI Drift mitigation

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -287,19 +287,23 @@ helper.defaultsDialog = (function () {
             },
             {
                 key: "nav_fw_pos_z_p",
-                value: 15
+                value: 25
             },
             {
-                key: "nav_fw_pos_z_d",
+                key: "nav_fw_pos_z_i",
                 value: 5
             },
             {
+                key: "nav_fw_pos_z_d",
+                value: 8
+            },
+            {
                 key: "nav_fw_pos_xy_p",
-                value: 60
+                value: 55
             },
             {
                 key: "fw_turn_assist_pitch_gain",
-                value: 0.5
+                value: 0.4
             },
             {
                 key: "max_angle_inclination_rll",
@@ -359,11 +363,19 @@ helper.defaultsDialog = (function () {
             },
             {
                 key: "imu_acc_ignore_rate",
-                value: 9
+                value: 7
             },
             {
                 key: "imu_acc_ignore_slope",
-                value: 5
+                value: 4
+            },
+            {
+                key: "imu_dcm_kp",
+                value: 1000
+            },
+            {
+                key: "imu_dcm_ki",
+                value: 0
             },
             {
                 key: "airmode_type",
@@ -486,19 +498,23 @@ helper.defaultsDialog = (function () {
             },
             {
                 key: "nav_fw_pos_z_p",
-                value: 15
+                value: 35
             },
             {
-                key: "nav_fw_pos_z_d",
+                key: "nav_fw_pos_z_i",
                 value: 5
             },
             {
+                key: "nav_fw_pos_z_d",
+                value: 10
+            },
+            {
                 key: "nav_fw_pos_xy_p",
-                value: 60
+                value: 70
             },
             {
                 key: "fw_turn_assist_pitch_gain",
-                value: 0.2
+                value: 0.3
             },
             {
                 key: "max_angle_inclination_rll",
@@ -563,6 +579,14 @@ helper.defaultsDialog = (function () {
             {
                 key: "imu_acc_ignore_slope",
                 value: 5
+            },
+            {
+                key: "imu_dcm_kp",
+                value: 1000
+            },
+            {
+                key: "imu_dcm_ki",
+                value: 0
             },
             {
                 key: "airmode_type",


### PR DESCRIPTION
Some Plane style related changes in inore rates, imu_dcm settings and althold PIDs to reduce AHI drift. 
Tested with community with all positive feedback

For release notes: 

If updating a fixed wing from INAV 3.0 or newer with setting transfer, please apply the following settings in the CLI based on Fixed wing type. 

FOR WINGS AND OTHER PLANES WITH NO TAIL:
set imu_acc_ignore_rate = 9
set imu_acc_ignore_slope = 5
set nav_fw_pos_z_p = 35
set nav_fw_pos_z_i = 5
set nav_fw_pos_z_d = 10
set nav_fw_pos_xy_p = 70
set imu_dcm_kp = 1000
set imu_dcm_ki = 0

FOR PLANES WITH A TAIL (DEDICATED ELEVATOR):
set imu_acc_ignore_rate = 7
set imu_acc_ignore_slope = 4
set nav_fw_pos_z_p = 25
set nav_fw_pos_z_i = 5
set nav_fw_pos_z_d = 7
set nav_fw_pos_xy_p = 55
set imu_dcm_kp = 1000
set imu_dcm_ki = 0