### PR TITLE
SBUS Output in ports

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1302,6 +1302,9 @@
     "portsFunction_MSP_DISPLAYPORT": {
         "message": "MSP DisplayPort"
     },
+    "portsFunction_SBUS_OUTPUT": {
+        "message": "SBus Output"
+    },
     "pidTuning_ShowAllPIDs": {
         "message": "Show all PIDs"
     },

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -42,6 +42,7 @@ var mspHelper = (function (gui) {
         'GSM_SMS': 19,
         'FRSKY_OSD': 20,
         'DJI_FPV': 21,
+        'SBUS_OUTPUT': 22,
         'SMARTPORT_MASTER': 23,
         'MSP_DISPLAYPORT': 25,
     };

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -114,6 +114,12 @@ TABS.ports.initialize = function (callback) {
         maxPorts: 1,
         defaultBaud: 57600 }
     );
+    portFunctionRules.push({
+        name: 'SBUS_OUTPUT',
+        groups: ['peripherals'],
+        maxPorts: 1,
+        defaultBaud: 115200 }
+    );
 
     for (var i = 0; i < portFunctionRules.length; i++) {
         portFunctionRules[i].displayName = chrome.i18n.getMessage('portsFunction_' + portFunctionRules[i].name);


### PR DESCRIPTION
Hello.

When I enable sbus_output via the cli, it doesn't show up in the ports. It is not convenient, as well as the inability to select it there.

But, most importantly, if I change something in the serial port settings through the configurator and save it, the sbus_output setting is deleted and it must be done manually.

Of course, it would be great to put the servo_protocol in GUI: PWM, BUS or PWM+SBUS. But, unfortunately, MSP packets do not return and do not accept this value. I think it would be more correct to make it a separate PR for the next versions of INAV and the configurator.