### PR TITLE
CLI usability enhancements

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1949,7 +1949,7 @@
         "message": "Clear Screen"
     },
     "cliCopyToClipboardBtn": {
-        "message": "Copy to clipboard"
+        "message": "Copy to Clipboard"
     },
     "cliExitBtn": {
         "message": "Exit"
@@ -1970,7 +1970,7 @@
         "message": "Copied!"
     },
     "cliLoadFromFileBtn": {
-        "message": "Load from file"
+        "message": "Load from File"
     },
     "cliConfirmSnippetDialogTitle": {
         "message": "Review loaded commands"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1946,19 +1946,25 @@
         "message": "CLI output successfully saved to file"
     },
     "cliClearOutputHistoryBtn": {
-        "message": "Clear output history"
+        "message": "Clear Screen"
     },
     "cliCopyToClipboardBtn": {
         "message": "Copy to clipboard"
     },
     "cliExitBtn": {
-        "message": "EXIT"
+        "message": "Exit"
     },
     "cliSaveSettingsBtn": {
-        "message": "SAVE SETTINGS"
+        "message": "Save Settings"
     },
     "cliMscBtn": {
         "message": "MSC"
+    },
+    "cliDiffAllBtn": {
+        "message": "Diff All"
+    },
+    "cliCommandsHelp": {
+        "message": "Type or paste commands in the box to the left. You can use the up and down arrow keys to recall previously typed commands. Type 'help' or click on this icon for more info."
     },
     "cliCopySuccessful": {
         "message": "Copied!"

--- a/tabs/cli.html
+++ b/tabs/cli.html
@@ -11,7 +11,12 @@
                 <div class="wrapper"></div>
             </div>
         </div>
-        <textarea name="commands" i18n_placeholder="cliInputPlaceholder" rows="1" cols="0"></textarea>
+        <div style="display:flex;align-items:center;justify-content:center;">
+            <textarea name="commands" i18n_placeholder="cliInputPlaceholder" rows="1" cols="0"></textarea>
+            <a class="helpiconLink" style="margin-left:5px;margin-right:5px;" href="https://github.com/iNavFlight/inav/blob/master/docs/Cli.md" target="_blank">
+                <div class="helpicon cf_tip" style="float:none;" data-i18n_title="cliCommandsHelp"></div>
+            </a>            
+        </div>
     </div>
     <div class="content_toolbar">
         <div class="btn save_btn" style="float: left; padding-left: 15px">
@@ -22,8 +27,9 @@
         <div class="btn save_btn pull-right">
             <a class="save" href="#" i18n="cliSaveToFileBtn"></a>
             <a class="load" href="#" i18n="cliLoadFromFileBtn"></a>
-            <a class="clear" href="#" i18n="cliClearOutputHistoryBtn"></a>
-            <a class="copy" href="#" i18n="cliCopyToClipboardBtn"></a>
+            <a class="copy" href="#" i18n="cliCopyToClipboardBtn"></a>            
+            <a class="clear" href="#" i18n="cliClearOutputHistoryBtn"></a>     
+            <a class="diffall" href="#" i18n="cliDiffAllBtn"></a>  
         </div>
     </div>
 

--- a/tabs/cli.html
+++ b/tabs/cli.html
@@ -11,7 +11,7 @@
                 <div class="wrapper"></div>
             </div>
         </div>
-        <div style="display:flex;align-items:center;justify-content:center;">
+        <div style="display:flex;align-items:center;">
             <textarea name="commands" i18n_placeholder="cliInputPlaceholder" rows="1" cols="0"></textarea>
             <a class="helpiconLink" style="margin-left:5px;margin-right:5px;" href="https://github.com/iNavFlight/inav/blob/master/docs/Cli.md" target="_blank">
                 <div class="helpicon cf_tip" style="float:none;" data-i18n_title="cliCommandsHelp"></div>

--- a/tabs/cli.js
+++ b/tabs/cli.js
@@ -191,6 +191,12 @@ TABS.cli.initialize = function (callback) {
             self.send(getCliCommand('msc\n', TABS.cli.cliBuffer));
         });
 
+        $('.tab-cli .diffall').click(function() {
+            self.outputHistory = "";
+            $('.tab-cli .window .wrapper').empty();
+            self.send(getCliCommand('diff all\n', TABS.cli.cliBuffer));
+        });
+
         $('.tab-cli .clear').click(function() {
             self.outputHistory = "";
             $('.tab-cli .window .wrapper').empty();
@@ -276,7 +282,7 @@ TABS.cli.initialize = function (callback) {
                 var out_string = textarea.val();
                 self.history.add(out_string.trim());
 
-                if (out_string.trim().toLowerCase() == "cls") {
+                if (out_string.trim().toLowerCase() == "cls" || out_string.trim().toLowerCase() == "clear") {
                     self.outputHistory = "";
                     $('.tab-cli .window .wrapper').empty();
                 } else {


### PR DESCRIPTION
![cli](https://user-images.githubusercontent.com/100724300/209750977-179a1d95-bc0f-43ff-b302-866089875272.png)

- Added a dedicated button for 'diff all'.

- Added help icon with verbiage in messages.json and hyperlink to CLI.md in the Github docs.

- Cleaned up the casing on 'Exit', 'Save Settings', 'Copy to Clipboard' and 'Load from File' buttons for consistency.

- Changed button to clear the output history to read 'Clear Screen' to save a little room on the screen which helps a little when the window is narrowed, but also because I think that's better phrasing for most people.

- Added the ability to type the command 'clear' in addition to 'cls' to clear the output history.