### PR TITLE
[SITl] Fix serial selection and executable name on Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inav-configurator",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "inav-configurator",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "GPL-3.0",
       "dependencies": {
         "archiver": "^2.0.3",


### PR DESCRIPTION
A couple of defects prevented using a "real" serial RX on the Linux SITL

* The shipped executable is 'Ser2TCP`, the Configurator attempted to spawn `ser2TCP`.
* The UI contained many undefined items and used device descriptions 
![old-sitl-serial](https://user-images.githubusercontent.com/158229/233989632-b57f542f-3eee-4a1d-999a-9a0c04a88479.png) 
* The supplied `Ser2TCP` expected a device node, rather than a device description, so even if it has been invoked correctly, it then failed.

This PR corrects the invoked name (uses the capitalised option for commonality with Windows and displays only relevant device node names. The selected device node is passed to the executable.
![fix_sitl_ser](https://user-images.githubusercontent.com/158229/233990362-a1fd681a-b58c-4cc8-8348-651ffca58800.png)

Tested on Arch Linux, "CP2102 USB to UART Bridge Controller" / `/dev/ttyUSB0` and IBUS RX.
