### PR TITLE
Change default Bing elevation datum to sealevel

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -4295,8 +4295,8 @@
     "missionMultiAddNewMission": {
         "message": "Add New Mission"
     },
-    "missionLevelEarthDEMModel": {
-        "message": "Use Sea Level Earth DEM Model: "
+    "missionEllipsoidEarthDEMModel": {
+        "message": "Use Ellipsoid Earth DEM Model: "
     },
     "SafehomeLegend": {
         "message": "Legend : "

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -4296,7 +4296,7 @@
         "message": "Add New Mission"
     },
     "missionEllipsoidEarthDEMModel": {
-        "message": "Use Ellipsoid Earth DEM Model: "
+        "message": "Use Ellipsoid instead of SL DEM: "
     },
     "SafehomeLegend": {
         "message": "Legend : "

--- a/js/waypoint.js
+++ b/js/waypoint.js
@@ -139,7 +139,7 @@ let Waypoint = function (number, action, lat, lon, alt=0, p1=0, p2=0, p3=0, endM
     self.getElevation = async function (globalSettings) {
         let elevation = "N/A";
         if (globalSettings.mapProviderType == 'bing') {
-            let elevationEarthModel = $('#elevationEarthModel').prop("checked") ? "sealevel" : "ellipsoid";
+            let elevationEarthModel = $('#elevationEarthModel').prop("checked") ? "ellipsoid" : "sealevel";
 
             const response = await fetch('http://dev.virtualearth.net/REST/v1/Elevation/List?points='+self.getLatMap()+','+self.getLonMap()+'&heights='+elevationEarthModel+'&key='+globalSettings.mapApiKey);
             const myJson = await response.json();

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -166,7 +166,7 @@
                         </div>
                     </div>
                     <div class="point" id="elevationEarthModelclass" style="display: none">
-                        <label class="spacer_box_title" for="elevationEarthModel" data-i18n="missionLevelEarthDEMModel"></label>
+                        <label class="spacer_box_title" for="elevationEarthModel" data-i18n="missionEllipsoidEarthDEMModel"></label>
                         <input id="elevationEarthModel" type="checkbox" value="0" class="togglemedium" required>
                     </div>
                 </div>


### PR DESCRIPTION
Closes https://github.com/iNavFlight/inav-configurator/issues/1893.

Changes default Bing maps elevation datum to Sea Level with Ellipsoid now an optional setting.