### PR TITLE
remove output_mode from mixer tab

### DIFF
--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -20,12 +20,6 @@
                             <label for="motor_direction_inverted"><span data-i18n="motor_direction_inverted"></span></label>
                             <div class="helpicon cf_tip" data-i18n_title="motor_direction_inverted_hint"></div>
                         </div>
-                        <div class="select">
-                            <select id="output_mode" data-setting="output_mode"></select>
-                            <label for="output_mode">
-                                <span data-i18n="output_modeTitle"></span>
-                            </label>
-                        </div>
                     </div>
                 </div>
             


### PR DESCRIPTION
<img width="923" alt="image" src="https://github.com/iNavFlight/inav-configurator/assets/966811/0aaa13b3-8931-44e7-8afc-1bdb24984ee9">

This function is replaced by per-timer function assignment

This side of https://github.com/iNavFlight/inav/pull/9300