### PR TITLE
Only show Ez Tune tab when platform is multirotor

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1552,7 +1552,7 @@
         "message": "Pitch trim for self-leveling flight modes. In degrees. +5 means airplane nose should be raised 5 deg from level"
     },
     "pidTuning_ButtonSave": {
-        "message": "Save"
+        "message": "Save and Reboot"
     },
     "pidTuning_ButtonRefresh": {
         "message": "Refresh"
@@ -2220,7 +2220,7 @@
         "message": "Blackbox configuration"
     },
     "blackboxButtonSave": {
-        "message": "Save and reboot"
+        "message": "Save and Reboot"
     },
     "serialLogging": {
         "message": "Outboard serial logging device"
@@ -4452,7 +4452,7 @@
         "message": "Confirm"
     },
     "mixerButtonSaveAndReboot": {
-        "message": "Save and reboot"
+        "message": "Save and Reboot"
     },
     "mixerApplyDescription": {
         "message": "This action overrides all current mixer settings and replaces them with default values. There is no 'Undo' option!"

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -257,6 +257,7 @@ function onValidFirmware()
 
                 $('#tabs ul.mode-connected .tab_setup a').click();
 
+                updateEzTuneTabVisibility(true);
                 updateFirmwareVersion();
             });
         });

--- a/main.js
+++ b/main.js
@@ -717,3 +717,28 @@ function updateFirmwareVersion() {
         globalSettings.docsTreeLocation = 'https://github.com/iNavFlight/inav/blob/master/docs/';
     }
 }
+
+function updateEzTuneTabVisibility(loadMixerConfig) {
+    let useEzTune = true;
+    if (CONFIGURATOR.connectionValid) {
+        if (loadMixerConfig) {
+            mspHelper.loadMixerConfig(function() {
+                if (MIXER_CONFIG.platformType == PLATFORM_MULTIROTOR || MIXER_CONFIG.platformType == PLATFORM_TRICOPTER) {
+                    $('.tab_ez_tune').removeClass("is-hidden");
+                } else {
+                    $('.tab_ez_tune').addClass("is-hidden");
+                    useEzTune = false;
+                }
+            });
+        } else {
+            if (MIXER_CONFIG.platformType == PLATFORM_MULTIROTOR || MIXER_CONFIG.platformType == PLATFORM_TRICOPTER) {
+                $('.tab_ez_tune').removeClass("is-hidden");
+            } else {
+                $('.tab_ez_tune').addClass("is-hidden");
+                useEzTune = false;
+            }
+        }
+    }
+
+    return useEzTune;
+}

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -668,6 +668,11 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
                 $('#platform-type').parent('.select').addClass('no-bottom-border');
             }
 
+            if (!updateEzTuneTabVisibility(false)) {
+                EZ_TUNE.enabled = 0;
+                mspHelper.saveEzTune();
+            }
+
             updateRefreshButtonStatus();
 
             updateMotorDirection();


### PR DESCRIPTION
The PR only shows the Ez Tune tab when the platform is either `PLATFORM_MULTIROTOR ` or `PLATFORM_TRICOPTER`. More platforms can be added in the function in main.js.

When changing the mixer to a non-supported platform. Ez Tune is automatically disabled.

Fixes #1881