### PR TITLE
Add a BF4.3 Compatible restricted OSD implementation.

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -538,25 +538,29 @@ OSD.constants = {
         'PAL',
         'NTSC',
         'HDZERO',
-        'DJIWTF'
+        'DJIWTF',
+        'BF43COMPAT'
     ],
     VIDEO_LINES: {
         PAL: 16,
         NTSC: 13,
         HDZERO: 18,
-        DJIWTF: 22
+        DJIWTF: 22,
+        BF43COMPAT: 16,
     },
     VIDEO_COLS: {
         PAL: 30,
         NTSC: 30,
         HDZERO: 50,
-        DJIWTF: 60
+        DJIWTF: 60,
+        BF43COMPAT: 30
     },
     VIDEO_BUFFER_CHARS: {
         PAL: 480,
         NTSC: 390,
         HDZERO: 900,
-        DJIWTF: 1320
+        DJIWTF: 1320,
+        BF43COMPAT: 480
     },
     UNIT_TYPES: [
         {name: 'osdUnitImperial', value: 0},
@@ -2388,7 +2392,7 @@ OSD.GUI.checkAndProcessSymbolPosition = function(pos, charCode) {
     }
 };
 
-const mspVideoSystem = [1,3,4];     // indexes of PAL, HDZERO, & DJIWTF
+const mspVideoSystem = [1,3,4,5];     // indexes of PAL, HDZERO, & DJIWTF
 const analogVideoSystem = [0,1,2];  // indexes of AUTO, PAL, & NTSC
 
 OSD.GUI.updateVideoMode = function() {

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -2392,7 +2392,7 @@ OSD.GUI.checkAndProcessSymbolPosition = function(pos, charCode) {
     }
 };
 
-const mspVideoSystem = [1,3,4,5];     // indexes of PAL, HDZERO, & DJIWTF
+const mspVideoSystem = [1,3,4,5];   // indexes of PAL, HDZERO, DJIWTF, & BF43COMPAT
 const analogVideoSystem = [0,1,2];  // indexes of AUTO, PAL, & NTSC
 
 OSD.GUI.updateVideoMode = function() {


### PR DESCRIPTION
This is the configurator side of InavFlight/inav#8631

This will add BF43COMPAT as an MSP Displayport option in the OSD tab.

Canvas size will be the same as PAL.