### PR TITLE
 Update README.md - fix grammatrical errors in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Various types of aircraft are supported by the tool and by INAV, e.g. quadcopter
 
 INAV Configurator comes `as is`, without any warranty and support from authors. If you found a bug, please create an issue on [GitHub](https://github.com/iNavFlight/inav-configurator/issues).
 
-The GitHub issue tracker is reserved for bugs and other technical problems. If you do not know how to setup
-everything, the hardware is not working or have any other _support_ problem, please consult:
+The GitHub issue tracker is reserved for bugs and other technical problems. If you do not know how to set up
+everything, the hardware is not working, or have any other _support_ problem, please consult:
 
 * [INAV Discord Server](https://discord.gg/peg2hhbYwN)
 * [INAV Official on Facebook](https://www.facebook.com/groups/INAVOfficial)


### PR DESCRIPTION
I have noticed some grammatical mistakes in **README** inside section "**Support**"

"**know how to setup everything**"  should be "**know how to set up everything**"

" **not working or have any other**"  should be " **not working, or have any other**"

"**Configurator start minimized**"  should be "**Configurator starts minimized..**"  

Screenshot-

![Screenshot (107)](https://github.com/iNavFlight/inav-configurator/assets/114826902/d490968d-946e-47a0-a92e-92b3f7a09727)
