### PR TITLE
Add HUD settings to OSD tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3431,12 +3431,42 @@
     "osd_hud_radar_disp_help": {
         "message": "This is used for INAV Radar/FormationFlight. 0 disables this feature."
     },
+
+    "osd_hud_radar_range_min": {
+        "message": "Minimum radar range"
+    },
+    "osd_hud_radar_range_min_help": {
+        "message": "Radar aircrafts closer than this will not be displayed in the HUD."
+    },
+
+    "osd_hud_radar_range_max": {
+        "message": "Maximum radar range"
+    },
+    "osd_hud_radar_range_max_help": {
+        "message": "Radar aircrafts further away than this will not be displayed in the HUD."
+    },
+
+
     "osd_hud_wp_disp": {
         "message": "Maximum number of waypoint elements on screen."
     },
     "osd_hud_wp_disp_help": {
         "message": "Number of Wayponts to show on screen. 0 disables this feature."
     },
+    "osd_camera_fov_h": {
+        "message": "Camera Horizontal FOV"
+    },
+    "osd_camera_fov_h_help": {
+        "message": "Camera Horizontal Field of View in Degrees. It is used to calculate the position of elements in the HUD display."
+    },
+    "osd_camera_fov_v": {
+        "message": "Camera Vertical FOV"
+    },
+    "osd_camera_fov_v_help": {
+        "message": "Camera Vertical Field of View in Degrees. It is used to calculate the position of elements in the HUD display."
+    },
+
+
     "osd_alarms": {
         "message": "Alarms"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3419,8 +3419,23 @@
     "osd_home_position_arm_screen": {
         "message": "Home Position on Arming Screen"
     },
+    "osd_hud_settings": {
+        "message": "Heads up Display settings"
+    },
+    "osd_hud_settings_HELP": {
+        "message": "This section allows tweaking the behavior of HUD elements."
+    },
     "osd_hud_radar_disp": {
-        "message": "Maximum number of radar elements on screen. 0 to disable."
+        "message": "Maximum number of radar elements on screen."
+    },
+    "osd_hud_radar_disp_help": {
+        "message": "This is used for INAV Radar/FormationFlight. 0 disables this feature."
+    },
+    "osd_hud_wp_disp": {
+        "message": "Maximum number of waypoint elements on screen."
+    },
+    "osd_hud_wp_disp_help": {
+        "message": "Number of Wayponts to show on screen. 0 disables this feature."
     },
     "osd_alarms": {
         "message": "Alarms"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3419,6 +3419,9 @@
     "osd_home_position_arm_screen": {
         "message": "Home Position on Arming Screen"
     },
+    "osd_hud_radar_disp": {
+        "message": "Maximum number of radar elements on screen. 0 to disable."
+    },
     "osd_alarms": {
         "message": "Alarms"
     },

--- a/tabs/osd.html
+++ b/tabs/osd.html
@@ -140,6 +140,10 @@
                                 <input type="checkbox" class="toggle update_preview" data-setting="osd_home_position_arm_screen" data-live="true">
                                 <span data-i18n="osd_home_position_arm_screen"></span>
                             </label>
+                            <label>
+                                <input type="number" data-step="1" data-setting-multiplier="1" data-setting="osd_hud_radar_disp" class="toggle update_preview" data-setting="osd_home_position_arm_screen" data-live="true">
+                                <span data-i18n="osd_hud_radar_disp"></span>
+                            </label>
                         </div>
                     </div>
                 </div>

--- a/tabs/osd.html
+++ b/tabs/osd.html
@@ -353,16 +353,40 @@
                                 <select class="update_preview" id="osd_horizon_offset" data-setting="osd_horizon_offset" data-setting-invert-select="true" data-live="true"></select>
                                 <span data-i18n="osd_horizon_offset"></span>
                             </label>
-                            <div for="osd_hud_radar_disp" class="helpicon cf_tip" data-i18n_title="osd_hud_radar_disp_help"></div>
-                            <label>
-                                <input type="number" data-step="1" data-setting-multiplier="1" data-setting="osd_hud_radar_disp" class="toggle update_preview" data-live="true">
-                                <span data-i18n="osd_hud_radar_disp"></span>
-                            </label>
                             <div for="osd_hud_wp_disp" class="helpicon cf_tip" data-i18n_title="osd_hud_wp_disp_help"></div>
                             <label>
                                 <input type="number" data-step="1" data-setting-multiplier="1" data-setting="osd_hud_wp_disp" class="toggle update_preview" data-live="true">
                                 <span data-i18n="osd_hud_wp_disp"></span>
                             </label>
+                            <div for="osd_hud_radar_disp" class="helpicon cf_tip" data-i18n_title="osd_hud_radar_disp_help"></div>
+                            <label>
+                                <input type="number" data-step="1" data-setting-multiplier="1" data-setting="osd_hud_radar_disp" class="toggle update_preview" data-live="true">
+                                <span data-i18n="osd_hud_radar_disp"></span>
+                            </label>
+
+                            <div for="osd_hud_radar_range_min" class="helpicon cf_tip" data-i18n_title="osd_hud_radar_range_min_help"></div>
+                            <label>
+                                <input type="number" data-step="1" data-unit="m" data-setting-multiplier="1" data-setting="osd_hud_radar_range_min" class="toggle update_preview" data-live="true">
+                                <span data-i18n="osd_hud_radar_range_min"></span>
+                            </label>
+                            <div for="osd_hud_radar_range_max" class="helpicon cf_tip" data-i18n_title="osd_hud_radar_range_max_help"></div>
+                            <label>
+                                <input type="number" data-step="1" data-unit="m" data-setting-multiplier="1" data-setting="osd_hud_radar_range_max" class="toggle update_preview" data-live="true">
+                                <span data-i18n="osd_hud_radar_range_max"></span>
+                            </label>
+
+                            <div for="osd_camera_fov_h" class="helpicon cf_tip" data-i18n_title="osd_camera_fov_h_help"></div>
+                            <label>
+                                <input type="number" data-step="1" data-setting-multiplier="1" data-setting="osd_camera_fov_h" class="toggle update_preview" data-live="true">
+                                <span data-i18n="osd_camera_fov_h"></span>
+                            </label>
+                            <div for="osd_camera_fov_v" class="helpicon cf_tip" data-i18n_title="osd_camera_fov_v_help"></div>
+                            <label>
+                                <input type="number" data-step="1" data-setting-multiplier="1" data-setting="osd_camera_fov_v" class="toggle update_preview" data-live="true">
+                                <span data-i18n="osd_camera_fov_v"></span>
+                            </label>
+
+
                         </div>
                     </div>
                 </div>

--- a/tabs/osd.html
+++ b/tabs/osd.html
@@ -114,11 +114,6 @@
                                 <select class="update_preview" data-setting="osd_crosshairs_style" data-live="true"></select>
                                 <span data-i18n="osd_crosshairs_style"></span>
                             </label>
-                            <div for="osd_horizon_offset" class="helpicon cf_tip" data-i18n_title="osd_horizon_offset_help"></div>
-                            <label>
-                                <select class="update_preview" id="osd_horizon_offset" data-setting="osd_horizon_offset" data-setting-invert-select="true" data-live="true"></select>
-                                <span data-i18n="osd_horizon_offset"></span>
-                            </label>
                             <label>
                                 <select class="update_preview" data-setting="osd_left_sidebar_scroll" data-live="true"></select>
                                 <span data-i18n="osd_left_sidebar_scroll"></span>
@@ -139,10 +134,6 @@
                             <label>
                                 <input type="checkbox" class="toggle update_preview" data-setting="osd_home_position_arm_screen" data-live="true">
                                 <span data-i18n="osd_home_position_arm_screen"></span>
-                            </label>
-                            <label>
-                                <input type="number" data-step="1" data-setting-multiplier="1" data-setting="osd_hud_radar_disp" class="toggle update_preview" data-setting="osd_home_position_arm_screen" data-live="true">
-                                <span data-i18n="osd_hud_radar_disp"></span>
                             </label>
                         </div>
                     </div>
@@ -350,6 +341,32 @@
                         </div>
                     </div>
                 </div>
+                <div class="gui_box grey hud-settings-container"> 
+                    <div class="gui_box_titlebar">
+                        <div for="osd_hud_settings" class="helpicon cf_tip" data-i18n_title="osd_hud_settings_HELP"></div>
+                        <div class="spacer_box_title" data-i18n="osd_hud_settings"></div>
+                    </div>
+                    <div class="spacer_box settings">
+                        <div id="osd_hud_settings">
+                            <div for="osd_horizon_offset" class="helpicon cf_tip" data-i18n_title="osd_horizon_offset_help"></div>
+                            <label>
+                                <select class="update_preview" id="osd_horizon_offset" data-setting="osd_horizon_offset" data-setting-invert-select="true" data-live="true"></select>
+                                <span data-i18n="osd_horizon_offset"></span>
+                            </label>
+                            <div for="osd_hud_radar_disp" class="helpicon cf_tip" data-i18n_title="osd_hud_radar_disp_help"></div>
+                            <label>
+                                <input type="number" data-step="1" data-setting-multiplier="1" data-setting="osd_hud_radar_disp" class="toggle update_preview" data-live="true">
+                                <span data-i18n="osd_hud_radar_disp"></span>
+                            </label>
+                            <div for="osd_hud_wp_disp" class="helpicon cf_tip" data-i18n_title="osd_hud_wp_disp_help"></div>
+                            <label>
+                                <input type="number" data-step="1" data-setting-multiplier="1" data-setting="osd_hud_wp_disp" class="toggle update_preview" data-live="true">
+                                <span data-i18n="osd_hud_wp_disp"></span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
             </div>
             <div id="fontmanagercontent" style="display:none; width:712px;">
                 <div class="font-picker" style="margin-bottom: 10px;">


### PR DESCRIPTION
INAV radar may soon get a poppulary boost as  https://github.com/FormationFlight/FormationFlight enables ExpressLRS receiver hardware to work as INAV radar unit, and ExpressLRS may also soon include radar support https://github.com/ExpressLRS/ExpressLRS/pull/2270. There is also work to add support for it in both Ardupilot (https://github.com/MUSTARDTIGERFPV/ardupilot) and 
Betaflight (https://github.com/MUSTARDTIGERFPV/Betaflight).

Currently, setup requires the user to both enable the Crosshair on the osd, as well as use the cli to to allow more than 0 radar elements on the OSD and tweak other parameters.

This pull request will add HUD settings section to the OSD tab with the options most likely to be used for a new setup.

![image](https://github.com/iNavFlight/inav-configurator/assets/23555060/a033c0ac-a766-4a26-8fc1-6eede20a899c)

