### PR TITLE
[rpm-build] remove obsolete dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -302,7 +302,7 @@ function get_release_filename(platform, ext, addition = '') {
 function build_win_zip(arch) {
     return function build_win_zip_proc(done) {
         var pkg = require('./package.json');
-    
+
         // Create ZIP
         console.log(`Creating ${arch} ZIP file...`);
         var src = path.join(appsDir, pkg.name, arch);
@@ -328,7 +328,7 @@ function build_win_iss(arch) {
         // Create Installer
         console.log(`Creating ${arch} Installer...`);
         const innoSetup = require('@quanle94/innosetup');
-            
+
         const APPS_DIR = './apps/';
         const pkg = require('./package.json');
 
@@ -386,7 +386,7 @@ gulp.task('release-osx64', function(done) {
 
         // Check if the bundle is signed
         const codesignCheckArgs = [ 'codesign', '-vvv', '--deep', '--strict', src ];
-        execSync.apply(this, codesignCheckArgs);        
+        execSync.apply(this, codesignCheckArgs);
     }
 
     // 'old' .zip mode
@@ -419,7 +419,7 @@ gulp.task('release-osx64', function(done) {
             done();
         });
         archive.finalize();
-    } 
+    }
     // 'new' .dmg mode
     else {
         const appdmg = require('appdmg');
@@ -643,7 +643,7 @@ function release_rpm(arch) {
             vendor: metadata.author,
             summary: metadata.description,
             license: 'GNU General Public License v3.0',
-            requires: ['libgconf-2-4', 'libatomic1'],
+            requires: ['libatomic1'],
             prefix: '/opt',
             files: [{
                 cwd: path.join(appsDir, metadata.name, arch),


### PR DESCRIPTION
Remove unnecessary / undesirable / obsolete dependency `libgconf-2-4`, which prevented installation on modern Fedora. Tested on F38.
