### PR TITLE
Add warning message to softserial ports

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -4672,5 +4672,8 @@
     },
     "nmeaWarning": {
         "message": "NMEA protocol is deprecated and might be removed in the future. Please use UBLOX or UBLOX7 protocol instead."
+    },
+    "softSerialWarning": {
+        "message": "It is not advisable to use softserial for flight critical devices like GPS or receiver, or high traffic devices like MSP DisplayPort."
     }
 }

--- a/tabs/ports.html
+++ b/tabs/ports.html
@@ -44,7 +44,7 @@
         <tbody>
             <tr class="portConfiguration">
                 <td class="identifierCell">
-                    <p class="identifier"></p>
+                    <p><div class="identifier"/> <div class="softSerialWarning"><img src="../images/icons/cf_icon_armed_active.svg" height="16" width="16" data-i18n_title="softSerialWarning"/></div></p>
                 </td>
                 <td class="functionsCell-data"><select class="msp_baudrate">
                         <!-- list generated here -->

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -229,6 +229,11 @@ TABS.ports.initialize = function (callback) {
             port_configuration_e.find('select.peripherals_baudrate').val(serialPort.peripherals_baudrate);
 
             port_configuration_e.find('.identifier').text(portIdentifierToNameMapping[serialPort.identifier]);
+            if (serialPort.identifier >= 30) {
+                port_configuration_e.find('.softSerialWarning').css("display", "inline")
+            } else {
+                port_configuration_e.find('.softSerialWarning').css("display", "none")
+            }
 
             port_configuration_e.data('index', portIndex);
             port_configuration_e.data('port', serialPort);


### PR DESCRIPTION
We often get users asking about osd problems on f411 fc because they are trying to use soft serial with MSP DisplayPort.

A warning triangle will be displayed on Soft Serial entries and when the mouse stops over the icon it will display the following message:

"It is not advisable to use softserial for flight critical devices like GPS or receiver, or high traffic devices like MSP DisplayPort."