### PR TITLE
Smarter pwm timer allocation, configurator changes

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -5474,5 +5474,8 @@
     },
     "targetPrefetchFailNoPort": {
         "message": "Cannot prefetch target: No port"
+    },
+    "timerOutputs": {
+        "message": "Timer outputs"
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -4491,7 +4491,7 @@
         "message": "This will reset all PID settings to firmware default values and save.\nDo you want to continue?"
     },
     "mappingTableOutput": {
-        "message": "Output"
+        "message": "Output (timer)"
     },
     "mappingTableFunction": {
         "message": "Function"

--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -180,6 +180,9 @@ var MSPCodes = {
     MSPV2_INAV_SET_RATE_PROFILE:        0x2008,
     MSPV2_INAV_AIR_SPEED:               0x2009,
     MSPV2_INAV_OUTPUT_MAPPING:          0x200A,
+    MSP2_INAV_MC_BRAKING:               0x200B,
+    MSP2_INAV_SET_MC_BRAKING:           0x200C,
+    MSPV2_INAV_OUTPUT_MAPPING_EXT:      0x200D,
 
     MSP2_INAV_MIXER:                    0x2010,
     MSP2_INAV_SET_MIXER:                0x2011,
@@ -190,9 +193,6 @@ var MSPCodes = {
     MSP2_INAV_OSD_SET_ALARMS:           0x2015,
     MSP2_INAV_OSD_PREFERENCES:          0x2016,
     MSP2_INAV_OSD_SET_PREFERENCES:      0x2017,
-
-    MSP2_INAV_MC_BRAKING:               0x200B,
-    MSP2_INAV_SET_MC_BRAKING:           0x200C,
 
     MSP2_INAV_SELECT_BATTERY_PROFILE:   0x2018,
 
@@ -216,6 +216,7 @@ var MSPCodes = {
     MSP2_INAV_PROGRAMMING_PID:          0x2028,
     MSP2_INAV_SET_PROGRAMMING_PID:      0x2029,
     MSP2_INAV_PROGRAMMING_PID_STATUS:   0x202A,
+
 
     MSP2_PID:                           0x2030,
     MSP2_SET_PID:                       0x2031,

--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -183,6 +183,8 @@ var MSPCodes = {
     MSP2_INAV_MC_BRAKING:               0x200B,
     MSP2_INAV_SET_MC_BRAKING:           0x200C,
     MSPV2_INAV_OUTPUT_MAPPING_EXT:      0x200D,
+    MSP2_INAV_TIMER_OUTPUT_MODE:        0x200E,
+    MSP2_INAV_SET_TIMER_OUTPUT_MODE:    0x200F,
 
     MSP2_INAV_MIXER:                    0x2010,
     MSP2_INAV_SET_MIXER:                0x2011,

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1482,8 +1482,25 @@ var mspHelper = (function (gui) {
             case MSPCodes.MSPV2_INAV_OUTPUT_MAPPING:
                 OUTPUT_MAPPING.flush();
                 for (i = 0; i < data.byteLength; ++i)
-                    OUTPUT_MAPPING.put(data.getUint8(i));
+                    OUTPUT_MAPPING.put({
+                        'timerId': i,
+                        'usageFlags': data.getUint8(i)});
                 break;
+
+            case MSPCodes.MSPV2_INAV_OUTPUT_MAPPING_EXT:
+                OUTPUT_MAPPING.flush();
+                for (i = 0; i < data.byteLength; i += 2) {
+                    timerId = data.getUint8(i);
+                    usageFlags = data.getUint8(i + 1);
+                    OUTPUT_MAPPING.put(
+                        {
+                            'timerId': timerId,
+                            'usageFlags': usageFlags
+                        });
+                }
+                break;
+
+
 
             case MSPCodes.MSP2_INAV_MC_BRAKING:
                 try {
@@ -2818,6 +2835,10 @@ var mspHelper = (function (gui) {
 
     self.loadOutputMapping = function (callback) {
         MSP.send_message(MSPCodes.MSPV2_INAV_OUTPUT_MAPPING, false, false, callback);
+    };
+
+    self.loadOutputMappingExt = function (callback) {
+        MSP.send_message(MSPCodes.MSPV2_INAV_OUTPUT_MAPPING_EXT, false, false, callback);
     };
 
     self.loadBatteryConfig = function (callback) {

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1486,7 +1486,6 @@ var mspHelper = (function (gui) {
                         'timerId': i,
                         'usageFlags': data.getUint8(i)});
                 break;
-
             case MSPCodes.MSPV2_INAV_OUTPUT_MAPPING_EXT:
                 OUTPUT_MAPPING.flush();
                 for (i = 0; i < data.byteLength; i += 2) {
@@ -1500,7 +1499,7 @@ var mspHelper = (function (gui) {
                 }
                 break;
             
-            case MSPCodes.MSPV2_INAV_TIMER_OUTPUT_MODE:
+            case MSPCodes.MSP2_INAV_TIMER_OUTPUT_MODE:
                 if(data.byteLength > 2) {
                     OUTPUT_MAPPING.flushTimerOverrides();
                 }
@@ -2851,17 +2850,16 @@ var mspHelper = (function (gui) {
     };
 
     self.loadTimerOutputModes = function(callback) {
-        MSP.send_message(MSPCodes.MSPV2_INAV_TIMER_OUTPUT_MODE, false, false, callback);
+        MSP.send_message(MSPCodes.MSP2_INAV_TIMER_OUTPUT_MODE, false, false, callback);
     }
 
     self.sendTimerOutputModes = function(callback) {
         var nextFunction = send_next_output_mode;
-
         var idIndex = 0;
 
-        var overrideIds = OUTPUT_MAPPING.getTimerOverrideIds();
+        var overrideIds = OUTPUT_MAPPING.getUsedTimerIds();
 
-        if (MODE_RANGES.length == 0) {
+        if (overrideIds.length == 0) {
             onCompleteCallback();
         } else {
             send_next_output_mode();
@@ -2871,7 +2869,7 @@ var mspHelper = (function (gui) {
 
             var timerId = overrideIds[idIndex];
 
-            var ouputMode = OUTPUT_MAPPING.getTimerOverride(timerId);
+            var outputMode = OUTPUT_MAPPING.getTimerOverride(timerId);
 
             var buffer = [];
             buffer.push(timerId);
@@ -2880,7 +2878,7 @@ var mspHelper = (function (gui) {
             // prepare for next iteration
             idIndex++;
             if (idIndex == overrideIds.length) {
-                nextFunction = onCompleteCallback;
+                nextFunction = callback;
 
             }
             MSP.send_message(MSPCodes.MSP2_INAV_SET_TIMER_OUTPUT_MODE, buffer, false, nextFunction);

--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -3,7 +3,8 @@
 
 let OutputMappingCollection = function () {
     let self = {},
-        data = [];
+        data = [],
+        timerOverrides = {};
 
     const TIM_USE_ANY = 0;
     const TIM_USE_PPM = 0;
@@ -18,6 +19,26 @@ let OutputMappingCollection = function () {
 
     const OUTPUT_TYPE_MOTOR = 0;
     const OUTPUT_TYPE_SERVO = 1;
+
+    const TIMER_OUTPUT_MODE_AUTO = 0;
+    const TIMER_OUTPUT_MODE_MOTORS = 1;
+    const TIMER_OUTPUT_MODE_SERVOS = 2;
+
+    self.flushTimerOverrides = function() {
+        timerOverrides = {};
+    }
+
+    self.setTimerOverride = function (timer, outputMode) {
+        timerOverrides[timer] = outputMode;
+    }
+
+    self.getTimerOverride = function (timer) {
+        timerOverrides[timer] = outputMode;
+    }
+
+    self.getTimerOverrideIds = function (timer) {
+        return Object.keys(timerOverrides).sort((a, b) => a - b);
+    }
 
     function getTimerMap(isMR, motors, servos) {
         let timerMap = [],

--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -31,20 +31,19 @@ let OutputMappingCollection = function () {
                 if (servosToGo > 0 && bit_check(data[i], TIM_USE_MC_SERVO)) {
                     servosToGo--;
                     timerMap[i] = OUTPUT_TYPE_SERVO;
-                } else if (motorsToGo > 0 && bit_check(data[i], TIM_USE_MC_MOTOR)) {
+                } else if (motorsToGo > 0 && bit_check(data[i]['usageFlags'], TIM_USE_MC_MOTOR)) {
                     motorsToGo--;
                     timerMap[i] = OUTPUT_TYPE_MOTOR;
                 }
             } else {
-                if (servosToGo > 0 && bit_check(data[i], TIM_USE_FW_SERVO)) {
+                if (servosToGo > 0 && bit_check(data[i]['usageFlags'], TIM_USE_FW_SERVO)) {
                     servosToGo--;
                     timerMap[i] = OUTPUT_TYPE_SERVO;
-                } else if (motorsToGo > 0 && bit_check(data[i], TIM_USE_FW_MOTOR)) {
+                } else if (motorsToGo > 0 && bit_check(data[i]['usageFlags'], TIM_USE_FW_MOTOR)) {
                     motorsToGo--;
                     timerMap[i] = OUTPUT_TYPE_MOTOR;
                 }
             }
-
         }
 
         return timerMap;
@@ -89,10 +88,10 @@ let OutputMappingCollection = function () {
 
         for (let i = 0; i < data.length; i++) {
             if (
-                bit_check(data[i], TIM_USE_MC_MOTOR) ||
-                bit_check(data[i], TIM_USE_MC_SERVO) ||
-                bit_check(data[i], TIM_USE_FW_MOTOR) ||
-                bit_check(data[i], TIM_USE_FW_SERVO)
+                bit_check(data[i]['usageFlags'], TIM_USE_MC_MOTOR) ||
+                bit_check(data[i]['usageFlags'], TIM_USE_MC_SERVO) ||
+                bit_check(data[i]['usageFlags'], TIM_USE_FW_MOTOR) ||
+                bit_check(data[i]['usageFlags'], TIM_USE_FW_SERVO)
             ) {
                 retVal++;
             };
@@ -104,15 +103,19 @@ let OutputMappingCollection = function () {
     function getFirstOutputOffset() {
         for (let i = 0; i < data.length; i++) {
             if (
-                bit_check(data[i], TIM_USE_MC_MOTOR) ||
-                bit_check(data[i], TIM_USE_MC_SERVO) ||
-                bit_check(data[i], TIM_USE_FW_MOTOR) ||
-                bit_check(data[i], TIM_USE_FW_SERVO)
+                bit_check(data[i]['usageFlags'], TIM_USE_MC_MOTOR) ||
+                bit_check(data[i]['usageFlags'], TIM_USE_MC_SERVO) ||
+                bit_check(data[i]['usageFlags'], TIM_USE_FW_MOTOR) ||
+                bit_check(data[i]['usageFlags'], TIM_USE_FW_SERVO)
             ) {
                 return i;
             }
         }
         return 0;
+    }
+
+    function getTimerId(outputIndex) {
+        return data[outputIndex]['timerId'];
     }
 
     function getOutput(servoIndex, bit) {
@@ -122,7 +125,7 @@ let OutputMappingCollection = function () {
         let lastFound = 0;
 
         for (let i = offset; i < data.length; i++) {
-            if (bit_check(data[i], bit)) {
+            if (bit_check(data[i]['usageFlags'], bit)) {
                 if (lastFound == servoIndex) {
                     return i - offset + 1;
                 } else {
@@ -132,6 +135,10 @@ let OutputMappingCollection = function () {
         }
 
         return null;
+    }
+
+    self.getTimerId = function(outputIndex) {
+        return getTimerId(outputIndex)
     }
 
     self.getFwServoOutput = function (servoIndex) {

--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -20,9 +20,9 @@ let OutputMappingCollection = function () {
     const OUTPUT_TYPE_MOTOR = 0;
     const OUTPUT_TYPE_SERVO = 1;
 
-    const TIMER_OUTPUT_MODE_AUTO = 0;
-    const TIMER_OUTPUT_MODE_MOTORS = 1;
-    const TIMER_OUTPUT_MODE_SERVOS = 2;
+    self.TIMER_OUTPUT_MODE_AUTO = 0;
+    self.TIMER_OUTPUT_MODE_MOTORS = 1;
+    self.TIMER_OUTPUT_MODE_SERVOS = 2;
 
     self.flushTimerOverrides = function() {
         timerOverrides = {};
@@ -33,11 +33,19 @@ let OutputMappingCollection = function () {
     }
 
     self.getTimerOverride = function (timer) {
-        timerOverrides[timer] = outputMode;
+        return timerOverrides[timer];
     }
 
-    self.getTimerOverrideIds = function (timer) {
-        return Object.keys(timerOverrides).sort((a, b) => a - b);
+    self.getUsedTimerIds = function (timer) {
+        let used = {};
+        let outputCount = self.getOutputCount();
+
+        for (let i = 0; i < outputCount; ++i) {
+            let timerId = self.getTimerId(i);
+            used[timerId] = 1;
+        }
+
+        return Object.keys(used).sort((a, b) => a - b);
     }
 
     function getTimerMap(isMR, motors, servos) {

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -33,27 +33,7 @@
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title" data-i18n="timerOutputs"></div>
                     </div>
-                    <div class="spacer_box" id="timerOutputsList">
-                        <!--
-                        <div class="select">
-                            <select id="platform-type"></select>
-                            <label for="platform-type">
-                                <span data-i18n="platformType"></span>
-                            </label>
-                        </div>
-                        <div class="checkbox">
-                            <input id="motor_direction_inverted" type="checkbox" class="toggle" data-setting="motor_direction_inverted" />
-                            <label for="motor_direction_inverted"><span data-i18n="motor_direction_inverted"></span></label>
-                            <div class="helpicon cf_tip" data-i18n_title="motor_direction_inverted_hint"></div>
-                        </div>
-                        <div class="select">
-                            <select id="output_mode" data-setting="output_mode"></select>
-                            <label for="output_mode">
-                                <span data-i18n="output_modeTitle"></span>
-                            </label>
-                        </div>
-                        -->
-                    </div>
+                    <div class="spacer_box" id="timerOutputsList"></div>
                 </div>
 
             </div>

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -28,6 +28,34 @@
                         </div>
                     </div>
                 </div>
+            
+                <div class="platform-type gui_box grey">
+                    <div class="gui_box_titlebar">
+                        <div class="spacer_box_title" data-i18n="timerOutputs"></div>
+                    </div>
+                    <div class="spacer_box" id="timerOutputsList">
+                        <!--
+                        <div class="select">
+                            <select id="platform-type"></select>
+                            <label for="platform-type">
+                                <span data-i18n="platformType"></span>
+                            </label>
+                        </div>
+                        <div class="checkbox">
+                            <input id="motor_direction_inverted" type="checkbox" class="toggle" data-setting="motor_direction_inverted" />
+                            <label for="motor_direction_inverted"><span data-i18n="motor_direction_inverted"></span></label>
+                            <div class="helpicon cf_tip" data-i18n_title="motor_direction_inverted_hint"></div>
+                        </div>
+                        <div class="select">
+                            <select id="output_mode" data-setting="output_mode"></select>
+                            <label for="output_mode">
+                                <span data-i18n="output_modeTitle"></span>
+                            </label>
+                        </div>
+                        -->
+                    </div>
+                </div>
+
             </div>
             <div class="rightWrapper">
                 <div class="platform-type gui_box grey">

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -27,7 +27,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         mspHelper.loadMotors,
         mspHelper.loadServoMixRules,
         mspHelper.loadMotorMixRules,
-        mspHelper.loadOutputMapping,
+        mspHelper.loadOutputMappingExt,
         mspHelper.loadLogicConditions
     ]);
     loadChainer.setExitPoint(loadHtml);
@@ -74,7 +74,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         $functionRow.append('<th data-i18n="mappingTableFunction"></th>');
 
         for (let i = 1; i <= outputCount; i++) {
-            $outputRow.append('<td>S' + i + '</td>');
+            $outputRow.append('<td>S' + i + ' (T' + (OUTPUT_MAPPING.getTimerId(i -1)) + ')</td>');
             $functionRow.append('<td id="function-' + i +'">-</td>');
         }
 

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -84,30 +84,40 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
 
     }
 
+    function updateTimerOverride() {
+        let timers = OUTPUT_MAPPING.getUsedTimerIds();
+
+        for(let i =0; i < timers.length;++i) {
+            let timerId = timers[i];
+            $select = $('#timer-output-' + timerId);
+            if(!$select) {
+                continue;
+            }
+            OUTPUT_MAPPING.setTimerOverride(timerId, $select.val());
+        }
+    }
+
     function renderTimerOverride() {
         let outputCount = OUTPUT_MAPPING.getOutputCount(),
             $container = $('#timerOutputsList'), timers = {};
 
 
-        let usedTimers = OUTPUT_MAPPING.getTimerOverrideIds();
+        let usedTimers = OUTPUT_MAPPING.getUsedTimerIds();
 
         for (t of usedTimers) {
             var usageMode = OUTPUT_MAPPING.getTimerOverride(t);
-            console.log("timer settings: " + t);
-            /*
             $container.append(
                         '<div class="select">' +
                             '<select id="timer-output-' + t + '">' +
-                                '<option value=' + TIMER_OUTPUT_MODE_AUTO + '' + (usageMode == TIMER_OUTPUT_MODE_AUTO ? ' selected' : '')+ '>AUTO</option>'+
-                                '<option value=' + TIMER_OUTPUT_MODE_MOTORS + '' + (usageMode == TIMER_OUTPUT_MODE_MOTORS ? ' selected' : '')+ '>MOTORS</option>'+
-                                '<option value=' + TIMER_OUTPUT_MODE_SERVOS + '' + (usageMode == TIMER_OUTPUT_MODE_SERVOS ? ' selected' : '')+ '>SERVOS</option>'+
+                                '<option value=' + OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO + '' + (usageMode == OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO ? ' selected' : '')+ '>AUTO</option>'+
+                                '<option value=' + OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS + '' + (usageMode == OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS ? ' selected' : '')+ '>MOTORS</option>'+
+                                '<option value=' + OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS + '' + (usageMode == OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS ? ' selected' : '')+ '>SERVOS</option>'+
                             '</select>' +
                             '<label for="timer-output-' + t + '">' +
                                 '<span> T' + t + '</span>' +
                             '</label>' +
                         '</div>'
             );
-            */
         }
 
     }
@@ -468,9 +478,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         MOTOR_RULES.cleanup();
         MOTOR_RULES.inflate();
 
-        for (timerId OUTPUT_MAPPING.getTimerOverrideIds()) {
-
-        }
+        updateTimerOverride();
 
         saveChainer.execute();
     }

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -28,6 +28,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         mspHelper.loadServoMixRules,
         mspHelper.loadMotorMixRules,
         mspHelper.loadOutputMappingExt,
+        mspHelper.loadTimerOutputModes,
         mspHelper.loadLogicConditions
     ]);
     loadChainer.setExitPoint(loadHtml);
@@ -37,6 +38,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         mspHelper.saveMixerConfig,
         mspHelper.sendServoMixer,
         mspHelper.sendMotorMixer,
+        mspHelper.sendTimerOutputModes,
         saveSettings,
         mspHelper.saveToEeprom
     ]);
@@ -87,29 +89,25 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
             $container = $('#timerOutputsList'), timers = {};
 
 
-        for(let i = 0; i < outputCount; ++i) {
-            let timer = OUTPUT_MAPPING.getTimerId(i);
-
-            timers[timer] = true;
-            console.log("timer: " + i + " " + timer);
-        }
-
-        let usedTimers = Object.keys(timers).sort((a,b) => a-b);
+        let usedTimers = OUTPUT_MAPPING.getTimerOverrideIds();
 
         for (t of usedTimers) {
+            var usageMode = OUTPUT_MAPPING.getTimerOverride(t);
             console.log("timer settings: " + t);
+            /*
             $container.append(
                         '<div class="select">' +
                             '<select id="timer-output-' + t + '">' +
-                                '<option>AUTO</option>'+
-                                '<option>MOTORS</option>'+
-                                '<option>SERVOS</option>'+
+                                '<option value=' + TIMER_OUTPUT_MODE_AUTO + '' + (usageMode == TIMER_OUTPUT_MODE_AUTO ? ' selected' : '')+ '>AUTO</option>'+
+                                '<option value=' + TIMER_OUTPUT_MODE_MOTORS + '' + (usageMode == TIMER_OUTPUT_MODE_MOTORS ? ' selected' : '')+ '>MOTORS</option>'+
+                                '<option value=' + TIMER_OUTPUT_MODE_SERVOS + '' + (usageMode == TIMER_OUTPUT_MODE_SERVOS ? ' selected' : '')+ '>SERVOS</option>'+
                             '</select>' +
                             '<label for="timer-output-' + t + '">' +
                                 '<span> T' + t + '</span>' +
                             '</label>' +
                         '</div>'
             );
+            */
         }
 
     }
@@ -469,6 +467,11 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         SERVO_RULES.inflate();
         MOTOR_RULES.cleanup();
         MOTOR_RULES.inflate();
+
+        for (timerId OUTPUT_MAPPING.getTimerOverrideIds()) {
+
+        }
+
         saveChainer.execute();
     }
 

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -82,6 +82,38 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
 
     }
 
+    function renderTimerOverride() {
+        let outputCount = OUTPUT_MAPPING.getOutputCount(),
+            $container = $('#timerOutputsList'), timers = {};
+
+
+        for(let i = 0; i < outputCount; ++i) {
+            let timer = OUTPUT_MAPPING.getTimerId(i);
+
+            timers[timer] = true;
+            console.log("timer: " + i + " " + timer);
+        }
+
+        let usedTimers = Object.keys(timers).sort((a,b) => a-b);
+
+        for (t of usedTimers) {
+            console.log("timer settings: " + t);
+            $container.append(
+                        '<div class="select">' +
+                            '<select id="timer-output-' + t + '">' +
+                                '<option>AUTO</option>'+
+                                '<option>MOTORS</option>'+
+                                '<option>SERVOS</option>'+
+                            '</select>' +
+                            '<label for="timer-output-' + t + '">' +
+                                '<span> T' + t + '</span>' +
+                            '</label>' +
+                        '</div>'
+            );
+        }
+
+    }
+
     function renderOutputMapping() {
         let outputMap = OUTPUT_MAPPING.getOutputTable(
             MIXER_CONFIG.platformType == PLATFORM_MULTIROTOR || MIXER_CONFIG.platformType == PLATFORM_TRICOPTER,
@@ -704,6 +736,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
 
         renderOutputTable();
         renderOutputMapping();
+        renderTimerOverride();
 
         LOGIC_CONDITIONS.init($('#logic-wrapper'));
 


### PR DESCRIPTION
This is the configurator side changes for iNavFlight/inav#9268

Timers are clearly identified on the output mapping table.
Individual timers can be set to AUTO, SERVOS or MOTORS.

Output mapping may be wrong until after save/reboot.

![image](https://github.com/iNavFlight/inav-configurator/assets/23555060/75e9d9ef-d91e-4c62-81ee-66aa5dae3c8f)

TODO:
* [x] Load and save timer overrides via msp

