### PR TITLE
Serialpassthrough button in port tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -4202,6 +4202,9 @@
     "portsPeripherals": {
         "message": "Peripherals"
     },
+    "serialpassthrough": {
+        "message": "Activate serialpassthrough"
+    },
     "appUpdateNotificationHeader": {
         "message": "New Configurator version available."
     },

--- a/src/css/tabs/ports.css
+++ b/src/css/tabs/ports.css
@@ -96,3 +96,12 @@
         height: 22px;
     }
 }
+
+.moreCell {
+    text-align: left;
+    white-space: nowrap;
+    padding: 5px 7px;
+    background-color: #828885;
+    color: white;
+    width: 10px;
+}

--- a/tabs/ports.html
+++ b/tabs/ports.html
@@ -18,6 +18,7 @@
                         <td i18n="portsSerialRx"></td>
                         <td data-i18n="portColumnSensors"></td>
                         <td class='peripherls-column' i18n="portsPeripherals"></td>
+                        <td class='serialpassthrough' i18n="serialpassthrough"></td>
                     </tr>
                 </thead>
                 <tbody>
@@ -49,7 +50,7 @@
                 <td class="functionsCell-data"><select class="msp_baudrate">
                         <!-- list generated here -->
                 </select></td>
-                <td class="functionsCell-telemetry"><select class="telemetry_baudrate"">
+                <td class="functionsCell-telemetry"><select class="telemetry_baudrate">
                         <!-- list generated here -->
                 </select></td>
                 <td class="functionsCell-rx"></td>
@@ -59,6 +60,9 @@
                 <td class="functionsCell-peripherals"><select class="peripherals_baudrate">
                         <!-- list generated here -->
                 </select></td>
+                <td class="functionsCell-serialpassthrough">
+                    <!-- list generated here -->
+                </td>
             </tr>
         </tbody>
     </table>

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -299,8 +299,10 @@ TABS.ports.initialize = function (callback) {
             }
 
             /////////////////////////////////////////////////////////////////
-            var serialpassthroughCell       = $(port_configuration_e).find('.functionsCell-serialpassthrough');
+            var serialpassthroughCell = $(port_configuration_e).find('.functionsCell-serialpassthrough');
 
+            //20 VCP
+            console.log(serialPort);
             if(serialPort.identifier !== 20 && serialPort.functions.length > 0 && serialPort.functions.indexOf('RX_SERIAL')){
                 ///////////////
                 var defaultFunction = serialPort.functions[0];
@@ -373,6 +375,13 @@ TABS.ports.initialize = function (callback) {
                     .then(set_serial_passthrough)
                     .then(close_configurator);
             });
+
+            $('.ports').find('.portConfiguration').first().append($('<td>').addClass('moreCell').attr('rowspan', SERIAL_CONFIG.ports.length).html(' >> ').click(function(){
+                $('.serialpassthrough, .functionsCell-serialpassthrough').show();
+                $(this).remove();
+            }));
+            $('.serialpassthrough, .functionsCell-serialpassthrough').hide();
+
         }else{
             $('.serialpassthrough, .functionsCell-serialpassthrough').remove();
         }


### PR DESCRIPTION
Story: Main goal was that writing whole comand into cli was slow and mainly because I do not remeber whole command. I use serialpassthrough once per month so would be more comfortably to just click to button. Serialpassthrough is not used as often so I decided to hidden buttons into clickable col. 

![image](https://github.com/iNavFlight/inav-configurator/assets/1698092/a46fe608-0194-4bce-9689-91fd2e14b5aa)


How it works: if you click to >>" col then area with buttons is opened. Buttons is generated only in row where is set some functionality (MSP, GPS, etc,,,, ), it's not showed for RX or USB VCP. Params for  serialpassthrough is taken from settings. Serialpassthrough params can be visualised by toats message from "question mark".

![image](https://github.com/iNavFlight/inav-configurator/assets/1698092/1eabb0fc-9e41-43bd-867b-cc69f33f0879)

If baud rate is not possible determinate then there is select for baudrate selecting. 
![image](https://github.com/iNavFlight/inav-configurator/assets/1698092/3e11f35c-02ce-4b01-950f-9e991adee462)


