### PR TITLE
mixer profile support

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -822,13 +822,11 @@ helper.defaultsDialog = (function () {
                 key: "nav_fw_launch_climb_angle",
                 value: 25
             },
-        ],
-        "features": [
             {
-                bit: 4, // Enable MOTOR_STOP
-                state: true
-            }
-        ]
+                key: "motorstop_on_low",
+                value: "ON"
+            },
+        ],
     },
     {
         "title": 'Airplane without a Tail (Wing, Delta, etc)',
@@ -1041,13 +1039,11 @@ helper.defaultsDialog = (function () {
                 key: "nav_fw_launch_climb_angle",
                 value: 25
             },
-        ],
-        "features": [
             {
-                bit: 4, // Enable MOTOR_STOP
-                state: true
-            }
-        ]
+                key: "motorstop_on_low",
+                value: "ON"
+            },
+        ],
     },
     {
         "title": 'Rovers & Boats',

--- a/js/fc.js
+++ b/js/fc.js
@@ -1270,6 +1270,7 @@ var FC = {
                     36: "AGL [cm]",
                     37: "Rangefinder [cm]",
                     38: "Active MixerProfile",
+                    39: "MixerTransition Active",
                 }
             },
             3: {

--- a/js/fc.js
+++ b/js/fc.js
@@ -195,6 +195,7 @@ var FC = {
         MIXER_CONFIG = {
             yawMotorDirection: 0,
             yawJumpPreventionLimit: 0,
+            motorStopOnLow: false,
             platformType: -1,
             hasFlaps: false,
             appliedMixerPreset: -1,
@@ -554,7 +555,6 @@ var FC = {
     getFeatures: function () {
         var features = [
             {bit: 1, group: 'batteryVoltage', name: 'VBAT'},
-            {bit: 4, group: 'other', name: 'MOTOR_STOP'},
             {bit: 6, group: 'other', name: 'SOFTSERIAL', haveTip: true, showNameInTip: true},
             {bit: 7, group: 'other', name: 'GPS', haveTip: true},
             {bit: 10, group: 'other', name: 'TELEMETRY', showNameInTip: true},
@@ -880,6 +880,7 @@ var FC = {
             'GVAR 5',               // 35
             'GVAR 6',               // 36
             'GVAR 7',               // 37
+            'Mixer Transition',     // 38
         ];
     },
     getServoMixInputName: function (input) {
@@ -1263,11 +1264,12 @@ var FC = {
                     30: "CRSF SNR",
                     31: "GPS Valid Fix",
                     32: "Loiter Radius [cm]",
-                    33: "Active Profile",
+                    33: "Active PIDProfile",
                     34: "Battery cells",
                     35: "AGL status [0/1]",
                     36: "AGL [cm]",
                     37: "Rangefinder [cm]",
+                    38: "Active MixerProfile",
                 }
             },
             3: {

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1453,7 +1453,8 @@ var mspHelper = (function (gui) {
                 break;
             case MSPCodes.MSP2_INAV_MIXER:
                 MIXER_CONFIG.yawMotorDirection = data.getInt8(0);
-                MIXER_CONFIG.yawJumpPreventionLimit = data.getUint16(1, true);
+                MIXER_CONFIG.yawJumpPreventionLimit = data.getUint8(1, true);
+                MIXER_CONFIG.motorStopOnLow = data.getUint8(1, true);
                 MIXER_CONFIG.platformType = data.getInt8(3);
                 MIXER_CONFIG.hasFlaps = data.getInt8(4);
                 MIXER_CONFIG.appliedMixerPreset = data.getInt16(5, true);
@@ -2154,8 +2155,8 @@ var mspHelper = (function (gui) {
 
             case MSPCodes.MSP2_INAV_SET_MIXER:
                 buffer.push(MIXER_CONFIG.yawMotorDirection);
-                buffer.push(lowByte(MIXER_CONFIG.yawJumpPreventionLimit));
-                buffer.push(highByte(MIXER_CONFIG.yawJumpPreventionLimit));
+                buffer.push(MIXER_CONFIG.yawJumpPreventionLimit);
+                buffer.push(MIXER_CONFIG.motorStopOnLow);
                 buffer.push(MIXER_CONFIG.platformType);
                 buffer.push(MIXER_CONFIG.hasFlaps);
                 buffer.push(lowByte(MIXER_CONFIG.appliedMixerPreset));

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -392,7 +392,6 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         const $fixedValueCalcInput = row.find(".mix-rule-fixed-value");
         if (FC.getServoMixInputNames()[$mixRuleInput.val()] === 'MAX') {
             $fixedValueCalcInput.show();
-            row.find(".mix-rule-speed").prop('disabled', true);
         } else {
             $fixedValueCalcInput.hide();
             row.find(".mix-rule-speed").prop('disabled', false);

--- a/tabs/outputs.html
+++ b/tabs/outputs.html
@@ -39,7 +39,7 @@
 
                 <div id="motor-stop-warning" data-i18n="motorStopWarning" class="warning-box"></div>
                 <div class="checkbox">
-                    <input type="checkbox" data-bit="4" class="feature toggle" name="MOTOR_STOP" title="MOTOR_STOP" id="feature-4">
+                    <input id="feature-4" type="checkbox" class="toggle" data-setting="motorstop_on_low" />
                     <label for="feature-4">
                         <span data-i18n="featureMOTOR_STOP"></span>
                     </label>


### PR DESCRIPTION
minimum mixer profile support:
- moved motorStopOnLow from feature to pid profile related settings
- added Mixer Transition servo mixing
- added Active MixerProfile and MixerTransition to OperandTypes
- allow speed setting for MAX smix

known issues:
- need to modify presets according to the motorStopOnLow changes
- save and reboot is broke in mixer tab, confirmed in SITL, not validated on real board