### PR TITLE
magnetometer alignment tool => alignment tool

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -900,18 +900,6 @@
     "configurationSerialRXHelp": {
         "message": "<strong>Note:</strong> Remember to configure a Serial Port (via Ports tab) for the serial receiver"
     },
-    "configurationBoardAlignment": {
-        "message": "Board and Sensor Alignment"
-    },
-    "configurationBoardAlignmentRoll": {
-        "message": "Roll Degrees"
-    },
-    "configurationBoardAlignmentPitch": {
-        "message": "Pitch Degrees"
-    },
-    "configurationBoardAlignmentYaw": {
-        "message": "Yaw Degrees"
-    },
     "configurationSensorAlignmentMag": {
         "message": "MAG Alignment"
     },
@@ -2035,16 +2023,19 @@
         "message": "Signal Strength"
     },
     "magnetometerHead": {
-        "message": "Magnetometer Alignment"
+        "message": "Alignment tool"
     },
     "magnetometerHelp": {
-        "message": "Adjust the magnetometer orientation to match physical orientation on the aircraft.<br/>If magnetometer is not BN-880, adjust according to \"compass direction\" arrow or axis markings on your magnetometer model.<br/><strong>Note:</strong> Magnetometer orientation preset (align_mag) is relative to FC. Make sure to align FC first (board_align_yaw, board_align_pitch, board_align_roll).<br/>If preset is not used (some of the align_mag_roll, align_mag_pitch or align_mag_yaw are non-zero), magnetometer orientation does not depend on FC orientation."
+        "message": "1. Adjust Flight Controller orientation to match physical orientation on the aircraft <u>according to \"direction\" arrow on Flight Controller</u>.<br/>2. Adjust magnetometer orientation to match physical orientation on the aircraft <u>according to \"compass direction\" arrow or axis markings on magnetometer</u>.<br/><strong>Note:</strong> Magnetometer orientation preset (align_mag) is relative to FC. Make sure to align FC first (align_board_pitch, align_board_roll, align_board_yaw).<br/>If preset is not used (orientation is set using align_mag_pitch, align_mag_roll and align_mag_yaw), then magnetometer orientation is independent."
     },
     "magnetometerOrientationPreset": {
         "message": "Orientation preset (align_mag). Relative to FC orientation"
     },
+    "boardInfo": {
+        "message": "1. Select Flight Controller alignment (align_board_pitch, align_board_roll, align_board_yaw)"
+    },
     "magnetometerInfo": {
-        "message": "Select a preset or create a custom configuration moving the sliders"
+        "message": "2. Select a preset (align_mag) or create a custom configuration using the sliders (align_mag_pitch, align_mag_roll, align_mag_yaw)"
     },
     "magnetometerElementToShow": {
         "message": "Element to show: Magnetometer model or axes"
@@ -2060,9 +2051,6 @@
         "message": "Value [degree]"
     },
 
-
-
-
     "configurationMagnetometerHelp": {
         "message": "<strong>Note:</strong> Remember to configure a Serial Port (via Ports tab) when using the Magnetometer feature."
     },
@@ -2070,7 +2058,7 @@
         "message": "Mag Statistics"
     },
     "tabMAGNETOMETER": {
-        "message": "Magnetometer"
+        "message": "Alignment tool"
     },
     "motors": {
         "message": "Motors"
@@ -4771,9 +4759,6 @@
     },
     "WaypointOptionP2": {
         "message": "P2"
-    },
-    "rollPitchAdjustmentsMoved": {
-        "message": "Roll & Pitch board orientation is available only in the CLI. Do not use it to trim the airplane for the level flight! Use Fixed Wing Level Trim on the PID tuning tab under Mechanics instead (<strong>fw_level_pitch_trim</strong>)."
     },
     "pidId": {
         "message": "#"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2038,16 +2038,16 @@
         "message": "Magnetometer Alignment"
     },
     "magnetometerHelp": {
-        "message": "Adjust the magnetometer orientation to match physical orientation on the aircraft.<br/>If magnetometer is not BN-880, adjust according to \"compass direction\" arrow or axis markings on your magnetometer model.<br/><strong>Note:</strong> Magnetometer alignment is relative to FC. Make sure to align FC first (board_align_yaw, board_align_pitch, board_align_roll)."
+        "message": "Adjust the magnetometer orientation to match physical orientation on the aircraft.<br/>If magnetometer is not BN-880, adjust according to \"compass direction\" arrow or axis markings on your magnetometer model.<br/><strong>Note:</strong> Magnetometer orientation preset (align_mag) is relative to FC. Make sure to align FC first (board_align_yaw, board_align_pitch, board_align_roll).<br/>If preset is not used (some of the align_mag_roll, align_mag_pitch or align_mag_yaw are non-zero), magnetometer orientation does not depend on FC orientation."
     },
     "magnetometerOrientationPreset": {
-        "message": "Orientation presets"
+        "message": "Orientation preset (align_mag). Relative to FC orientation"
     },
     "magnetometerInfo": {
         "message": "Select a preset or create a custom configuration moving the sliders"
     },
     "magnetometerElementToShow": {
-        "message": "Element to show"
+        "message": "Element to show: Magnetometer model or axes"
     },
 
     "axisTableTitleAxis": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2032,10 +2032,10 @@
         "message": "Orientation preset (align_mag). Relative to FC orientation"
     },
     "boardInfo": {
-        "message": "1. Select Flight Controller alignment (align_board_roll, align_board_pitch, align_board_yaw)"
+        "message": "1. Select Flight Controller alignment<br>(align_board_roll, align_board_pitch, align_board_yaw)"
     },
     "magnetometerInfo": {
-        "message": "2. Select a preset (align_mag) or create a custom configuration using the sliders (align_mag_roll, align_mag_pitch, align_mag_yaw)"
+        "message": "2. Select a preset (align_mag) or create a custom configuration using the sliders<br>(align_mag_roll, align_mag_pitch, align_mag_yaw)"
     },
     "magnetometerElementToShow": {
         "message": "Element to show: Magnetometer model or axes"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2026,16 +2026,16 @@
         "message": "Alignment tool"
     },
     "magnetometerHelp": {
-        "message": "1. Adjust Flight Controller orientation to match physical orientation on the aircraft <u>according to \"direction\" arrow on Flight Controller</u>.<br/>2. Adjust magnetometer orientation to match physical orientation on the aircraft <u>according to \"compass direction\" arrow or axis markings on magnetometer</u>.<br/><strong>Note:</strong> Magnetometer orientation preset (align_mag) is relative to FC. Make sure to align FC first (align_board_pitch, align_board_roll, align_board_yaw).<br/>If preset is not used (orientation is set using align_mag_pitch, align_mag_roll and align_mag_yaw), then magnetometer orientation is independent."
+        "message": "1. Adjust Flight Controller orientation to match physical orientation on the aircraft <u>according to \"direction\" arrow on Flight Controller</u>.<br/>2. Adjust magnetometer orientation to match physical orientation on the aircraft <u>according to \"compass direction\" arrow or axis markings on magnetometer</u>.<br/><strong>Note:</strong> Magnetometer orientation preset (align_mag) is relative to FC. Make sure to align FC first (align_board_pitch, align_board_roll, align_board_yaw).<br/>If preset is not used (orientation is set using align_mag_roll, align_mag_pitch and align_mag_yaw), then magnetometer orientation is independent."
     },
     "magnetometerOrientationPreset": {
         "message": "Orientation preset (align_mag). Relative to FC orientation"
     },
     "boardInfo": {
-        "message": "1. Select Flight Controller alignment (align_board_pitch, align_board_roll, align_board_yaw)"
+        "message": "1. Select Flight Controller alignment (align_board_roll, align_board_pitch, align_board_yaw)"
     },
     "magnetometerInfo": {
-        "message": "2. Select a preset (align_mag) or create a custom configuration using the sliders (align_mag_pitch, align_mag_roll, align_mag_yaw)"
+        "message": "2. Select a preset (align_mag) or create a custom configuration using the sliders (align_mag_roll, align_mag_pitch, align_mag_yaw)"
     },
     "magnetometerElementToShow": {
         "message": "Element to show: Magnetometer model or axes"

--- a/src/css/tabs/magnetometer.css
+++ b/src/css/tabs/magnetometer.css
@@ -137,7 +137,7 @@
 .tab-magnetometer #interactive_block {
     position: absolute;
     width: calc(100% - 40px);
-    height: calc(100% - 245px);
+    height: calc(100% - 200px);
     background-color: #f9f9f9;
     border-radius: 5px;
     border: 1px solid #e4e4e4;

--- a/src/css/tabs/magnetometer.css
+++ b/src/css/tabs/magnetometer.css
@@ -136,8 +136,9 @@
 
 .tab-magnetometer #interactive_block {
     position: absolute;
-    width: calc(100% - 40px);
-    height: calc(100% - 200px);
+    width: calc(100% - 655px);
+    height: 771px;
+    min-height: calc(100% - 200px);
     background-color: #f9f9f9;
     border-radius: 5px;
     border: 1px solid #e4e4e4;
@@ -189,6 +190,17 @@ progress[value]::-webkit-progress-value {
     border-radius: 2px;
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.25) inset;
 }
+
+.tab-magnetometer-left-wrapper {
+    float:left;
+    width: calc( 100% - 655px );
+}
+
+.tab-magnetometer-right-wrapper {
+    float:right;
+    width: 600px;
+}
+
 
 @media only screen and (max-width: 1055px) , only screen and (max-device-width: 1055px) {
 

--- a/src/css/tabs/setup.css
+++ b/src/css/tabs/setup.css
@@ -40,6 +40,21 @@
     float: left;
 }
 
+.attitude_note1 {
+   position: absolute;
+   left: 130px;
+   top: 29px;
+   font-size: 10px;
+}
+
+.attitude_note2 {
+   position: absolute;
+   left: 130px;
+   top: 13px;
+   font-size: 10px;
+}
+
+
 #interactive_block a.reset {
     position: absolute;
     display: block;

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -54,28 +54,6 @@
 
                 </div>
             </div>
-            <div class="board gui_box grey">
-                <div class="gui_box_titlebar">
-                    <div class="spacer_box_title" data-i18n="configurationBoardAlignment"></div>
-                    <div class="helpicon cf_tip" data-i18n_title="configHelp2"></div>
-                </div>
-                <div class="spacer_box">
-                    <div class="info-box" data-i18n="rollPitchAdjustmentsMoved"></div>
-                    <div class="number">
-                        <input id="board_align_yaw" type="number" name="board_align_yaw" step="0.1" min="-180" max="360" />
-                        <div class="alignicon yaw"></div>
-                        <label for="board_align_yaw" data-i18n="configurationBoardAlignmentYaw"></label>
-                    </div>
-                    <div class="select" style="position: relative; top: -3px;">
-                        <select id="magalign" class="magalign">
-                            <option value="0">Default</option>
-                            <!-- list generated here -->
-                        </select>
-                        <div class="alignicon yaw"></div>
-                        <label for="magalign" data-i18n="configurationSensorAlignmentMag"></label>
-                    </div>
-                </div>
-            </div>
 
             <div class="config-section gui_box grey other">
                 <div class="gui_box_titlebar">

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -256,7 +256,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
         $('a.save').click(function () {
             //UPDATE: moved to GPS tab and hidden
-            MISC.mag_declination = parseFloat($('#mag_declination').val());
+            //MISC.mag_declination = parseFloat($('#mag_declination').val());
 
             ARMING_CONFIG.auto_disarm_delay = parseInt($('input[name="autodisarmdelay"]').val());
 

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -30,12 +30,10 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
     var saveChainer = new MSPChainerClass();
 
     var saveChain = [
-        mspHelper.saveSensorAlignment,
         mspHelper.saveAccTrim,
         mspHelper.saveArmingConfig,
         mspHelper.saveAdvancedConfig,
         mspHelper.saveVTXConfig,
-        mspHelper.saveBoardAlignment,
         mspHelper.saveCurrentMeterConfig,
         mspHelper.saveMiscV2,
         saveSettings,
@@ -114,14 +112,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
         // translate to user-selected language
         localize();
-
-        let alignments = FC.getSensorAlignments();
-        let orientation_mag_e = $('select.magalign');
-
-        for (i = 0; i < alignments.length; i++) {
-            orientation_mag_e.append('<option value="' + (i + 1) + '">' + alignments[i] + '</option>');
-        }
-        orientation_mag_e.val(SENSOR_ALIGNMENT.align_mag);
 
         // VTX
         var config_vtx = $('.config-vtx');
@@ -209,7 +199,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('input[name="board_align_yaw"]').val((BOARD_ALIGNMENT.yaw / 10.0).toFixed(1));
 
         // fill magnetometer
-        $('#mag_declination').val(MISC.mag_declination);
+        //UPDATE: moved to GPS tab and hidden
+        //$('#mag_declination').val(MISC.mag_declination);
 
         // fill battery voltage
         $('#voltagesource').val(MISC.voltage_source);
@@ -264,6 +255,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $i2cSpeed.change();
 
         $('a.save').click(function () {
+            //UPDATE: moved to GPS tab and hidden
             MISC.mag_declination = parseFloat($('#mag_declination').val());
 
             ARMING_CONFIG.auto_disarm_delay = parseInt($('input[name="autodisarmdelay"]').val());
@@ -280,8 +272,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             MISC.battery_capacity_warning = parseInt($('#battery_capacity_warning').val() * MISC.battery_capacity / 100);
             MISC.battery_capacity_critical = parseInt($('#battery_capacity_critical').val() * MISC.battery_capacity / 100);
             MISC.battery_capacity_unit = $('#battery_capacity_unit').val();
-
-            SENSOR_ALIGNMENT.align_mag = parseInt(orientation_mag_e.val());
 
             googleAnalytics.sendEvent('Setting', 'I2CSpeed', $('#i2c_speed').children("option:selected").text());
 
@@ -300,7 +290,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             helper.features.reset();
             helper.features.fromUI($('.tab-configuration'));
             helper.features.execute(function () {
-                BOARD_ALIGNMENT.yaw = Math.round(parseFloat($('input[name="board_align_yaw"]').val()) * 10);
                 CURRENT_METER_CONFIG.scale = parseInt($('#currentscale').val());
                 CURRENT_METER_CONFIG.offset = Math.round(parseFloat($('#currentoffset').val()) * 10);
                 saveChainer.execute();

--- a/tabs/magnetometer.html
+++ b/tabs/magnetometer.html
@@ -48,7 +48,7 @@
                     <tbody>
                         <tr>
                             <td class="info">
-                                <p class="title" data-i18n="configurationSensorAlignmentMagPitch"></p>
+                                <p class="title" data-i18n="configurationSensorAlignmentMagRoll"></p>
                             </td>
                             <td>
                                 <div id="board_roll_slider" class="slider"></div>
@@ -59,7 +59,7 @@
                         </tr>
                         <tr>
                             <td class="info">
-                                <p class="title" data-i18n="configurationSensorAlignmentMagRoll"></p>
+                                <p class="title" data-i18n="configurationSensorAlignmentMagPitch"></p>
                             </td>
                             <td>
                                 <div id="board_pitch_slider" class="slider"></div>
@@ -129,7 +129,7 @@
                     <tbody>
                         <tr>
                             <td class="info">
-                                <p class="title" data-i18n="configurationSensorAlignmentMagPitch"></p>
+                                <p class="title" data-i18n="configurationSensorAlignmentMagRoll"></p>
                             </td>
                             <td>
                                 <div id="roll_slider" class="slider"></div>
@@ -140,7 +140,7 @@
                         </tr>
                         <tr>
                             <td class="info">
-                                <p class="title" data-i18n="configurationSensorAlignmentMagRoll"></p>
+                                <p class="title" data-i18n="configurationSensorAlignmentMagPitch"></p>
                             </td>
                             <td>
                                 <div id="pitch_slider" class="slider"></div>

--- a/tabs/magnetometer.html
+++ b/tabs/magnetometer.html
@@ -1,186 +1,188 @@
-<div class="tab-magnetometer">
-    <div class="content_wrapper" style="height: calc(80% - 40px)">
+<div class="tab-magnetometer toolbar_fixed_bottom">
+    <div class="content_wrapper">
         <div class="tab_title" data-i18n="tabMagnetometer">Magnetometer</div>
         <div class="note spacebottom">
             <div class="note_spacer">
                 <p i18n="magnetometerHelp"></p>
             </div>
         </div>
-        <div style="height: calc(100% - 150px);">
-            <div id="model">
-                <div class="model-and-info">
-                    <div id="interactive_block">
-                        <div id="canvas_wrapper">
-                            <canvas id="canvas"></canvas>
-                                <div class="attitude_info">
-                                <dl>
-                                    <dt>Heading:</dt>
-                                    <dd class="heading">&nbsp;</dd>
-                                    <dt>Pitch:</dt>
-                                    <dd class="pitch">&nbsp;</dd>
-                                    <dt>Roll:</dt>
-                                    <dd class="roll">&nbsp;</dd>
-                                </dl>
-                            </div>
-                            <div class="attitude_note1" >(Values according to <b>saved</b> settings)</div>
-                            <div class="attitude_note2" >(North: 0, East: 90, South: 180, West: 270)</div>
+        <div class="cf_column tab-magnetometer-left-wrapper">
+            <div class="model-and-info">
+                <div id="interactive_block">
+                    <div id="canvas_wrapper">
+                        <canvas id="canvas"></canvas>
+                            <div class="attitude_info">
+                            <dl>
+                                <dt>Heading:</dt>
+                                <dd class="heading">&nbsp;</dd>
+                                <dt>Pitch:</dt>
+                                <dd class="pitch">&nbsp;</dd>
+                                <dt>Roll:</dt>
+                                <dd class="roll">&nbsp;</dd>
+                            </dl>
                         </div>
+                        <div class="attitude_note1" >(Values according to <b>saved</b> settings)</div>
+                        <div class="attitude_note2" >(North: 0, East: 90, South: 180, West: 270)</div>
                     </div>
                 </div>
             </div>
         </div>
-        <div class="config-section gui_box grey">
-            <div class="spacer_box">
-                <div id="board-alignment-info" class="info-box">
-                    <span data-i18n="boardInfo"></span>
+        <div class="cf_column tab-magnetometer-right-wrapper">
+            <div class="config-section gui_box grey">
+                <div class="spacer_box">
+                    <div id="board-alignment-info" class="info-box">
+                        <span data-i18n="boardInfo"></span>
+                    </div>
+
+                    <table class="axis-table">
+                        <thead>
+                            <tr>
+                                <td style="width: 5%; padding-bottom: 10px;">
+                                    <p class="table-title">
+                                        <span data-i18n="axisTableTitleAxis"></span>
+                                    </p>
+                                </td>
+                                <td style="width: 90%; padding-bottom: 10px;">
+                                    <p class="table-title">
+                                        <span data-i18n="axisTableTitleSlider"></span>
+                                    </p>
+                                </td>
+                                <td style="width: 5%; padding-bottom: 10px;">
+                                    <a class="table-title">
+                                        <span data-i18n="axisTableTitleValue"></span>
+                                    </a>
+
+                                </td>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="info">
+                                    <p class="title" data-i18n="configurationSensorAlignmentMagRoll"></p>
+                                </td>
+                                <td>
+                                    <div id="board_roll_slider" class="slider"></div>
+                                </td>
+                                <td>
+                                    <input type="number" id="boardAlignRoll" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="info">
+                                    <p class="title" data-i18n="configurationSensorAlignmentMagPitch" style="margin: 5px"></p>
+                                </td>
+                                <td>
+                                    <div id="board_pitch_slider" class="slider"></div>
+                                </td>
+                                <td>
+                                    <input type="number" id="boardAlignPitch" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="info">
+                                    <p class="title" data-i18n="configurationSensorAlignmentMagYaw"></p>
+                                </td>
+                                <td>
+                                    <div id="board_yaw_slider" class="slider"></div>
+                                </td>
+                                <td>
+                                    <input type="number" id="boardAlignYaw" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
+            </div>
 
-                <table class="axis-table">
-                    <thead>
-                        <tr>
-                            <td style="width: 5%; padding-bottom: 10px;">
-                                <p class="table-title">
-                                    <span data-i18n="axisTableTitleAxis"></span>
-                                </p>
-                            </td>
-                            <td style="width: 90%; padding-bottom: 10px;">
-                                <p class="table-title">
-                                    <span data-i18n="axisTableTitleSlider"></span>
-                                </p>
-                            </td>
-                            <td style="width: 5%; padding-bottom: 10px;">
-                                <a class="table-title">
-                                    <span data-i18n="axisTableTitleValue"></span>
-                                </a>
+            <div class="config-section gui_box grey">
+                <div class="spacer_box">
+                    <div id="alignment-info" class="info-box">
+                        <span data-i18n="magnetometerInfo"></span>
+                    </div>
+                    <div class="select" style="display: flex; justify-content: left;">
+                        <select id="magalign" class="magalign">
+                            <option value="0">Default</option>
+                            <!-- list generated here -->
+                        </select>
+                        <label for="magalign" data-i18n="magnetometerOrientationPreset"></label>
+                    </div>
+                    <div class="select" style="display: flex; justify-content: left;">
+                        <select id="element_to_show">
+                            <option value="0" selected>Magnetometer</option>
+                            <option value="1">XYZ</option>
+                            <!-- list generated here -->
+                        </select>
+                        <label for="element_to_show" data-i18n="magnetometerElementToShow"></label>
+                    </div>
 
-                            </td>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td class="info">
-                                <p class="title" data-i18n="configurationSensorAlignmentMagRoll"></p>
-                            </td>
-                            <td>
-                                <div id="board_roll_slider" class="slider"></div>
-                            </td>
-                            <td>
-                                <input type="number" id="boardAlignRoll" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="info">
-                                <p class="title" data-i18n="configurationSensorAlignmentMagPitch"></p>
-                            </td>
-                            <td>
-                                <div id="board_pitch_slider" class="slider"></div>
-                            </td>
-                            <td>
-                                <input type="number" id="boardAlignPitch" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="info">
-                                <p class="title" data-i18n="configurationSensorAlignmentMagYaw"></p>
-                            </td>
-                            <td>
-                                <div id="board_yaw_slider" class="slider"></div>
-                            </td>
-                            <td>
-                                <input type="number" id="boardAlignYaw" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+                    <table class="axis-table">
+                        <thead>
+                            <tr>
+                                <td style="width: 5%; padding-bottom: 10px;">
+                                    <p class="table-title">
+                                        <span data-i18n="axisTableTitleAxis"></span>
+                                    </p>
+                                </td>
+                                <td style="width: 90%; padding-bottom: 10px;">
+                                    <p class="table-title">
+                                        <span data-i18n="axisTableTitleSlider"></span>
+                                    </p>
+                                </td>
+                                <td style="width: 5%; padding-bottom: 10px;">
+                                    <a class="table-title">
+                                        <span data-i18n="axisTableTitleValue"></span>
+                                    </a>
+
+                                </td>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="info">
+                                    <p class="title" data-i18n="configurationSensorAlignmentMagRoll"></p>
+                                </td>
+                                <td>
+                                    <div id="roll_slider" class="slider"></div>
+                                </td>
+                                <td>
+                                    <input type="number" id="alignRoll" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="info">
+                                    <p class="title" data-i18n="configurationSensorAlignmentMagPitch" style="margin: 5px"></p>
+                                </td>
+                                <td>
+                                    <div id="pitch_slider" class="slider"></div>
+                                </td>
+                                <td>
+                                    <input type="number" id="alignPitch" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="info">
+                                    <p class="title" data-i18n="configurationSensorAlignmentMagYaw"></p>
+                                </td>
+                                <td>
+                                    <div id="yaw_slider" class="slider"></div>
+                                </td>
+                                <td>
+                                    <input type="number" id="alignYaw" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
-
-        <div class="config-section gui_box grey">
-            <div class="spacer_box">
-                <div id="alignment-info" class="info-box">
-                    <span data-i18n="magnetometerInfo"></span>
-                </div>
-                <div class="select" style="display: flex; justify-content: left;">
-                    <select id="magalign" class="magalign">
-                        <option value="0">Default</option>
-                        <!-- list generated here -->
-                    </select>
-                    <label for="magalign" data-i18n="magnetometerOrientationPreset"></label>
-                </div>
-                <div class="select" style="display: flex; justify-content: left;">
-                    <select id="element_to_show">
-                        <option value="0" selected>Magnetometer</option>
-                        <option value="1">XYZ</option>
-                        <!-- list generated here -->
-                    </select>
-                    <label for="element_to_show" data-i18n="magnetometerElementToShow"></label>
-                </div>
-
-                <table class="axis-table">
-                    <thead>
-                        <tr>
-                            <td style="width: 5%; padding-bottom: 10px;">
-                                <p class="table-title">
-                                    <span data-i18n="axisTableTitleAxis"></span>
-                                </p>
-                            </td>
-                            <td style="width: 90%; padding-bottom: 10px;">
-                                <p class="table-title">
-                                    <span data-i18n="axisTableTitleSlider"></span>
-                                </p>
-                            </td>
-                            <td style="width: 5%; padding-bottom: 10px;">
-                                <a class="table-title">
-                                    <span data-i18n="axisTableTitleValue"></span>
-                                </a>
-
-                            </td>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td class="info">
-                                <p class="title" data-i18n="configurationSensorAlignmentMagRoll"></p>
-                            </td>
-                            <td>
-                                <div id="roll_slider" class="slider"></div>
-                            </td>
-                            <td>
-                                <input type="number" id="alignRoll" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="info">
-                                <p class="title" data-i18n="configurationSensorAlignmentMagPitch"></p>
-                            </td>
-                            <td>
-                                <div id="pitch_slider" class="slider"></div>
-                            </td>
-                            <td>
-                                <input type="number" id="alignPitch" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="info">
-                                <p class="title" data-i18n="configurationSensorAlignmentMagYaw"></p>
-                            </td>
-                            <td>
-                                <div id="yaw_slider" class="slider"></div>
-                            </td>
-                            <td>
-                                <input type="number" id="alignYaw" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        <div class="content_toolbar">
-            <div class="btn save_btn">
-                <a class="save" href="#" data-i18n="configurationButtonSave"></a>
-            </div>
+        <div class="clear-both"></div>
+    </div>
+    <div class="content_toolbar supported hide">
+        <div class="btn save_btn">
+            <a class="save" href="#" data-i18n="configurationButtonSave"></a>
         </div>
     </div>
+
 </div>
 
 <div id="tab-auxiliary-templates">

--- a/tabs/magnetometer.html
+++ b/tabs/magnetometer.html
@@ -12,8 +12,19 @@
                     <div id="interactive_block">
                         <div id="canvas_wrapper">
                             <canvas id="canvas"></canvas>
+                                <div class="attitude_info">
+                                <dl>
+                                    <dt>Heading:</dt>
+                                    <dd class="heading">&nbsp;</dd>
+                                    <dt>Pitch:</dt>
+                                    <dd class="pitch">&nbsp;</dd>
+                                    <dt>Roll:</dt>
+                                    <dd class="roll">&nbsp;</dd>
+                                </dl>
+                            </div>
+                            <div class="attitude_note1" >(Values according to <b>saved</b> settings)</div>
+                            <div class="attitude_note2" >(North: 0, East: 90, South: 180, West: 270)</div>
                         </div>
-                        <a class="reset" href="#" data-i18n="initialSetupButtonResetZaxis"></a>
                     </div>
                 </div>
             </div>

--- a/tabs/magnetometer.html
+++ b/tabs/magnetometer.html
@@ -20,6 +20,72 @@
         </div>
         <div class="config-section gui_box grey">
             <div class="spacer_box">
+                <div id="board-alignment-info" class="info-box">
+                    <span data-i18n="boardInfo"></span>
+                </div>
+
+                <table class="axis-table">
+                    <thead>
+                        <tr>
+                            <td style="width: 5%; padding-bottom: 10px;">
+                                <p class="table-title">
+                                    <span data-i18n="axisTableTitleAxis"></span>
+                                </p>
+                            </td>
+                            <td style="width: 90%; padding-bottom: 10px;">
+                                <p class="table-title">
+                                    <span data-i18n="axisTableTitleSlider"></span>
+                                </p>
+                            </td>
+                            <td style="width: 5%; padding-bottom: 10px;">
+                                <a class="table-title">
+                                    <span data-i18n="axisTableTitleValue"></span>
+                                </a>
+
+                            </td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="info">
+                                <p class="title" data-i18n="configurationSensorAlignmentMagPitch"></p>
+                            </td>
+                            <td>
+                                <div id="board_roll_slider" class="slider"></div>
+                            </td>
+                            <td>
+                                <input type="number" id="boardAlignRoll" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="info">
+                                <p class="title" data-i18n="configurationSensorAlignmentMagRoll"></p>
+                            </td>
+                            <td>
+                                <div id="board_pitch_slider" class="slider"></div>
+                            </td>
+                            <td>
+                                <input type="number" id="boardAlignPitch" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="info">
+                                <p class="title" data-i18n="configurationSensorAlignmentMagYaw"></p>
+                            </td>
+                            <td>
+                                <div id="board_yaw_slider" class="slider"></div>
+                            </td>
+                            <td>
+                                <input type="number" id="boardAlignYaw" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="config-section gui_box grey">
+            <div class="spacer_box">
                 <div id="alignment-info" class="info-box">
                     <span data-i18n="magnetometerInfo"></span>
                 </div>
@@ -69,7 +135,7 @@
                                 <div id="roll_slider" class="slider"></div>
                             </td>
                             <td>
-                                <input type="number" id="alignRoll" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="180" />
+                                <input type="number" id="alignRoll" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
                             </td>
                         </tr>
                         <tr>
@@ -80,7 +146,7 @@
                                 <div id="pitch_slider" class="slider"></div>
                             </td>
                             <td>
-                                <input type="number" id="alignPitch" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="180" />
+                                <input type="number" id="alignPitch" class="tab-magnetometer" data-setting="tz_offset" data-setting-multiplier="1" step="1" min="-180" max="360" />
                             </td>
                         </tr>
                         <tr>

--- a/tabs/magnetometer.js
+++ b/tabs/magnetometer.js
@@ -50,7 +50,7 @@ TABS.magnetometer.initialize = function (callback) {
         },
         function (callback) {
             mspHelper.getSetting("align_mag_pitch").then(function (data) {
-                self.alignmentConfig.pitch = (parseInt(data.value, 10) / 10) - 180;
+                self.alignmentConfig.pitch = parseInt(data.value, 10) / 10;
             }).then(callback)
         },
         function (callback) {
@@ -65,7 +65,7 @@ TABS.magnetometer.initialize = function (callback) {
     loadChainer.execute();
 
     function areAnglesZero() {
-        return self.alignmentConfig.pitch === -180 && self.alignmentConfig.roll === 0 && self.alignmentConfig.yaw === 0
+        return self.alignmentConfig.pitch === 0 && self.alignmentConfig.roll === 0 && self.alignmentConfig.yaw === 0
     }
 
     function isBoardAlignmentZero() {
@@ -104,7 +104,7 @@ TABS.magnetometer.initialize = function (callback) {
             if (self.isSavePreset)
                 mspHelper.setSetting("align_mag_pitch", 0, callback);
             else
-                mspHelper.setSetting("align_mag_pitch", (180 + self.alignmentConfig.pitch) * 10, callback);
+                mspHelper.setSetting("align_mag_pitch", self.alignmentConfig.pitch * 10, callback);
 
         },
         function (callback) {
@@ -151,7 +151,8 @@ TABS.magnetometer.initialize = function (callback) {
     }
 
     function toUpperRange(input, max) {
-        while (input + 360 <= max) input +=360;
+        while (input > max) input -= 360;
+        while (input + 360 <= max) input += 360;
         return input;
     }
 
@@ -163,23 +164,23 @@ TABS.magnetometer.initialize = function (callback) {
         //pitch, roll, yaw
         switch (selectedPreset) {
             case 1: //CW0_DEG = 1
-                return [180, 0, 0];
-            case 2: //CW90_DEG = 2
-                return [180, 0, 90];
-            case 3: //CW180_DEG = 3
-                return [180, 0, 180];
-            case 4: //CW270_DEG = 4
-                return [180, 0, 270];
-            case 5: //CW0_DEG_FLIP = 5
                 return [0, 0, 0];
-            case 6: //CW90_DEG_FLIP = 5
+            case 2: //CW90_DEG = 2
                 return [0, 0, 90];
-            case 7: //CW180_DEG_FLIP = 5
+            case 3: //CW180_DEG = 3
                 return [0, 0, 180];
+            case 4: //CW270_DEG = 4
+                return [0, 0, 270];
+            case 5: //CW0_DEG_FLIP = 5
+                return [180, 0, 0];
+            case 6: //CW90_DEG_FLIP = 5
+                return [180, 0, 90];
+            case 7: //CW180_DEG_FLIP = 5
+                return [180, 0, 180];
             case 0: //ALIGN_DEFAULT = 0
             case 8: //CW270_DEG_FLIP = 5
             default://If not recognized, returns defualt
-                return [0, 0, 270];
+                return [180, 0, 270];
         }
     }
 
@@ -193,8 +194,8 @@ TABS.magnetometer.initialize = function (callback) {
         //degree[0] - pitch
         //degree[1] - roll
         //degree[2] - yaw
-        //-pitch, -180 - yaw, roll
-        var magRotation = new THREE.Euler(-THREE.Math.degToRad(degree[0]), THREE.Math.degToRad(-180 - degree[2]), THREE.Math.degToRad(degree[1]), 'YXZ'); 
+        //-(pitch-180), -180 - yaw, roll
+        var magRotation = new THREE.Euler(-THREE.Math.degToRad(degree[0]-180), THREE.Math.degToRad(-180 - degree[2]), THREE.Math.degToRad(degree[1]), 'YXZ'); 
         var matrix = (new THREE.Matrix4()).makeRotationFromEuler(magRotation);
 
         var boardRotation = new THREE.Euler( THREE.Math.degToRad( -self.boardAlignmentConfig.pitch ), THREE.Math.degToRad( -self.boardAlignmentConfig.yaw ), THREE.Math.degToRad( -self.boardAlignmentConfig.roll ), 'YXZ');
@@ -205,7 +206,7 @@ TABS.magnetometer.initialize = function (callback) {
         var euler = new THREE.Euler();
         euler.setFromRotationMatrix(matrix, 'YXZ');
 
-        var pitch = toUpperRange( Math.round( THREE.Math.radToDeg(-euler.x)), 180 );
+        var pitch = toUpperRange( Math.round( THREE.Math.radToDeg(-euler.x)) + 180, 180 );
         var yaw = toUpperRange( Math.round( -180 - THREE.Math.radToDeg(euler.y)), 359 );
         var roll = toUpperRange( Math.round( THREE.Math.radToDeg(euler.z)), 180 );
 
@@ -577,7 +578,7 @@ TABS.magnetometer.initialize3D = function () {
         xyz.visible = !self.showMagnetometer;
         fc.visible = true;
 
-        var magRotation = new THREE.Euler(-THREE.Math.degToRad(self.alignmentConfig.pitch), THREE.Math.degToRad(-180 - self.alignmentConfig.yaw), THREE.Math.degToRad(self.alignmentConfig.roll), 'YXZ'); 
+        var magRotation = new THREE.Euler(-THREE.Math.degToRad(self.alignmentConfig.pitch-180), THREE.Math.degToRad(-180 - self.alignmentConfig.yaw), THREE.Math.degToRad(self.alignmentConfig.roll), 'YXZ'); 
         var matrix = (new THREE.Matrix4()).makeRotationFromEuler(magRotation);
 
         var boardRotation = new THREE.Euler( THREE.Math.degToRad( -self.boardAlignmentConfig.pitch ), THREE.Math.degToRad( -self.boardAlignmentConfig.yaw ), THREE.Math.degToRad( -self.boardAlignmentConfig.roll ), 'YXZ');

--- a/tabs/magnetometer.js
+++ b/tabs/magnetometer.js
@@ -1,5 +1,5 @@
 'use strict';
-/*global chrome,GUI,BOARD_ALIGNMENT,TABS,nwdialog,$*/
+/*global chrome,GUI,BOARD_ALIGNMENT,TABS,nwdialog,helper,$*/
 
 TABS.magnetometer = {};
 
@@ -314,6 +314,10 @@ TABS.magnetometer.initialize = function (callback) {
         self.pageElements.pitch_slider = $('#pitch_slider');
         self.pageElements.yaw_slider = $('#yaw_slider');
 
+        self.roll_e = $('dd.roll'),
+        self.pitch_e = $('dd.pitch'),
+        self.heading_e = $('dd.heading');
+
         for (i = 0; i < alignments.length; i++) {
             self.pageElements.orientation_mag_e.append('<option value="' + (i + 1) + '">' + alignments[i] + '</option>');
         }
@@ -507,6 +511,21 @@ TABS.magnetometer.initialize = function (callback) {
         self.pageElements.yaw_slider.on('slide', (e) => {
             disableSavePreset();
         });
+
+        function get_fast_data() {
+            if (helper.mspQueue.shouldDrop()) {
+                return;
+            }
+
+            MSP.send_message(MSPCodes.MSP_ATTITUDE, false, false, function () {
+	            self.roll_e.text(chrome.i18n.getMessage('initialSetupAttitude', [SENSOR_DATA.kinematics[0]]));
+	            self.pitch_e.text(chrome.i18n.getMessage('initialSetupAttitude', [SENSOR_DATA.kinematics[1]]));
+                self.heading_e.text(chrome.i18n.getMessage('initialSetupAttitude', [SENSOR_DATA.kinematics[2]]));
+                self.render3D();
+            });
+        }
+
+        helper.mspBalancedInterval.add('setup_data_pull_fast', 40, 1, get_fast_data);
 
         GUI.content_ready(callback);
     }


### PR DESCRIPTION
I hope now alignment tool works correctly and is  clear for the user.

![image](https://github.com/iNavFlight/inav-configurator/assets/11955117/efd71308-cade-4182-983d-2085576d2046)


1) Removed board yaw and magnetometer alignment preset from Configuration tab
2) Renamed Magnetometer alignment tab to Alignment tool
3) Added board alignment roll, pitch, yaw sliders to Aligmnent tool tab
4) Fixed multiple bugs related to roll/pitch/yaw magnetometer orientation
5) Align_mag preset is relative to FC, but alignment_mag_roll/pitch/yaw are NOT!
6) Clear indication which settings are used: align_mag or align_mag_xxx
7) Align_mag_xxx are caclulated from preset + FC orientation, allowing to switch from preset to explicit angles easily