### PR TITLE
Fix issue with auto-select target on older firmware

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2125,8 +2125,7 @@
         "message": "No reboot sequence"
     },
     "firmwareFlasherOnlineSelectBoardDescription": {
-
-        "message": "Select your board to see available online firmware releases - Select the correct firmware appropriate for your board."
+        "message": "Select your board to see available online firmware releases - Select the correct firmware appropriate for your board. Please note that <strong>Auto-select Target</strong> will only work for INAV firmwares 5.0 and newer."
     },
     "firmwareFlasherOnlineSelectFirmwareVersionDescription": {
         "message": "Select firmware version for your board."

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -708,24 +708,21 @@ TABS.firmware_flasher.onOpen = function(openInfo) {
             MSP.send_message(MSPCodes.MSP_FC_VARIANT, false, false, function () {
                 if (CONFIG.flightControllerIdentifier == 'INAV') {
                     MSP.send_message(MSPCodes.MSP_FC_VERSION, false, false, function () {
-                        if (semver.gte(CONFIG.flightControllerVersion, CONFIGURATOR.minfirmwareVersionAccepted) && semver.lt(CONFIG.flightControllerVersion, CONFIGURATOR.maxFirmwareVersionAccepted)) {
-                            if (CONFIGURATOR.connection.type == ConnectionType.BLE && semver.lt(CONFIG.flightControllerVersion, "5.0.0")) {  
-                                onBleNotSupported();
-                            } else {
-                                mspHelper.getCraftName(function(name) {
-                                    if (name) {
-                                        CONFIG.name = name;
-                                    }
-                                    TABS.firmware_flasher.onValidFirmware();  
-                                });
-                            }
-                        } else  {
-                            onInvalidFirmwareVersion();
+                        if (semver.lt(CONFIG.flightControllerVersion, "5.0.0")) {
+                            GUI.log("Cannot prefetch target: INAV Firmware too old");
+                            TABS.firmware_flasher.closeTempConnection();
+                        } else {
+                            mspHelper.getCraftName(function(name) {
+                                if (name) {
+                                    CONFIG.name = name;
+                                }
+                                TABS.firmware_flasher.onValidFirmware();  
+                            });
                         }
                     });
                 } else {
                     GUI.log("Cannot prefetch target: Non-INAV Firmware");
-                    onInvalidFirmwareVariant();
+                    TABS.firmware_flasher.closeTempConnection();
                 }
             });
         });


### PR DESCRIPTION
A bug was found on 6.0 FP2 with the auto-select target feature. This fixes that issue.

[[Demo]](https://youtu.be/AEWEqWpaMso)