### PR TITLE
Add warning about output mapping needing save and reboot

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1953,6 +1953,9 @@
     "mixerWizardInfo": {
         "message": "<ol><li>Remove propellers</li><li>Connect LiPo and use Outputs Tab to test all motors</li><li>Note the position of each motor (motor #1 - Left Top and so on)</li><li>Fill the table below</li></ol>"
     },
+    "mixerSaveAndRebootNeeded": {
+        "message": "Save and reboot is needed when changing timer outputs or changing the number of motors."
+    },
     "gpsHead": {
         "message": "Position"
     },

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -71,6 +71,7 @@
             <div class="gui_box_titlebar">
                 <div class="spacer_box_title" data-i18n="mappingTableTitle"></div>
             </div>
+            <div id="saveAndRebootNeeded" data-i18n="mixerSaveAndRebootNeeded"></div>
             <table class="output-table">
                 <tr id="output-row">
 


### PR DESCRIPTION
When changing number of motors, or timer output assignments, a save and reboot will be needed to display the correct output mapping