### PR TITLE
Make links to documents relevant to firmware version

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1933,6 +1933,9 @@
     "cliReboot": {
         "message": "CLI reboot detected"
     },
+    "cliDocsBtn": {
+        "message": "CLI Command Docs"
+    },
     "cliSaveToFileBtn": {
         "message": "Save to File"
     },

--- a/js/settings.js
+++ b/js/settings.js
@@ -672,7 +672,7 @@ var Settings = (function () {
                 }
 
                 if (typeof dataSettingName !== "undefined" && dataSettingName !== "") {
-                    helpIcon.wrap('<a class="helpiconLink" href="https://github.com/iNavFlight/inav/blob/master/docs/Settings.md#' + dataSettingName + '" target="_blank"></a>');
+                    helpIcon.wrap('<a class="helpiconLink" href="' + globalSettings.docsTreeLocation + 'Settings.md#' + dataSettingName + '" target="_blank"></a>');
                 }
             }
 

--- a/main.js
+++ b/main.js
@@ -24,12 +24,16 @@ let globalSettings = {
     // Used to depict how the units are displayed within the UI
     unitType: null,
     // Used to convert units within the UI
-    osdUnits: null,    
+    osdUnits: null,
+    // Map  
     mapProviderType: null,
     mapApiKey: null,
     proxyURL: null,
     proxyLayer: null,
+    // Show colours for profiles
     showProfileParameters: null,
+    // tree target for documents
+    docsTreeLocation: 'master',
 };
 
 $(document).ready(function () {
@@ -673,7 +677,21 @@ function updateActivatedTab() {
 function updateFirmwareVersion() {
     if (CONFIGURATOR.connectionValid) {
         $('#logo .firmware_version').text(CONFIG.flightControllerVersion + " [" + CONFIG.target + "]");
+        globalSettings.docsTreeLocation = 'https://github.com/iNavFlight/inav/blob/' + CONFIG.flightControllerVersion + '/docs/';
+
+        // If this is a master branch firmware, this will find a 404 as there is no tag tree. So default to master for docs.
+        $.ajax({
+            url : globalSettings.docsTreeLocation + 'Settings.md',
+            method: "HEAD",
+            statusCode: {
+                404: function() {
+                    globalSettings.docsTreeLocation = 'https://github.com/iNavFlight/inav/blob/master/docs/';
+                }
+            }
+        });
     } else {
         $('#logo .firmware_version').text(chrome.i18n.getMessage('fcNotConnected'));
+        
+        globalSettings.docsTreeLocation = 'https://github.com/iNavFlight/inav/blob/master/docs/';
     }
 }

--- a/tabs/cli.html
+++ b/tabs/cli.html
@@ -20,6 +20,7 @@
             <a class="exit" href="#" i18n="cliExitBtn"></a>
         </div>
         <div class="btn save_btn pull-right">
+            <a class="cliDocsBtn" href="#" i18n="cliDocsBtn" target="_blank"></a>
             <a class="save" href="#" i18n="cliSaveToFileBtn"></a>
             <a class="load" href="#" i18n="cliLoadFromFileBtn"></a>
             <a class="clear" href="#" i18n="cliClearOutputHistoryBtn"></a>

--- a/tabs/cli.js
+++ b/tabs/cli.js
@@ -146,6 +146,8 @@ TABS.cli.initialize = function (callback) {
         // translate to user-selected language
         localize();
 
+        $('.cliDocsBtn').attr('href', globalSettings.docsTreeLocation + 'Settings.md');
+
         CONFIGURATOR.cliActive = true;
 
         var textarea = $('.tab-cli textarea[name="commands"]');


### PR DESCRIPTION
This PR improves on the current links to documents. Specifically the **?** links which go to the specific setting in `settings.md`. Currently, this just links to the document in the master branch. However, as things change, get added, or removed; it would be better to link to the document in the correct tree location for that version. This PR does that. I have also added a button on the CLI page to link to settings.md too.

This method can be used to link to any document on the firmware repo, using the correct firmware version. All you need to do is link to `globalSettings.docsTreeLocation + "Settings.md"` for example.

[DEMO](https://youtu.be/hrb8HtneBOY)