### PR TITLE
Mission Control: Bug fixes related to P3 field

### DIFF
--- a/js/waypointCollection.js
+++ b/js/waypointCollection.js
@@ -360,7 +360,8 @@ let WaypointCollection = function () {
                 }
                 altPoint2measure.push(self.getWaypoint(nStart).getAlt());
                 namePoint2measure.push(self.getWaypoint(nStart).getLayerNumber()+1);
-                refPoint2measure.push(self.getWaypoint(nStart).getP3());
+                let useAbsoluteAlt = (self.getWaypoint(nStart).getP3() & (1 << 0));
+                refPoint2measure.push(useAbsoluteAlt);
                 nStart++;
             }
             else if (self.getWaypoint(nStart).getAction() == MWNP.WPTYPE.JUMP) {

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2123,12 +2123,13 @@ TABS.mission_control.initialize = function (callback) {
                 }
 
                 P3Value = TABS.mission_control.setBit(P3Value, MWNP.P3.ALT_TYPE, $('#pointP3Alt').prop("checked"));
-                selectedMarker.setP3(P3Value);
                 (async () => {
                     const elevationAtWP = await selectedMarker.getElevation(globalSettings);
                     $('#elevationValueAtWP').text(elevationAtWP);
                     var altitude = Number($('#pointAlt').val());
                     if (P3Value != selectedMarker.getP3()) {
+                        selectedMarker.setP3(P3Value);
+                        
                         if ($('#pointP3Alt').prop("checked")) {
                             if (altitude < 0) {
                                 altitude = settings.alt;

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2811,13 +2811,14 @@ TABS.mission_control.initialize = function (callback) {
     }
 
     /* resetAltitude = true : For selected WPs only. Changes WP Altitude value back to previous value if setting below ground level.
-     ^ resetAltitude = false : changes WP Altitude to value required to give ground clearance = default Altitude setting */
-    function checkAltElevSanity(resetAltitude, checkAltitude, elevation, P3Datum) {
+     ^ resetAltitude = false : changes WP Altitude to value required to give ground clearance = default Altitude setting
+     ^ AbsAltCheck : check value for whether or not to use absolute altitude. This can be the P3 bitset or excplicitly set to true or false */
+    function checkAltElevSanity(resetAltitude, checkAltitude, elevation, AbsAltCheck) {
         let groundClearance = "NO HOME";
         let altitude = checkAltitude;
-        let altUsingAbsolute = (typeof P3Datum == "boolean") ? P3Datum : TABS.mission_control.isBitSet(P3Datum, MWNP.P3.ALT_TYPE);
+        AbsAltCheck = (typeof AbsAltCheck == "boolean") ? AbsAltCheck : TABS.mission_control.isBitSet(AbsAltCheck, MWNP.P3.ALT_TYPE);
 
-        if (altUsingAbsolute) {
+        if (AbsAltCheck) {
             if (checkAltitude < 100 * elevation) {
                 if (resetAltitude) {
                     alert(chrome.i18n.getMessage('MissionPlannerAltitudeChangeReset'));

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -54,7 +54,6 @@ var dictOfLabelParameterPoint = {
 };
 
 var waypointOptions = ['JUMP','SET_HEAD','RTH'];
-var initParam3 = 0;
 
 ////////////////////////////////////
 //
@@ -1818,14 +1817,12 @@ TABS.mission_control.initialize = function (callback) {
                 selectedFeature.setStyle(getWaypointIcon(selectedMarker, true));
 
                 let P3Value = selectedMarker.getP3();
-                initParam3 = 0; // Reset init bits for P3 before setting up checkboxes
 
                 changeSwitchery($('#pointP3Alt'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.ALT_TYPE));
                 changeSwitchery($('#pointP3UserAction1'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_1));
                 changeSwitchery($('#pointP3UserAction2'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_2));
                 changeSwitchery($('#pointP3UserAction3'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_3));
                 changeSwitchery($('#pointP3UserAction4'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_4));
-                initParam3 = 31; // Set all bits for above P3 params to true, after setting checkboxes
 
                 var altitudeMeters = app.ConvertCentimetersToMeters(selectedMarker.getAlt());
 
@@ -2951,12 +2948,7 @@ TABS.mission_control.isBitSet = function(bits, testBit) {
 }
 
 TABS.mission_control.setBit = function(bits, bit, value) {
-    if ((initParam3 & (1 << bit)) != 0) {
-        value = value ? 1 : 0;
-        bits &= ~(1 << bit);
-        bits |= (value << bit);
-    }
-    return bits;
+    return value ? bits |= (1 << bit) : bits &= ~(1 << bit);
 }
 
 // window.addEventListener("error", handleError, true);


### PR DESCRIPTION
Fixes #1721 

- Added const to make bitfield stuff more readable
- changed `checkAltElevationSanity()` as it was treating P3 as a Boolean. Some times this function was called with explicitly not using absolute altitude. This is still possible. The function can accept a Boolean _or_ the P3 bitfield.
- Fixed issue where alt and user action checkboxes could not be unset.
- Added **.mission** filter to the load mission from file dialog box.