### PR TITLE
Update presets for 6.0

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -457,6 +457,18 @@ helper.defaultsDialog = (function () {
                 value: "STANDARD"
             },
             {
+                key: "imu_acc_ignore_rate",
+                value: 15
+            },
+            {
+                key: "imu_acc_ignore_slope",
+                value: 10
+            },
+            {
+                key: "imu_inertia_comp_method",
+                value: ADAPTIVE
+            },
+            {
                 key: "throttle_idle",
                 value: 5.0
             },
@@ -666,6 +678,18 @@ helper.defaultsDialog = (function () {
             {
                 key: "motor_pwm_protocol",
                 value: "STANDARD"
+            },
+            {
+                key: "imu_acc_ignore_rate",
+                value: 15
+            },
+            {
+                key: "imu_acc_ignore_slope",
+                value: 10
+            },
+            {
+                key: "imu_inertia_comp_method",
+                value: ADAPTIVE
             },
             {
                 key: "throttle_idle",


### PR DESCRIPTION
Removed IMU settings as the new Firmware Defaults will match MR and FW. 
Added new YAW Default PIDs for better Turn-Assist control in nav modes with stab yaw used and more authority in acro. these Yaw Settings are tested in V-Tail and T-Tail planes (Talon GT, Ranger 1600, Ranger 2400, X-UAV Clouds and Esky Eagle) with no issues.