### PR TITLE
Change NAV POSHOLD mode text to NAV LOITER on fixed wing platforms

### DIFF
--- a/js/peripherals.js
+++ b/js/peripherals.js
@@ -16,11 +16,6 @@ function isPeripheralSelected(peripheralName) {
 function adjustBoxNameIfPeripheralWithModeID(modeId, defaultName) {
     if (isPeripheralSelected("RUNCAM_DEVICE_CONTROL")) {
         switch (modeId) {
-            case 11: // NAV POSHOLD
-                if (FC.isAirplane()) {
-                    return "LOITER";
-                }
-                break;
             case 39: // BOXCAMERA1
                 return "CAMERA WI-FI";
             case 40: // BOXCAMERA2
@@ -28,10 +23,15 @@ function adjustBoxNameIfPeripheralWithModeID(modeId, defaultName) {
             case 41: // BOXCAMERA3
                 return "CAMERA CHANGE MODE";
             default:
-                return defaultName;
+                break;
         }
-    } 
+    }
     
-    return defaultName;
-    
+    if (modeId === 11) {
+        if (FC.isAirplane()) {
+            return "NAV LOITER";
+        }
+    }
+
+    return defaultName;  
 }

--- a/js/peripherals.js
+++ b/js/peripherals.js
@@ -16,6 +16,11 @@ function isPeripheralSelected(peripheralName) {
 function adjustBoxNameIfPeripheralWithModeID(modeId, defaultName) {
     if (isPeripheralSelected("RUNCAM_DEVICE_CONTROL")) {
         switch (modeId) {
+            case 11: // NAV POSHOLD
+                if (FC.isAirplane()) {
+                    return "LOITER";
+                }
+                break;
             case 39: // BOXCAMERA1
                 return "CAMERA WI-FI";
             case 40: // BOXCAMERA2

--- a/tabs/auxiliary.js
+++ b/tabs/auxiliary.js
@@ -103,7 +103,9 @@ TABS.auxiliary.initialize = function (callback) {
         var modeTemplate = $('#tab-auxiliary-templates .mode');
         var newMode = modeTemplate.clone();
         var modeName = AUX_CONFIG[modeIndex];
-        // if user choose the runcam split at peripheral column, then adjust the boxname(BOXCAMERA1, BOXCAMERA2, BOXCAMERA3)
+        
+        // If the runcam split peripheral is used, then adjust the boxname(BOXCAMERA1, BOXCAMERA2, BOXCAMERA3)
+        // If platform is fixed wing, rename POS HOLD to LOITER
         modeName = adjustBoxNameIfPeripheralWithModeID(modeId, modeName);
  
         $(newMode).attr('id', 'mode-' + modeIndex);


### PR DESCRIPTION
This change comes as a result of hearing a lot of confusion from new pilots when setting up modes. Amongst the fixed wing community in general, position hold is referred to as loiter. In fact, everywhere else in inav, the settings for this mode on fixed wing are referred to as loiter too, For example, loiter direction, loiter change, and loiter radius. It makes sense to change the wording of the mode in the modes tab to loiter too. This does not effect anything as far as the navigation or functionality goes. It is a visual change only.

Fixed wing modes page example
![image](https://user-images.githubusercontent.com/17590174/184480665-c92741fc-3d87-4c5c-bce4-0b320c7c49fe.png)

The same FC switched to a multirotor, and fake compass added
![image](https://user-images.githubusercontent.com/17590174/184480719-49d41356-4fdb-4ce9-9737-249efa65253d.png)

### Release notes
On fixed wing platforms. On the modes page, the navigation mode `NAV POSHOLD` is now displayed as `NAV LOITER`. The functionality has not changed. Only the name for consistency.