### PR TITLE
Add i18n to the LED_strip Tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -161,7 +161,7 @@
     "connectionBleType": {
         "message": "BLE device type: $1"
     },
-    "connectionBleNotSupported" : {
+    "connectionBleNotSupported": {
         "message": "<span style=\"color: red\">Connection error:</span> Firmware doesn't support BLE connections. Abort."
     },
     "connectionBleInterrupted": {
@@ -761,7 +761,7 @@
     "serialrx_inverted": {
         "message": "Serial Port Inverted (comparing to protocol default)"
     },
-    "serialrx_halfduplex" : {
+    "serialrx_halfduplex": {
         "message": "Serial receiver half-duplex"
     },
     "configurationFeaturesHelp": {
@@ -1010,7 +1010,7 @@
     "configurationGPSProtocol": {
         "message": "Protocol"
     },
-     "configurationGPSUseGalileo": {
+    "configurationGPSUseGalileo": {
         "message": "Gps use Galileo Satellites"
     },
     "tzOffset": {
@@ -1179,7 +1179,7 @@
         "message": "Reset PID Controller"
     },
     "pidTuning_PIDgains": {
-        "message" :"PID gains"
+        "message": "PID gains"
     },
     "pidTuning_Name": {
         "message": "Name"
@@ -1244,7 +1244,7 @@
     "pidTuning_RollAndPitchExpo": {
         "message": "Roll & Pitch Expo"
     },
-    "pidTuning_YawExpo" : {
+    "pidTuning_YawExpo": {
         "message": "Yaw Expo"
     },
     "pidTuning_MaxRollAngle": {
@@ -1510,7 +1510,7 @@
     "auxiliaryHelp": {
         "message": "Use ranges to define the switches on your transmitter and corresponding mode assignments.  A receiver channel that gives a reading between a range min/max will activate the mode.  Remember to save your settings using the Save button."
     },
-	"auxiliaryToggleUnused": {
+    "auxiliaryToggleUnused": {
         "message": "Hide unused modes"
     },
     "auxiliaryMin": {
@@ -1522,7 +1522,7 @@
     "auxiliaryAddRange": {
         "message": "Add Range"
     },
-    "auxiliaryAutoChannelSelect" : {
+    "auxiliaryAutoChannelSelect": {
         "message": "AUTO"
     },
     "auxiliaryButtonSave": {
@@ -1586,7 +1586,7 @@
     "adjustmentsGroupPIDTuning": {
         "message": "PID Tuning"
     },
-    "adjustmentsGroupNavigationFlight" : {
+    "adjustmentsGroupNavigationFlight": {
         "message": "Navigation and Flight"
     },
     "adjustmentsGroupMisc": {
@@ -1827,7 +1827,7 @@
         "message": "Mixer wizard"
     },
     "mixerWizardInfo": {
-        "message":"<ol><li>Remove propellers</li><li>Connect LiPo and use Outputs Tab to test all motors</li><li>Note the position of each motor (motor #1 - Left Top and so on)</li><li>Fill the table below</li></ol>"
+        "message": "<ol><li>Remove propellers</li><li>Connect LiPo and use Outputs Tab to test all motors</li><li>Note the position of each motor (motor #1 - Left Top and so on)</li><li>Fill the table below</li></ol>"
     },
     "gpsHead": {
         "message": "Position"
@@ -2187,10 +2187,10 @@
     "firmwareFlasherManualBaudDescription": {
         "message": "Manual selection of baud rate for boards that don't support the default speed or for flashing via bluetooth.<br /><span style=\"color: red\">Note:</span> Not used when flashing via USB DFU"
     },
-    "firmwareFlasherShowDevelopmentReleases":{
+    "firmwareFlasherShowDevelopmentReleases": {
         "message": "Show unstable releases"
     },
-    "firmwareFlasherShowDevelopmentReleasesDescription":{
+    "firmwareFlasherShowDevelopmentReleasesDescription": {
         "message": "Show Release-Candidates and Development Releases."
     },
     "firmwareFlasherOptionLabelSelectFirmware": {
@@ -2412,31 +2412,31 @@
         "message": "ESC protocol"
     },
     "escRefreshRate": {
-        "message" : "ESC refresh rate"
+        "message": "ESC refresh rate"
     },
     "escProtocolHelp": {
-        "message" : "ESC has to support chosen protocol. Change only if you know that ESC supports it!"
+        "message": "ESC has to support chosen protocol. Change only if you know that ESC supports it!"
     },
     "escRefreshRatelHelp": {
-        "message" : "ESC has to support refresh rate. Change only if you know that ESC supports it!"
+        "message": "ESC has to support refresh rate. Change only if you know that ESC supports it!"
     },
     "servoRefreshRate": {
-        "message" : "Servo refresh rate"
+        "message": "Servo refresh rate"
     },
     "servoRefreshRatelHelp": {
-        "message" : "Servo has to support refresh rate. Change only if you know that servo supports it. Too high refresh rate might damage servos!"
+        "message": "Servo has to support refresh rate. Change only if you know that servo supports it. Too high refresh rate might damage servos!"
     },
     "logPwmOutputDisabled": {
-        "message" : "PWM output is disabled. Motors and servos will not work. Use <u>Outputs</u> tab to enable!"
+        "message": "PWM output is disabled. Motors and servos will not work. Use <u>Outputs</u> tab to enable!"
     },
     "configurationGyroSyncTitle": {
-        "message" : "Synchronize looptime with gyroscope"
+        "message": "Synchronize looptime with gyroscope"
     },
     "configurationGyroLpfTitle": {
-        "message" : "Gyroscope LPF cutoff frequency"
+        "message": "Gyroscope LPF cutoff frequency"
     },
     "configurationGyroSyncDenominator": {
-        "message" : "Gyroscope denominator"
+        "message": "Gyroscope denominator"
     },
     "yawJumpPreventionLimit": {
         "message": "Yaw jump prevention"
@@ -2856,34 +2856,34 @@
         "message": "Used in Extra, Fixed and 'At Least' RTH altitude modes"
     },
     "rthTrackBack": {
-    "message": "RTH Track Back Mode"
+        "message": "RTH Track Back Mode"
     },
     "rthTrackBackHelp": {
-    "message": "When enabled, the aircraft will follow its last path backwards first before flying home directly. Fixed Wing crafts will fly back the path with climbing but not descending. Usage modes for RTH Track Back. OFF = disabled, ON = Normal and Failsafe RTH, FS = Failsafe RTH only."
+        "message": "When enabled, the aircraft will follow its last path backwards first before flying home directly. Fixed Wing crafts will fly back the path with climbing but not descending. Usage modes for RTH Track Back. OFF = disabled, ON = Normal and Failsafe RTH, FS = Failsafe RTH only."
     },
     "rthTrackBackDistance": {
-    "message": "RTH Track Back Distance"
+        "message": "RTH Track Back Distance"
     },
     "rthTrackBackDistanceHelp": {
-    "message": "Distance flown during Track Back. Normal RTH is executed once this total flight distance is exceeded [m]."
+        "message": "Distance flown during Track Back. Normal RTH is executed once this total flight distance is exceeded [m]."
     },
     "rthSafeHome": {
-    "message": "Safe Home Mode"
+        "message": "Safe Home Mode"
     },
     "rthSafeHomeHelp": {
-    "message": "Used to control when safehomes will be used. Possible values are OFF, RTH and RTH_FS. See Safehome documentation for more information."
+        "message": "Used to control when safehomes will be used. Possible values are OFF, RTH and RTH_FS. See Safehome documentation for more information."
     },
     "rthSafeHomeDistance": {
-    "message": "Safe Home Max Distance"
+        "message": "Safe Home Max Distance"
     },
     "rthSafeHomeDistanceHelp": {
-    "message": "In order for a safehome to be used, it must be less than this distance [in cm] from the arming point."
+        "message": "In order for a safehome to be used, it must be less than this distance [in cm] from the arming point."
     },
     "navMaxAltitude": {
-    "message": "Max Altitude for Navigation"
+        "message": "Max Altitude for Navigation"
     },
     "navMaxAltitudeHelp": {
-    "message": "Max allowed altitude (above Home Point) that applies to all NAV modes (including Altitude Hold). 0 means limit is disabled"
+        "message": "Max allowed altitude (above Home Point) that applies to all NAV modes (including Altitude Hold). 0 means limit is disabled"
     },
     "rthHomeAltitudeLabel": {
         "message": "RTH Home altitude"
@@ -2892,16 +2892,16 @@
         "message": "Used when not landing at the home point. Upon arriving at home, the plane will loiter and change altitude to the RTH Home Altitude. Default is 0, which is feature disabled."
     },
     "rthTwoStage": {
-    "message": "Climb First Stage Method"
+        "message": "Climb First Stage Method"
     },
     "rthTwoStageHelp": {
-    "message": "Staged Return To Home Function if Climb First is enabled. Set Climb First Stage Altitude to 0, to use classic Single-Stage RTH."
+        "message": "Staged Return To Home Function if Climb First is enabled. Set Climb First Stage Altitude to 0, to use classic Single-Stage RTH."
     },
     "rthTwoStageAlt": {
-    "message": "Climb First Stage Altitude"
+        "message": "Climb First Stage Altitude"
     },
     "rthTwoStageAltHelp": {
-    "message": "Altitude Setting for the first Stage of Staged RTH. Set to 0 to Disable Two-Stage RTH [0-65000cm]"
+        "message": "Altitude Setting for the first Stage of Staged RTH. Set to 0 to Disable Two-Stage RTH [0-65000cm]"
     },
     "landMaxAltVspd": {
         "message": "The craft will start to descend at this speed, once it reaches the <strong>Home</strong> location."
@@ -3011,10 +3011,10 @@
     "loiterDirectionHelp": {
         "message": "This setting allows you to choose the loiter direction. Selecting YAW allows you to change the loiter direction with the yaw stick."
     },
-     "controlSmoothness": {
+    "controlSmoothness": {
         "message": "Control Smoothness"
     },
-     "controlSmoothnessHelp": {
+    "controlSmoothnessHelp": {
         "message": "How smoothly the autopilot controls the airplane to correct the navigation error [0-9]."
     },
     "wpTrackingAccuracy": {
@@ -3117,82 +3117,82 @@
         "message": "The maximum distance between the home point and the first waypoint."
     },
     "fixedWingNavigationConfiguration": {
-      "message": "Fixed Wing Navigation Settings"
+        "message": "Fixed Wing Navigation Settings"
     },
     "osd_unsupported_msg1": {
-        "message" : "Your flight controller isn't responding to OSD commands. This probably means that it does not have an integrated OSD."
+        "message": "Your flight controller isn't responding to OSD commands. This probably means that it does not have an integrated OSD."
     },
     "osd_unsupported_msg2": {
-        "message" : "Note that some flight controllers have an onboard <a href=\"https://www.youtube.com/watch?v=ikKH_6SQ-Tk\" target=\"_blank\">MinimOSD</a> that can be flashed and configured with <a href=\"https://github.com/ShikOfTheRa/scarab-osd/releases/latest\" target=\"_blank\">scarab-osd</a>, however the MinimOSD cannot be configured through this interface."
+        "message": "Note that some flight controllers have an onboard <a href=\"https://www.youtube.com/watch?v=ikKH_6SQ-Tk\" target=\"_blank\">MinimOSD</a> that can be flashed and configured with <a href=\"https://github.com/ShikOfTheRa/scarab-osd/releases/latest\" target=\"_blank\">scarab-osd</a>, however the MinimOSD cannot be configured through this interface."
     },
     "osd_elements": {
-        "message" : "Elements"
+        "message": "Elements"
     },
     "osd_preview_title": {
-        "message" : "Preview <span>(drag to change position)</span>"
+        "message": "Preview <span>(drag to change position)</span>"
     },
-    "osd_preview_title_drag":{
+    "osd_preview_title_drag": {
         "message": ""
     },
     "osd_video_format": {
-        "message" : "Video Format"
+        "message": "Video Format"
     },
     "osd_craft_name": {
-        "message" : "Craft Name"
+        "message": "Craft Name"
     },
-    "osd_pilot_name" : {
-        "message" : "Pilot's Name"
+    "osd_pilot_name": {
+        "message": "Pilot's Name"
     },
     "osd_units": {
-        "message" : "Units"
+        "message": "Units"
     },
     "osd_main_voltage_decimals": {
-        "message" : "Voltage Decimals"
+        "message": "Voltage Decimals"
     },
     "osd_mah_used_precision": {
-        "message" : "mAh Used Precision"
+        "message": "mAh Used Precision"
     },
     "osd_coordinate_digits": {
-        "message" : "Coordinate Digits"
+        "message": "Coordinate Digits"
     },
     "osd_plus_code_digits": {
-        "message" : "Plus Code Digits"
+        "message": "Plus Code Digits"
     },
     "osd_plus_code_short": {
-        "message" : "Plus Code Remove Leading Digits"
+        "message": "Plus Code Remove Leading Digits"
     },
     "osd_esc_rpm_precision": {
-      "message": "ESC RPM precision"
+        "message": "ESC RPM precision"
     },
     "osd_esc_rpm_precision_help": {
         "message": "The number of digits shown in the RPM display. If the RPM is higher than the number of digits, it will be shown in thousand RPM with as many decimal places as allowed."
-      },
+    },
     "osd_crosshairs_style": {
-        "message" : "Crosshairs Style"
+        "message": "Crosshairs Style"
     },
     "osd_horizon_offset": {
-        "message" : "AHI & HUD offset"
+        "message": "AHI & HUD offset"
     },
-    "osd_horizon_offset_help" : {
-        "message" : "Move the HUD and AHI up or down on the OSD to get it level with the actual horizon. The AHI can appear high or low depending on the camera angle in flight. <span style='color:red;'>NOTE: </span> This does not work with the Pixel OSD. For that use the `osd_ahi_vertical_offset` command in the CLI."
+    "osd_horizon_offset_help": {
+        "message": "Move the HUD and AHI up or down on the OSD to get it level with the actual horizon. The AHI can appear high or low depending on the camera angle in flight. <span style='color:red;'>NOTE: </span> This does not work with the Pixel OSD. For that use the `osd_ahi_vertical_offset` command in the CLI."
     },
     "osd_left_sidebar_scroll": {
-        "message" : "Left Sidebar Scroll"
+        "message": "Left Sidebar Scroll"
     },
     "osd_right_sidebar_scroll": {
-        "message" : "Right Sidebar Scroll"
+        "message": "Right Sidebar Scroll"
     },
     "osd_crsf_lq_format": {
-        "message" : "Crossfire LQ Format"
+        "message": "Crossfire LQ Format"
     },
     "osd_sidebar_scroll_arrows": {
-        "message" : "Sidebar Scroll Arrows"
+        "message": "Sidebar Scroll Arrows"
     },
     "osd_home_position_arm_screen": {
-        "message" : "Home Position on Arming Screen"
+        "message": "Home Position on Arming Screen"
     },
     "osd_alarms": {
-        "message" : "Alarms"
+        "message": "Alarms"
     },
     "osdLayoutDefault": {
         "message": "Default Layout"
@@ -3251,16 +3251,16 @@
     "osdAlarmMAX_NEG_ALTITUDE_HELP": {
         "message": "The altitude indicator will flash when altitude is negative and its absolute value is greater than this alarm. Useful when taking off from elevated places. Zero disables this alarm."
     },
-    "osd_airspeed_min_alarm" : {
+    "osd_airspeed_min_alarm": {
         "message": "Minimum Airspeed"
     },
-    "osd_airspeed_min_alarm_HELP" : {
+    "osd_airspeed_min_alarm_HELP": {
         "message": "The airspeed indicator will flash when the airspeed is below this threshold. Zero disables this alarm."
     },
-    "osd_airspeed_max_alarm" : {
+    "osd_airspeed_max_alarm": {
         "message": "Maximum Airspeed"
     },
-    "osd_airspeed_max_alarm_HELP" : {
+    "osd_airspeed_max_alarm_HELP": {
         "message": "The airspeed indicator will flash when the airspeed is above this threshold. Zero disables this alarm."
     },
     "osd_gforce_alarm": {
@@ -3795,82 +3795,82 @@
         "message": "For HD: red lines show 4:3 screen, HDZero: keep within the blue box for a higher refresh rate, AUTO/PAL: green line is NTSC limit."
     },
     "osd_dji_HD_FPV": {
-        "message" : "DJI HD FPV"
+        "message": "DJI HD FPV"
     },
-       "osd_dji_hide_unsupported": {
+    "osd_dji_hide_unsupported": {
         "message": "Hide unsupported elements"
     },
     "osd_dji_ESC_temp": {
-        "message" : "Source of <i>ESC Temperature</i>"
+        "message": "Source of <i>ESC Temperature</i>"
     },
     "osd_dji_RSSI_source": {
-        "message" : "Source of <i>RSSI</i>"
+        "message": "Source of <i>RSSI</i>"
     },
     "osd_dji_GPS_source": {
-        "message" : "Source of <i>GPS Speed</i>"
+        "message": "Source of <i>GPS Speed</i>"
     },
     "osd_dji_speed_source": {
-        "message" : "Source of <i>3D Speed</i>"
+        "message": "Source of <i>3D Speed</i>"
     },
     "osd_dji_use_craft_name_elements": {
-        "message" : "Use craft name for messages and additional elements.</span><br/>Elements in <span class=\"blue\">blue</span> appear in Craft Name."
+        "message": "Use craft name for messages and additional elements.</span><br/>Elements in <span class=\"blue\">blue</span> appear in Craft Name."
     },
     "osd_dji_adjustments": {
-        "message" : "Show adjustments in Craft Name"
+        "message": "Show adjustments in Craft Name"
     },
     "osd_dji_cn_alternating_duration": {
-        "message" : "Craft Name alternating duration (in 1/10 sec)"
+        "message": "Craft Name alternating duration (in 1/10 sec)"
     },
     "osd_switch_indicator_settings": {
-        "message" : "Switch Indicator Settings"
+        "message": "Switch Indicator Settings"
     },
     "osd_switch_indicators_align_left": {
-        "message" : "Align switch names to left of switches"
+        "message": "Align switch names to left of switches"
     },
     "osdSwitchInd0": {
-        "message" : "Switch 1"
+        "message": "Switch 1"
     },
     "osdSwitchInd1": {
-        "message" : "Switch 2"
+        "message": "Switch 2"
     },
     "osdSwitchInd2": {
-        "message" : "Switch 3"
+        "message": "Switch 3"
     },
     "osdSwitchInd3": {
-        "message" : "Switch 4"
+        "message": "Switch 4"
     },
     "osd_font_default": {
-        "message" : "Default"
+        "message": "Default"
     },
     "osd_font_vision": {
-        "message" : "Vision"
+        "message": "Vision"
     },
     "osd_font_impact": {
-        "message" : "Impact"
+        "message": "Impact"
     },
     "osd_font_impact_mini": {
-        "message" : "Impact mini"
+        "message": "Impact mini"
     },
     "osd_font_clarity": {
-        "message" : "Clarity"
+        "message": "Clarity"
     },
     "osd_font_clarity_medium": {
-        "message" : "Clarity medium"
+        "message": "Clarity medium"
     },
     "osd_font_bold": {
-        "message" : "Bold"
+        "message": "Bold"
     },
     "osd_font_large": {
-        "message" : "Large"
+        "message": "Large"
     },
     "osd_font_load_file": {
-        "message" : "Open Font File"
+        "message": "Open Font File"
     },
     "osd_font_upload": {
-        "message" : "Upload Font"
+        "message": "Upload Font"
     },
     "osd_font_manager": {
-        "message" : "Font Manager"
+        "message": "Font Manager"
     },
     "uploadingCharacters": {
         "message": "Uploading..."
@@ -4019,7 +4019,7 @@
     "mixerLoadAndApplyPresetRules": {
         "message": "Load and apply"
     },
-    "mixerApplyModalTitle" : {
+    "mixerApplyModalTitle": {
         "message": "Confirm"
     },
     "mixerButtonSaveAndReboot": {
@@ -4028,10 +4028,10 @@
     "mixerApplyDescription": {
         "message": "This action overrides all current mixer settings and replaces them with default values. There is no 'Undo' option!"
     },
-    "mixerWizardModalTitle" : {
+    "mixerWizardModalTitle": {
         "message": "Quadcopter Mixer Wizard"
     },
-    "mixerWizardModalApply" : {
+    "mixerWizardModalApply": {
         "message": "Apply"
     },
     "motorWizard0": {
@@ -4466,9 +4466,8 @@
     "motor_direction_inverted": {
         "message": "Normal motor direction / Props In configuration"
     },
-    "motor_direction_isInverted" :
-    {
-        "message" : "Reversed motor direction / Props Out configuration"
+    "motor_direction_isInverted": {
+        "message": "Reversed motor direction / Props Out configuration"
     },
     "motor_direction_inverted_hint": {
         "message": "Enable if the motor direction is reversed and the props are mounted in the opposite direction."
@@ -4553,5 +4552,67 @@
     },
     "nmeaWarning": {
         "message": "NMEA protocol is deprecated and might be removed in the future. Please use UBLOX or UBLOX7 protocol instead."
+    },
+
+
+    "ledStripRemainingText": {
+        "message": "Remaining",
+        "description": "In the LED STRIP, text next the counter of leds remaining"
+    },
+    "ledStripClearSelectedButton": {
+        "message": "Clear selected",
+        "description": "In the LED STRIP, clear selected leds"
+    },
+    "ledStripClearAllButton": {
+        "message": "Clear ALL",
+        "description": "In the LED STRIP, clear all leds"
+    },
+    "ledStripFunctionSection": {
+        "message": "LED Functions"
+    },
+    "ledStripFunctionTitle": {
+        "message": "Function"
+    },
+    "ledStripFunctionNoneOption": {
+        "message": "None",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionColorOption": {
+        "message": "Color",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionModesOption": {
+        "message": "Modes &amp; Orientation",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionArmOption": {
+        "message": "Arm State",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionBatteryOption": {
+        "message": "Battery",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionRSSIOption": {
+        "message": "RSSI",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionGPSOption": {
+        "message": "GPS",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionRingOption": {
+        "message": "Ring",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionChannelOption": {
+        "message": "Channel",
+        "description": "One of the modes of the Led Strip"
     }
+
+
+
+
+
+
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2,7 +2,6 @@
     "translation_version": {
         "message": "0"
     },
-
     "options_title": {
         "message": "Application Options"
     },
@@ -21,7 +20,6 @@
     "options_render": {
         "message": "Configurator rendering options"
     },
-
     "connect": {
         "message": "Connect"
     },
@@ -4553,19 +4551,26 @@
     "nmeaWarning": {
         "message": "NMEA protocol is deprecated and might be removed in the future. Please use UBLOX or UBLOX7 protocol instead."
     },
-
-
+    "ledStripColorSetupTitle": {
+        "message": "Color setup"
+    },
+    "ledStripH": {
+        "message": "H"
+    },
+    "ledStripS": {
+        "message": "S"
+    },
+    "ledStripV": {
+        "message": "V"
+    },
     "ledStripRemainingText": {
-        "message": "Remaining",
-        "description": "In the LED STRIP, text next the counter of leds remaining"
+        "message": "Remaining"
     },
     "ledStripClearSelectedButton": {
-        "message": "Clear selected",
-        "description": "In the LED STRIP, clear selected leds"
+        "message": "Clear selected"
     },
     "ledStripClearAllButton": {
-        "message": "Clear ALL",
-        "description": "In the LED STRIP, clear all leds"
+        "message": "Clear ALL"
     },
     "ledStripFunctionSection": {
         "message": "LED Functions"
@@ -4574,45 +4579,190 @@
         "message": "Function"
     },
     "ledStripFunctionNoneOption": {
-        "message": "None",
-        "description": "One of the modes of the Led Strip"
+        "message": "None"
     },
     "ledStripFunctionColorOption": {
-        "message": "Color",
-        "description": "One of the modes of the Led Strip"
+        "message": "Color"
     },
     "ledStripFunctionModesOption": {
-        "message": "Modes &amp; Orientation",
-        "description": "One of the modes of the Led Strip"
+        "message": "Modes &amp; Orientation"
     },
     "ledStripFunctionArmOption": {
-        "message": "Arm State",
-        "description": "One of the modes of the Led Strip"
+        "message": "Arm State"
     },
     "ledStripFunctionBatteryOption": {
-        "message": "Battery",
-        "description": "One of the modes of the Led Strip"
+        "message": "Battery"
     },
     "ledStripFunctionRSSIOption": {
-        "message": "RSSI",
-        "description": "One of the modes of the Led Strip"
+        "message": "RSSI"
     },
     "ledStripFunctionGPSOption": {
-        "message": "GPS",
-        "description": "One of the modes of the Led Strip"
+        "message": "GPS"
     },
     "ledStripFunctionRingOption": {
-        "message": "Ring",
-        "description": "One of the modes of the Led Strip"
+        "message": "Ring"
     },
     "ledStripFunctionChannelOption": {
-        "message": "Channel",
-        "description": "One of the modes of the Led Strip"
+        "message": "Channel"
+    },
+    "ledStripColorModifierTitle": {
+        "message": "Color modifier"
+    },
+    "ledStripThrottleText": {
+        "message": "Throttle"
+    },
+    "ledStripLarsonscannerText": {
+        "message": "Larson scanner"
+    },
+    "ledStripBlinkTitle": {
+        "message": "Blink"
+    },
+    "ledStripBlinkAlwaysOverlay": {
+        "message": "Blink always"
+    },
+    "ledStripBlinkLandingOverlay": {
+        "message": "Blink on landing"
+    },
+    "ledStripStrobeText": {
+        "message": "Strobe"
+    },
+    "ledStripEnableStrobeLightEffectText": {
+        "message": "Enable strobe light effect"
+    },
+    "ledStripOverlayTitle": {
+        "message": "Overlay"
+    },
+    "ledStripWarningsOverlay": {
+        "message": "Warnings"
+    },
+    "ledStripIndecatorOverlay": {
+        "message": "Indicator"
+    },
+    "colorBlack": {
+        "message": "black"
+    },
+    "colorWhite": {
+        "message": "white"
+    },
+    "colorRed": {
+        "message": "red"
+    },
+    "colorOrange": {
+        "message": "orange"
+    },
+    "colorYellow": {
+        "message": "yellow"
+    },
+    "colorLimeGreen": {
+        "message": "lime green"
+    },
+    "colorGreen": {
+        "message": "green"
+    },
+    "colorMintGreen": {
+        "message": "mint green"
+    },
+    "colorCyan": {
+        "message": "cyan"
+    },
+    "colorLightBlue": {
+        "message": "light blue"
+    },
+    "colorBlue": {
+        "message": "blue"
+    },
+    "colorDarkViolet": {
+        "message": "dark violet"
+    },
+    "colorMagenta": {
+        "message": "magenta"
+    },
+    "colorDeepPink": {
+        "message": "deep pink"
+    },
+    "ledStripSelectChannelFromColorList": {
+        "message": "Select Channel from color list"
+    },
+    "ledStripModeColorsTitle": {
+        "message": "Mode colors"
+    },
+    "ledStripModeColorsModeOrientation": {
+        "message": "Orientation"
+    },
+    "ledStripModeColorsModeHeadfree": {
+        "message": "Headfree"
+    },
+    "ledStripModeColorsModeHorizon": {
+        "message": "Horizon"
+    },
+    "ledStripModeColorsModeAngle": {
+        "message": "Angle"
+    },
+    "ledStripModeColorsModeMag": {
+        "message": "Mag"
+    },
+    "ledStripModeColorsModeBaro": {
+        "message": "Baro"
+    },
+
+    "ledStripDirN": {
+        "message": "N"
+    },
+    "ledStripDirE": {
+        "message": "E"
+    },
+    "ledStripDirS": {
+        "message": "S"
+    },
+    "ledStripDirW": {
+        "message": "W"
+    },
+    "ledStripDirU": {
+        "message": "U"
+    },
+    "ledStripDirD": {
+        "message": "D"
+    },
+    "ledStripModesOrientationTitle": {
+        "message": "LED Orientation and Color"
+    },
+    "ledStripModesSpecialColorsTitle": {
+        "message": "Special colors"
+    },
+    "ledStripModeColorsModeDisarmed": {
+        "message": "Disarmed"
+    },
+    "ledStripModeColorsModeArmed": {
+        "message": "Armed"
+    },
+    "ledStripModeColorsModeAnimation": {
+        "message": "Animation"
+    },
+    "ledStripModeColorsModeBlinkBg": {
+        "message": "Blink background"
+    },
+    "ledStripModeColorsModeGPSNoSats": {
+        "message": "GPS: no sats"
+    },
+    "ledStripModeColorsModeGPSNoLock": {
+        "message": "GPS: no lock"
+    },
+    "ledStripModeColorsModeGPSLocked": {
+        "message": "GPS: locked"
+    },
+    "ledStripWiring": {
+        "message": "LED Strip Wiring"
+    },
+    "ledStripWiringMode": {
+        "message": "Wire Ordering Mode"
+    },
+    "ledStripWiringClearControl": {
+        "message": "Clear selected"
+    },
+    "ledStripWiringClearAllControl": {
+        "message": "Clear ALL Wiring"
+    },
+    "ledStripWiringMessage": {
+        "message": "LEDs without wire ordering number will not be saved."
     }
-
-
-
-
-
-
 }

--- a/tabs/led_strip.html
+++ b/tabs/led_strip.html
@@ -46,29 +46,29 @@
         <div class="controls">
             <div class="wires-remaining">
                 <div></div>
-                Remaining
+                <span i18n="ledStripRemainingText"></span>
             </div>
-            <button class="funcClear">Clear selected</button>
-            <button class="funcClearAll">Clear ALL</button>
+            <button class="funcClear" i18n="ledStripClearSelectedButton"></button>
+            <button class="funcClearAll" i18n="ledStripClearAllButton"></button>
 
-            <div class="section">LED Functions</div>
-            
-            
+            <div class="section" i18n="ledStripFunctionSection"></div>
+
+
             <div class="select">
-                <span class="color_section">Function</span>
+                <span class="color_section" i18n="ledStripFunctionTitle">Function</span>
                 <select class="functionSelect">
-                    <option value="">None</option>
-                    <option value="function-c" class="">Color</option>
-                    <option value="function-f" class="">Modes &amp; Orientation</option>
-                    <option value="function-a" class="">Arm State</option>
-                    <option value="function-l" class="extra_functions20">Battery</option>
-                    <option value="function-s" class="extra_functions20">RSSI</option>
-                    <option value="function-g" class="extra_functions20">GPS</option>
-                    <option value="function-r" class="">Ring</option>
-                    <option value="function-h" class="channel_info">Channel</option>
+                    <option value="" i18n="ledStripFunctionNoneOption">None</option>
+                    <option value="function-c" class="" i18n="ledStripFunctionColorOption">Color</option>
+                    <option value="function-f" class="" i18n="ledStripFunctionModesOption">Modes &amp; Orientation</option>
+                    <option value="function-a" class="" i18n="ledStripFunctionArmOption">Arm State</option>
+                    <option value="function-l" class="extra_functions20" i18n="ledStripFunctionBatteryOption">Battery</option>
+                    <option value="function-s" class="extra_functions20" i18n="ledStripFunctionRSSIOption">RSSI</option>
+                    <option value="function-g" class="extra_functions20" i18n="ledStripFunctionGPSOption">GPS</option>
+                    <option value="function-r" class="" i18n="ledStripFunctionRingOption">Ring</option>
+                    <option value="function-h" class="channel_info" i18n="ledStripFunctionChannelOption">Channel</option>
                 </select>
             </div>
-            
+
 
             <div class="modifiers">
                 <span class="color_section">Color modifier</span>
@@ -81,7 +81,7 @@
                     <label> <span>Larson scanner</span></label>
                 </div>
             </div>
-            
+
             <div class="blinkers extra_functions20">
                 <span class="color_section">Blink</span>
                 <div class="checkbox blinkOverlay">
@@ -98,7 +98,7 @@
                     <label> <span>Enable strobe light effect</span></label>
                 </div>
             </div>
-                        
+
             <div class="overlays">
                 <span class="color_section">Overlay</span>
                 <div class="checkbox warningOverlay">
@@ -114,10 +114,10 @@
             <div class="channel_info">
                 <span class="color_section">Select Channel from color list</span>
             </div>
-            
+
             <div class="mode_colors">
                 <div class="section">Mode colors</div>
-                
+
                 <select class="modeSelect">
                     <option value="0">Orientation</option>
                     <option value="1">Headfree</option>
@@ -134,7 +134,7 @@
                 <button class="mode_color-0-4 dir-u">U</button>
                 <button class="mode_color-0-5 dir-d">D</button>
             </div>
-            
+
             <div class="section">LED Orientation and Color</div>
             <div class="directions">
                 <button class="dir-n">N</button>
@@ -144,7 +144,7 @@
                 <button class="dir-u">U</button>
                 <button class="dir-d">D</button>
             </div>
-            
+
             <div class="colors">
                 <button class="color-0" title="black">0</button>
                 <button class="color-1" title="white">1</button>
@@ -175,7 +175,7 @@
                 <button class="mode_color-6-6" title="orange">GPS: no lock</button>
                 <button class="mode_color-6-7" title="green">GPS: locked</button>
             </div>
-            
+
             <div class="section">LED Strip Wiring</div>
             <div class="wiringMode">
                 <button class="funcWire w100">Wire Ordering Mode</button>
@@ -186,11 +186,11 @@
             </div>
             <p>LEDs without wire ordering number will not be saved.</p>
         </div>
-        
+
         <div class="colorControls">
 
         </div>
-        
+
         <div class="clear-both"></div>
     </div>
     <div class="content_toolbar">

--- a/tabs/led_strip.html
+++ b/tabs/led_strip.html
@@ -26,19 +26,19 @@
             <div class="block"></div>
         </div>
         <div class="colorDefineSliders">
-            <div class="">Color setup</div>
+            <div class="" i18n="ledStripColorSetupTitle"></div>
             <div class="colorDefineSliderContainer">
-                <Label class="colorDefineSliderLabel">H</Label>
+                <Label class="colorDefineSliderLabel" i18n="ledStripH"></Label>
                 <input class="sliderHSV" type="range" min="0" max="359" value="0">
                 <Label class="colorDefineSliderValue Hvalue">0</Label>
             </div>
             <div class="colorDefineSliderContainer">
-                <Label class="colorDefineSliderLabel">S</Label>
+                <Label class="colorDefineSliderLabel" i18n="ledStripS"></Label>
                 <input class="sliderHSV" type="range" min="0" max="255" value="0">
                 <Label class="colorDefineSliderValue Svalue">0</Label>
             </div>
             <div class="colorDefineSliderContainer">
-                <Label class="colorDefineSliderLabel">V</Label>
+                <Label class="colorDefineSliderLabel" i18n="ledStripV"></Label>
                 <input class="sliderHSV" type="range" min="0" max="255" value="0">
                 <Label class="colorDefineSliderValue Vvalue">0</Label>
             </div>
@@ -55,136 +55,136 @@
 
 
             <div class="select">
-                <span class="color_section" i18n="ledStripFunctionTitle">Function</span>
+                <span class="color_section" i18n="ledStripFunctionTitle"></span>
                 <select class="functionSelect">
-                    <option value="" i18n="ledStripFunctionNoneOption">None</option>
-                    <option value="function-c" class="" i18n="ledStripFunctionColorOption">Color</option>
-                    <option value="function-f" class="" i18n="ledStripFunctionModesOption">Modes &amp; Orientation</option>
-                    <option value="function-a" class="" i18n="ledStripFunctionArmOption">Arm State</option>
-                    <option value="function-l" class="extra_functions20" i18n="ledStripFunctionBatteryOption">Battery</option>
-                    <option value="function-s" class="extra_functions20" i18n="ledStripFunctionRSSIOption">RSSI</option>
-                    <option value="function-g" class="extra_functions20" i18n="ledStripFunctionGPSOption">GPS</option>
-                    <option value="function-r" class="" i18n="ledStripFunctionRingOption">Ring</option>
-                    <option value="function-h" class="channel_info" i18n="ledStripFunctionChannelOption">Channel</option>
+                    <option value="" i18n="ledStripFunctionNoneOption"></option>
+                    <option value="function-c" class="" i18n="ledStripFunctionColorOption"></option>
+                    <option value="function-f" class="" i18n="ledStripFunctionModesOption"></option>
+                    <option value="function-a" class="" i18n="ledStripFunctionArmOption"></option>
+                    <option value="function-l" class="extra_functions20" i18n="ledStripFunctionBatteryOption"></option>
+                    <option value="function-s" class="extra_functions20" i18n="ledStripFunctionRSSIOption"></option>
+                    <option value="function-g" class="extra_functions20" i18n="ledStripFunctionGPSOption"></option>
+                    <option value="function-r" class="" i18n="ledStripFunctionRingOption"></option>
+                    <option value="function-h" class="channel_info" i18n="ledStripFunctionChannelOption"></option>
                 </select>
             </div>
 
 
             <div class="modifiers">
-                <span class="color_section">Color modifier</span>
+                <span class="color_section" i18n="ledStripColorModifierTitle"></span>
                 <div class="checkbox">
                     <input type="checkbox" name="ThrottleHue" class="toggle function-t" />
-                    <label> <span>Throttle</span></label>
+                    <label> <span i18n="ledStripThrottleText"></span></label>
                 </div>
                 <div class="checkbox extra_functions20">
                     <input type="checkbox" name="LarsonScanner" class="toggle function-o" />
-                    <label> <span>Larson scanner</span></label>
+                    <label> <span i18n="ledStripLarsonscannerText"></span></label>
                 </div>
             </div>
 
             <div class="blinkers extra_functions20">
-                <span class="color_section">Blink</span>
+                <span class="color_section" i18n="ledStripBlinkTitle"></span>
                 <div class="checkbox blinkOverlay">
                     <input type="checkbox" name="blink" class="toggle function-b" />
-                    <label> <span>Blink always</span></label>
+                    <label> <span i18n="ledStripBlinkAlwaysOverlay"></span></label>
                 </div>
                 <div class="checkbox landingBlinkOverlay">
                     <input type="checkbox" name="landingBlink" class="toggle function-n" />
-                    <label> <span>Blink on landing</span></label>
+                    <label> <span i18n="ledStripBlinkLandingOverlay"></span></label>
                 </div>
-                <span class="color_section">Strobe</span>
+                <span class="color_section" i18n="ledStripStrobeText"></span>
                 <div class="checkbox strobeOverlay">
                     <input type="checkbox" name="strobe" class="toggle function-e" />
-                    <label> <span>Enable strobe light effect</span></label>
+                    <label> <span i18n="ledStripEnableStrobeLightEffectText"></span></label>
                 </div>
             </div>
 
             <div class="overlays">
-                <span class="color_section">Overlay</span>
+                <span class="color_section" i18n="ledStripOverlayTitle"></span>
                 <div class="checkbox warningOverlay">
                     <input type="checkbox" name="Warnings" class="toggle function-w" />
-                    <label> <span>Warnings</span></label>
+                    <label> <span i18n="ledStripWarningsOverlay"></span></label>
                 </div>
                 <div class="checkbox indicatorOverlay">
                     <input type="checkbox" name="Indicator" class="toggle function-i" />
-                    <label> <span>Indicator</span></label>
+                    <label> <span i18n="ledStripIndecatorOverlay"></span></label>
                 </div>
             </div>
 
             <div class="channel_info">
-                <span class="color_section">Select Channel from color list</span>
+                <span class="color_section" i18n="ledStripSelectChannelFromColorList"></span>
             </div>
 
             <div class="mode_colors">
-                <div class="section">Mode colors</div>
+                <div class="section" i18n="ledStripModeColorsTitle"></div>
 
-                <select class="modeSelect">
-                    <option value="0">Orientation</option>
-                    <option value="1">Headfree</option>
-                    <option value="2">Horizon</option>
-                    <option value="3">Angle</option>
-                    <option value="4">Mag</option>
-                    <option value="5">Baro</option>
+                <select id="ledStripModeColorsModeSelect" class="modeSelect">
+                    <option value="0" i18n="ledStripModeColorsModeOrientation"></option>
+                    <option value="1" i18n="ledStripModeColorsModeHeadfree"></option>
+                    <option value="2" i18n="ledStripModeColorsModeHorizon"></option>
+                    <option value="3" i18n="ledStripModeColorsModeAngle"></option>
+                    <option value="4" i18n="ledStripModeColorsModeMag"></option>
+                    <option value="5" i18n="ledStripModeColorsModeBaro"></option>
                 </select>
 
-                <button class="mode_color-0-0 dir-n">N</button>
-                <button class="mode_color-0-1 dir-e">E</button>
-                <button class="mode_color-0-2 dir-s">S</button>
-                <button class="mode_color-0-3 dir-w">W</button>
-                <button class="mode_color-0-4 dir-u">U</button>
-                <button class="mode_color-0-5 dir-d">D</button>
+                <button class="mode_color-0-0 dir-n" i18n="ledStripDirN"></button>
+                <button class="mode_color-0-1 dir-e" i18n="ledStripDirE"></button>
+                <button class="mode_color-0-2 dir-s" i18n="ledStripDirS"></button>
+                <button class="mode_color-0-3 dir-w" i18n="ledStripDirW"></button>
+                <button class="mode_color-0-4 dir-u" i18n="ledStripDirU"></button>
+                <button class="mode_color-0-5 dir-d" i18n="ledStripDirD"></button>
             </div>
 
-            <div class="section">LED Orientation and Color</div>
+            <div class="section" i18n="ledStripModesOrientationTitle"></div>
             <div class="directions">
-                <button class="dir-n">N</button>
-                <button class="dir-e">E</button>
-                <button class="dir-s">S</button>
-                <button class="dir-w">W</button>
-                <button class="dir-u">U</button>
-                <button class="dir-d">D</button>
+                <button class="dir-n" i18n="ledStripDirN"></button>
+                <button class="dir-e" i18n="ledStripDirE"></button>
+                <button class="dir-s" i18n="ledStripDirS"></button>
+                <button class="dir-w" i18n="ledStripDirW"></button>
+                <button class="dir-u" i18n="ledStripDirU"></button>
+                <button class="dir-d" i18n="ledStripDirD"></button>
             </div>
 
             <div class="colors">
-                <button class="color-0" title="black">0</button>
-                <button class="color-1" title="white">1</button>
-                <button class="color-2" title="red">2</button>
-                <button class="color-3" title="orange">3</button>
-                <button class="color-4" title="yellow">4</button>
-                <button class="color-5" title="lime green">5</button>
-                <button class="color-6" title="green">6</button>
-                <button class="color-7" title="mint green">7</button>
-                <button class="color-8" title="cyan">8</button>
-                <button class="color-9" title="light blue">9</button>
-                <button class="color-10" title="blue">10</button>
-                <button class="color-11" title="dark violet">11</button>
-                <button class="color-12" title="magenta">12</button>
-                <button class="color-13" title="deep pink">13</button>
-                <button class="color-14" title="black">14</button>
-                <button class="color-15" title="black">15</button>
+                <button class="color-0" i18n_title="colorBlack">0</button>
+                <button class="color-1" i18n_title="colorWhite">1</button>
+                <button class="color-2" i18n_title="colorRed">2</button>
+                <button class="color-3" i18n_title="colorOrange">3</button>
+                <button class="color-4" i18n_title="colorYellow">4</button>
+                <button class="color-5" i18n_title="colorLimeGreen">5</button>
+                <button class="color-6" i18n_title="colorGreen">6</button>
+                <button class="color-7" i18n_title="colorMintGreen">7</button>
+                <button class="color-8" i18n_title="colorCyan">8</button>
+                <button class="color-9" i18n_title="colorLightBlue">9</button>
+                <button class="color-10" i18n_title="colorBlue">10</button>
+                <button class="color-11" i18n_title="colorDarkViolet">11</button>
+                <button class="color-12" i18n_title="colorMagenta">12</button>
+                <button class="color-13" i18n_title="colorDeepPink">13</button>
+                <button class="color-14" i18n_title="colorBlack">14</button>
+                <button class="color-15" i18n_title="colorBlack">15</button>
             </div>
 
             <div class="special_colors mode_colors">
-                <div class="section">Special colors</div>
-                <button class="mode_color-6-0" title="green">Disarmed</button>
-                <button class="mode_color-6-1" title="blue">Armed</button>
-                <button class="mode_color-6-2" title="white">Animation</button>
-                <!-- button class="mode_color-6-3" title="black">Background</button -->
-                <button class="mode_color-6-4" title="black">Blink background</button>
-                <button class="mode_color-6-5" title="red">GPS: no sats</button>
-                <button class="mode_color-6-6" title="orange">GPS: no lock</button>
-                <button class="mode_color-6-7" title="green">GPS: locked</button>
+                <div class="section" i18n="ledStripModesSpecialColorsTitle"></div>
+                <button class="mode_color-6-0" i18n_title="colorGreen" i18n="ledStripModeColorsModeDisarmed"></button>
+                <button class="mode_color-6-1" i18n_title="colorBlue" i18n="ledStripModeColorsModeArmed"></button>
+                <button class="mode_color-6-2" i18n_title="colorWhite" i18n="ledStripModeColorsModeAnimation"></button>
+                <!-- button class="mode_color-6-3" i18n_title="colorBlack">Background</button -->
+                <button class="mode_color-6-4" i18n_title="colorBlack" i18n="ledStripModeColorsModeBlinkBg"></button>
+                <button class="mode_color-6-5" i18n_title="colorRed" i18n="ledStripModeColorsModeGPSNoSats"></button>
+                <button class="mode_color-6-6" i18n_title="colorOrange" i18n="ledStripModeColorsModeGPSNoLock"></button>
+                <button class="mode_color-6-7" i18n_title="colorGreen" i18n="ledStripModeColorsModeGPSLocked"></button>
             </div>
 
-            <div class="section">LED Strip Wiring</div>
+            <div class="section" i18n="ledStripWiring"></div>
             <div class="wiringMode">
-                <button class="funcWire w100">Wire Ordering Mode</button>
+                <button class="funcWire w100" i18n="ledStripWiringMode"></button>
             </div>
             <div class="wiringControls">
-                <button class="funcWireClearSelect w50">Clear selected</button>
-                <button class="funcWireClear w50">Clear ALL Wiring</button>
+                <button class="funcWireClearSelect w50" i18n="ledStripWiringClearControl"></button>
+                <button class="funcWireClear w50" i18n="ledStripWiringClearAllControl"></button>
             </div>
-            <p>LEDs without wire ordering number will not be saved.</p>
+            <p i18n="ledStripWiringMessage"></p>
         </div>
 
         <div class="colorControls">


### PR DESCRIPTION
This PR adds all the text in LED_strip.html to i18n.

**Why would I want to do this?**

Since INAV configurator only supports English language for the time being, since INAV4.0, I have provided a local built Chinese version of the configurator for Chinese players, but I found that there is still a lot of text in the code that has not been added to i18n. Every time INAV releases a new version of the configurator, I have to spend a lot of time manually changing the text to Chinese before building.

This may be a relic of history, but if INAV eventually wants to support multiple languages like Betaflight, these texts will have to be added to i18n. So why not start preparing for multilingualism now?

For my first attempt, I chose the LED_strip Tab because the Betaflight configurator code gives me a good reference, since INAV and Betaflight both originate from Cleanflight.