### PR TITLE
Fix BFHDCOMPAT dragging of elements inside warning boxes

### DIFF
--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -565,6 +565,7 @@ button {
     bottom: 0px;
     left: 450px;
     right: 0px;
+    pointer-events: none;
 }
 
 .tab-osd .hd_bfhdcompat_storagebox {
@@ -574,6 +575,7 @@ button {
     height: 55px;
     right: 0px;
     width: 80px;
+    pointer-events: none;
 }
 
 .tab-osd .hd_avatar_bottom {


### PR DESCRIPTION
The preview includes boxes to mark areas where native OSD elements usually live.

This fix allows the user to drag elements out of those boxes without setting "Show preview guides" off or switching to another HD system type.

![image](https://user-images.githubusercontent.com/23555060/228777335-528611fc-85b2-42ff-8283-0e4a73b8c30b.png)
