### PR TITLE
Add AUTO detect to modes page

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1486,7 +1486,7 @@
     "auxiliaryHelp": {
         "message": "Use ranges to define the switches on your transmitter and corresponding mode assignments.  A receiver channel that gives a reading between a range min/max will activate the mode.  Remember to save your settings using the Save button."
     },
-	    "auxiliaryToggleUnused": {
+	"auxiliaryToggleUnused": {
         "message": "Hide unused modes"
     },
     "auxiliaryMin": {
@@ -1497,6 +1497,9 @@
     },
     "auxiliaryAddRange": {
         "message": "Add Range"
+    },
+    "auxiliaryAutoChannelSelect" : {
+        "message": "AUTO"
     },
     "auxiliaryButtonSave": {
         "message": "Save"


### PR DESCRIPTION
This adds the very useful AUTO detection of the switches to the range. This is pulled from BetaFlight, where it has proven very useful.

To select the switch for the range, set the channel to AUTO, then move the switch.

Fixes #1194 

[DEMO](https://youtu.be/l9OGl_3sfUg)