### PR TITLE
Allow default baud rates on ports page

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1167,7 +1167,7 @@
         "message": "DJI FPV VTX"
     },
     "portsFunction_MSP_DISPLAYPORT": {
-        "message": "MSP Displayport"
+        "message": "MSP DisplayPort"
     },
     "pidTuning_ShowAllPIDs": {
         "message": "Show all PIDs"

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -807,7 +807,7 @@ var mspHelper = (function (gui) {
                         msp_baudrate: BAUD_RATES[data.getUint8(offset + 5)],
                         sensors_baudrate: BAUD_RATES[data.getUint8(offset + 6)],
                         telemetry_baudrate: BAUD_RATES[data.getUint8(offset + 7)],
-                        blackbox_baudrate: BAUD_RATES[data.getUint8(offset + 8)]
+                        peripherals_baudrate: BAUD_RATES[data.getUint8(offset + 8)]
                     };
 
                     offset += bytesPerPort;
@@ -1782,7 +1782,7 @@ var mspHelper = (function (gui) {
                     buffer.push(BAUD_RATES.indexOf(serialPort.msp_baudrate));
                     buffer.push(BAUD_RATES.indexOf(serialPort.sensors_baudrate));
                     buffer.push(BAUD_RATES.indexOf(serialPort.telemetry_baudrate));
-                    buffer.push(BAUD_RATES.indexOf(serialPort.blackbox_baudrate));
+                    buffer.push(BAUD_RATES.indexOf(serialPort.peripherals_baudrate));
                 }
                 break;
 

--- a/tabs/ports.html
+++ b/tabs/ports.html
@@ -49,14 +49,14 @@
                 <td class="functionsCell-data"><select class="msp_baudrate">
                         <!-- list generated here -->
                 </select></td>
-                <td class="functionsCell-telemetry"><select class="telemetry_baudrate">
+                <td class="functionsCell-telemetry"><select class="telemetry_baudrate"">
                         <!-- list generated here -->
                 </select></td>
                 <td class="functionsCell-rx"></td>
                 <td class="functionsCell-sensors"><select class="sensors_baudrate">
                         <!-- list generated here -->
                 </select></td>
-                <td class="functionsCell-peripherals"><select class="blackbox_baudrate">
+                <td class="functionsCell-peripherals"><select class="peripherals_baudrate">
                         <!-- list generated here -->
                 </select></td>
             </tr>

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -2,11 +2,17 @@
 
 TABS.ports = {};
 
+var portFunctionRules;
+
 TABS.ports.initialize = function (callback) {
 
-    var functionRules = [
+    /*  ** portFunctionRules Notes **
+        Do not set a defaultBaud for functions in the telemetry group. 
+        These should default to AUTO, which is handled in the onchange function. The baud rate is then set by the firmware.
+    */
+    portFunctionRules = [
          {name: 'MSP',                  groups: ['data', 'msp'], maxPorts: 2},
-         {name: 'GPS',                  groups: ['sensors'], maxPorts: 1},
+         {name: 'GPS',                  groups: ['sensors'], maxPorts: 1, defaultBaud: 115200},
          {name: 'TELEMETRY_FRSKY',      groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1},
          {name: 'TELEMETRY_HOTT',       groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1},
          {name: 'TELEMETRY_SMARTPORT',  groups: ['telemetry'], maxPorts: 1},
@@ -15,7 +21,7 @@ TABS.ports.initialize = function (callback) {
          {name: 'BLACKBOX',             groups: ['peripherals'], sharableWith: ['msp'], notSharableWith: ['telemetry'], maxPorts: 1}
     ];
 
-    functionRules.push({
+    portFunctionRules.push({
         name: 'TELEMETRY_MAVLINK',
         groups: ['telemetry'],
         sharableWith: ['msp'],
@@ -26,7 +32,7 @@ TABS.ports.initialize = function (callback) {
     /*
      * Support for FlySky iBus Telemetry
      */
-    functionRules.push({
+    portFunctionRules.push({
         name: 'TELEMETRY_IBUS',
         groups: ['telemetry'],
         sharableWith: ['msp'],
@@ -34,79 +40,83 @@ TABS.ports.initialize = function (callback) {
         maxPorts: 1
     });
 
-    functionRules.push({
+    portFunctionRules.push({
         name: 'RANGEFINDER',
         groups: ['sensors'],
         maxPorts: 1 }
     );
 
-    functionRules.push({
+    portFunctionRules.push({
         name: 'GSM_SMS',
         groups: ['telemetry'],
         maxPorts: 1 }
     );
 
     // support configure RunCam Device
-    functionRules.push({
+    portFunctionRules.push({
         name: 'RUNCAM_DEVICE_CONTROL',
         groups: ['peripherals'],
         maxPorts: 1 }
     );
 
-    functionRules.push({
+    portFunctionRules.push({
         name: 'TBS_SMARTAUDIO',
         groups: ['peripherals'],
         maxPorts: 1 }
     );
-    functionRules.push({
+    portFunctionRules.push({
         name: 'IRC_TRAMP',
         groups: ['peripherals'],
         maxPorts: 1 }
     );
-    functionRules.push({
+    portFunctionRules.push({
         name: 'VTX_FFPV',
         groups: ['peripherals'],
         maxPorts: 1 }
     );
 
-    functionRules.push({
+    portFunctionRules.push({
         name: 'OPFLOW',
         groups: ['sensors'],
         maxPorts: 1 }
     );
 
-    functionRules.push({
+    portFunctionRules.push({
         name: 'ESC',
         groups: ['peripherals'],
-        maxPorts: 1 }
+        maxPorts: 1,
+        defaultBaud: 115200 }
     );
 
-    functionRules.push({
+    portFunctionRules.push({
         name: 'FRSKY_OSD',
         groups: ['peripherals'],
-        maxPorts: 1 }
+        maxPorts: 1,
+        defaultBaud: 250000 }
     );
 
-    functionRules.push({
+    portFunctionRules.push({
         name: 'DJI_FPV',
         groups: ['peripherals'],
-        maxPorts: 1 }
+        maxPorts: 1,
+        defaultBaud: 115200 }
     );
 
-    functionRules.push({
+    portFunctionRules.push({
         name: 'MSP_DISPLAYPORT',
         groups: ['peripherals'],
         maxPorts: 1 }
     );
 
-    functionRules.push({
+    portFunctionRules.push({
         name: 'SMARTPORT_MASTER',
         groups: ['peripherals'],
-        maxPorts: 1 }
+        maxPorts: 1,
+        defaultBaud: 57600 }
     );
 
-    for (var i = 0; i < functionRules.length; i++) {
-        functionRules[i].displayName = chrome.i18n.getMessage('portsFunction_' + functionRules[i].name);
+    for (var i = 0; i < portFunctionRules.length; i++) {
+        portFunctionRules[i].displayName = chrome.i18n.getMessage('portsFunction_' + portFunctionRules[i].name);
     }
 
     var mspBaudRates = [
@@ -137,7 +147,7 @@ TABS.ports.initialize = function (callback) {
         '115200'
     ];
 
-    var blackboxBaudRates = [
+    var peripheralsBaudRates = [
         '19200',
         '38400',
         '57600',
@@ -199,9 +209,9 @@ TABS.ports.initialize = function (callback) {
             $elements.append('<option value="' + telemetryBaudRates_post1_6_3[i] + '">' + telemetryBaudRates_post1_6_3[i] + '</option>');
         }
 
-        $elements = $('select.blackbox_baudrate');
-        for (i = 0; i < blackboxBaudRates.length; i++) {
-            $elements.append('<option value="' + blackboxBaudRates[i] + '">' + blackboxBaudRates[i] + '</option>');
+        $elements = $('select.peripherals_baudrate');
+        for (i = 0; i < peripheralsBaudRates.length; i++) {
+            $elements.append('<option value="' + peripheralsBaudRates[i] + '">' + peripheralsBaudRates[i] + '</option>');
         }
 
         var ports_e = $('.tab-ports .ports');
@@ -216,7 +226,7 @@ TABS.ports.initialize = function (callback) {
             port_configuration_e.find('select.msp_baudrate').val(serialPort.msp_baudrate);
             port_configuration_e.find('select.telemetry_baudrate').val(serialPort.telemetry_baudrate);
             port_configuration_e.find('select.sensors_baudrate').val(serialPort.sensors_baudrate);
-            port_configuration_e.find('select.blackbox_baudrate').val(serialPort.blackbox_baudrate);
+            port_configuration_e.find('select.peripherals_baudrate').val(serialPort.peripherals_baudrate);
 
             port_configuration_e.find('.identifier').text(portIdentifierToNameMapping[serialPort.identifier]);
 
@@ -228,9 +238,11 @@ TABS.ports.initialize = function (callback) {
                 var column = columns[columnIndex];
 
                 var functions_e = $(port_configuration_e).find('.functionsCell-' + column);
+                let functions_e_id = "portFunc-" + column + "-" + portIndex;
+                functions_e.attr("id", functions_e_id);
 
-                for (i = 0; i < functionRules.length; i++) {
-                    var functionRule = functionRules[i];
+                for (i = 0; i < portFunctionRules.length; i++) {
+                    var functionRule = portFunctionRules[i];
                     var functionName = functionRule.name;
 
                     if (functionRule.groups.indexOf(column) == -1) {
@@ -254,7 +266,7 @@ TABS.ports.initialize = function (callback) {
                         select_e = functions_e.find(selectElementSelector);
 
                         if (select_e.size() == 0) {
-                            functions_e.prepend('<span class="function"><select name="' + selectElementName + '" /></span>');
+                            functions_e.prepend('<span class="function"><select name="' + selectElementName + '" class="' + selectElementName + '" onchange="updateDefaultBaud(\'' + functions_e_id + '\', \'' + column + '\')" /></span>');
                             select_e = functions_e.find(selectElementSelector);
                             var disabledText = chrome.i18n.getMessage('portsTelemetryDisabled');
                             select_e.append('<option value="">' + disabledText + '</option>');
@@ -322,7 +334,7 @@ TABS.ports.initialize = function (callback) {
                 msp_baudrate: $(portConfiguration_e).find('.msp_baudrate').val(),
                 telemetry_baudrate: $(portConfiguration_e).find('.telemetry_baudrate').val(),
                 sensors_baudrate: $(portConfiguration_e).find('.sensors_baudrate').val(),
-                blackbox_baudrate: $(portConfiguration_e).find('.blackbox_baudrate').val(),
+                peripherals_baudrate: $(portConfiguration_e).find('.peripherals_baudrate').val(),
                 identifier: oldSerialPort.identifier
             };
             SERIAL_CONFIG.ports.push(serialPort);
@@ -348,6 +360,23 @@ TABS.ports.initialize = function (callback) {
         }
     }
 };
+
+function updateDefaultBaud(baudSelect, column) {
+    let section = $("#" + baudSelect);
+    let portName = section.find('.function-' + column).val();
+    let baudRate = (column === 'telemetry') ? "AUTO" : 115200;;
+
+    for (i = 0; i < portFunctionRules.length; i++) {
+        if (portFunctionRules[i].name === portName) {
+            if (typeof portFunctionRules[i].defaultBaud !== 'undefined') {
+                baudRate = portFunctionRules[i].defaultBaud;
+            }
+            break;
+        }
+    }
+
+    section.find("." + column + "_baudrate").children('[value=' + baudRate + ']').prop('selected', true);
+}
 
 TABS.ports.cleanup = function (callback) {
     if (callback) callback();


### PR DESCRIPTION
This PR allows default baud rates to be set, per function, on the ports page. For example, SmartPort should run at 57600 baud. But, when the option is selected currently, the baud rate stays at 115200. This PR corrects that. Each function can have a default baud rate set. When the function is selected, it will automatically set the baud rate to it's default. The user still has the power to change this baud rate. **Telemetry** is left on AUTO, as these are defined in the firmware. However **sensors** and **peripherals** have no AUTO option. So a default baud will help in their setup.

[Demo](https://youtu.be/QMxG58s6yrE)