### PR TITLE
Fixed mixer config issues

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -1202,19 +1202,26 @@ helper.defaultsDialog = (function () {
 
                     helper.mixer.loadServoRules(currentMixerPreset);
                     helper.mixer.loadMotorRules(currentMixerPreset);
+                    
+                    MIXER_CONFIG.platformType = currentMixerPreset.platform;
+                    MIXER_CONFIG.appliedMixerPreset = selectedDefaultPreset.mixerToApply;
+                    MIXER_CONFIG.hasFlaps = (currentMixerPreset.hasFlaps === true) ? true : false;
 
                     SERVO_RULES.cleanup();
                     SERVO_RULES.inflate();
                     MOTOR_RULES.cleanup();
                     MOTOR_RULES.inflate();
 
-                    mspHelper.sendServoMixer(function () {
-                        mspHelper.sendMotorMixer(function () {
-                            MSP.send_message(MSPCodes.MSP_SELECT_SETTING, [currentControlProfile], false, function() {
-                                MSP.send_message(MSPCodes.MSP2_INAV_SELECT_BATTERY_PROFILE, [currentBatteryProfile], false, privateScope.finalize(selectedDefaultPreset));
+                    mspHelper.saveMixerConfig(function() {
+                        mspHelper.sendServoMixer(function () {
+                            mspHelper.sendMotorMixer(function () {
+                                MSP.send_message(MSPCodes.MSP_SELECT_SETTING, [currentControlProfile], false, function() {
+                                    MSP.send_message(MSPCodes.MSP2_INAV_SELECT_BATTERY_PROFILE, [currentBatteryProfile], false, privateScope.finalize(selectedDefaultPreset));
+                                });
                             });
                         });
                     });
+                    
                 } else {
                     MSP.send_message(MSPCodes.MSP_SELECT_SETTING, [currentControlProfile], false, function() {
                         MSP.send_message(MSPCodes.MSP2_INAV_SELECT_BATTERY_PROFILE, [currentBatteryProfile], false, privateScope.finalize(selectedDefaultPreset));

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -628,6 +628,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
             loadedMixerPresetID = currentMixerPreset.id;
             helper.mixer.loadServoRules(currentMixerPreset);
             helper.mixer.loadMotorRules(currentMixerPreset);
+            MIXER_CONFIG.hasFlaps = (currentMixerPreset.hasFlaps === true) ? true : false;
             renderServoMixRules();
             renderMotorMixRules();
             renderOutputMapping();


### PR DESCRIPTION
1. When save and reboot was applied on the mixer page, the has flaps option was not saved.
2. When defaults were selected, the auto-mixer application did not take mixer config in to account.