### PR TITLE
preset on pid_iterm_limit_percent for MC

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -178,6 +178,10 @@ helper.defaultsDialog = (function () {
                 key: "mc_i_yaw",
                 value: 80
             },
+            {
+                key: "pid_iterm_limit_percent",
+                value: 50
+            },
             /*
                 * TPA
                 */
@@ -391,6 +395,10 @@ helper.defaultsDialog = (function () {
                 key: "mc_i_yaw",
                 value: 80
             },
+            {
+                key: "pid_iterm_limit_percent",
+                value: 50
+            },
             /*
              * TPA
              */
@@ -585,6 +593,10 @@ helper.defaultsDialog = (function () {
             {
                 key: "mc_i_yaw",
                 value: 80
+            },
+            {
+                key: "pid_iterm_limit_percent",
+                value: 50
             },
             /*
              * TPA


### PR DESCRIPTION
Set pid_iterm_limit_percent=50 for multi-rotor preset.
Default 33 might be better but 50 should be safer for unbalanced CoG/very windy conditions