### PR TITLE
Change Reset Accelerometer Calibration button

### DIFF
--- a/src/css/tabs/calibration.css
+++ b/src/css/tabs/calibration.css
@@ -148,8 +148,8 @@
  }
 
  #calib_btn a.resetCalibration {
-    background-color: #860000;
-    color: #e4e4e4;
+    background-color: grey;
+    color: rgb(100, 100, 100);
  }
 
  #calib_btn a.resetCalibration:hover {

--- a/src/css/tabs/calibration.css
+++ b/src/css/tabs/calibration.css
@@ -149,7 +149,7 @@
 
  #calib_btn a.resetCalibration {
     background-color: grey;
-    color: rgb(100, 100, 100);
+    color: rgb(212, 212, 212);
  }
 
  #calib_btn a.resetCalibration:hover {


### PR DESCRIPTION
Folks didn't like the red button. They thought there was an error with the calibration. So I have changed the button to a subtle grey. Hovering changes red as a warning still.

![image](https://user-images.githubusercontent.com/17590174/202254696-e6121351-a8b0-4567-b22d-f1728ce884b8.png)
