### PR TITLE
Fixed and enhanced LC display

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -1249,7 +1249,7 @@ var FC = {
             4: {
                 name: "Logic Condition",
                 type: "range",
-                range: [0, 31],
+                range: [0, (LOGIC_CONDITIONS.getMaxLogicConditionCount()-1)],
                 default: 0
             },
             5: {

--- a/js/gui.js
+++ b/js/gui.js
@@ -304,13 +304,22 @@ GUI_control.prototype.renderLogicConditionSelect = function ($container, logicCo
 
     let $select = $container.append('<select class="mix-rule-condition">').find("select"),
         lcCount = logicConditions.getCount();
+        option  = "";
 
     if (withAlways) {
         $select.append('<option value="-1">Always</option>')
     }
     for (let i = 0; i < lcCount ; i++) {
-        if (!onlyEnabled || (logicConditions.isEnabled(i))) {
-            $select.append('<option value="' + i + '">Logic Condition ' + i + ' </option>');
+        if (!onlyEnabled || i === current || (logicConditions.isEnabled(i))) {
+            option = '<option';
+
+            if (i === current && !logicConditions.isEnabled(i)) {
+                option+= ' class="lc_disabled"';
+            }
+            
+            option+= ' value="' + i + '">Logic Condition ' + i + ' </option>';
+
+            $select.append(option);
         }
     }
 

--- a/js/gui.js
+++ b/js/gui.js
@@ -300,7 +300,7 @@ GUI_control.prototype.renderOperandValue = function ($container, operandMetadata
  * @param  {function} onChange
  * @param  {boolean} withAlways
  */
-GUI_control.prototype.renderLogicConditionSelect = function ($container, logicConditions, current, onChange, withAlways) {
+GUI_control.prototype.renderLogicConditionSelect = function ($container, logicConditions, current, onChange, withAlways, onlyEnabled) {
 
     let $select = $container.append('<select class="mix-rule-condition">').find("select"),
         lcCount = logicConditions.getCount();
@@ -309,7 +309,9 @@ GUI_control.prototype.renderLogicConditionSelect = function ($container, logicCo
         $select.append('<option value="-1">Always</option>')
     }
     for (let i = 0; i < lcCount ; i++) {
-        $select.append('<option value="' + i + '">Logic Condition ' + i + ' </option>');
+        if (!onlyEnabled || (logicConditions.isEnabled(i))) {
+            $select.append('<option value="' + i + '">Logic Condition ' + i + ' </option>');
+        }
     }
 
     $select.val(current).change(onChange);

--- a/js/logicCondition.js
+++ b/js/logicCondition.js
@@ -218,9 +218,10 @@ let LogicCondition = function (enabled, activatorId, operation, operandAType, op
         if (self.getEnabled()) {
             GUI.renderLogicConditionSelect(
                 $e, 
-                LOGIC_CONDITIONS, 
+                LOGIC_CONDITIONS,
                 self.getActivatorId, 
                 self.onActivatorChange,
+                true,
                 true
             );
         } else {

--- a/js/logicConditionsCollection.js
+++ b/js/logicConditionsCollection.js
@@ -28,6 +28,10 @@ let LogicConditionsCollection = function () {
         return data.length
     };
 
+    self.isEnabled = function (lcID) {
+        return data[lcID].getEnabled();
+    }
+
     self.open = function () {
         self.render();
         $container.show();

--- a/main.css
+++ b/main.css
@@ -2010,6 +2010,10 @@ select {
     padding: 1px;
 }
 
+.lc_disabled {
+    color: #aaa;
+}
+
 .ic_osd {
     background-image: url("../images/icons/icon_osd.svg");
     background-position-y: 4px;

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -295,6 +295,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
                     function () {
                         servoRule.setConditionId($(this).val());
                     },
+                    true,
                     true
                 );
 

--- a/tabs/programming.js
+++ b/tabs/programming.js
@@ -40,7 +40,6 @@ TABS.programming.initialize = function (callback, scrollPosition) {
     }
 
     function processHtml() {
-
         LOGIC_CONDITIONS.init($('#subtab-lc'));
         LOGIC_CONDITIONS.render();
 


### PR DESCRIPTION
Fixed an issue where only the first 32 logic conditions were showing as options for operands. This is now dynamic, based on the maximum number of logic conditions.

Fixes #1602 (fc.js:1252)

I also enhanced the display of the **Active** column of both **Programming** and **Mixer**. The select boxes will now only show Logic Conditions that are enabled.

![image](https://user-images.githubusercontent.com/17590174/184506806-631650d8-8073-497a-8e52-aa553e235a7a.png)

![image](https://user-images.githubusercontent.com/17590174/184506815-f443d09e-b8eb-4213-8472-e7d9323b08ad.png)

Logic Conditions that were selected and then later disabled are shown in grey
![image](https://user-images.githubusercontent.com/17590174/184508373-fe6a60b8-5967-49e3-88b1-54676386af22.png)
