### PR TITLE
QNE Altitude

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -4091,6 +4091,12 @@
     "osdElement_OSD_RANGEFINDER": {
         "message": "Rangefinder distance"
     },
+    "osdElement_QNE_ALTITUDE": {
+        "message": "QNE Altitude"
+    },
+    "osdElement_QNE_ALTITUDE_HELP": {
+        "message": "Altitude above normal pressure"
+    },
     "osdSettingPLUS_CODE_DIGITS_HELP": {
         "message": "Precision at the equator: 10=13.9x13.9m; 11=2.8x3.5m; 12=56x87cm; 13=11x22cm."
     },

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -1220,7 +1220,21 @@ OSD.constants = {
                                 return FONT.embed_dot('25.6') + FONT.symbol(SYM.DIST_KM);
                         }
                     }
-                }
+                },
+                {
+                    name: 'QNE_ALTITUDE',
+                    id: 147,
+                    preview: function () {
+                        switch (OSD.data.preferences.units) {
+                            case 0: // Imperial
+                            case 3: // UK
+                            case 4: // GA
+                                return ' 375' + FONT.symbol(SYM.ALT_FT);
+                            default: // Metric
+                                return ' 114' + FONT.symbol(SYM.ALT_M);
+                        }
+                    }
+                },
             ]
         },
         {


### PR DESCRIPTION
QNE Altitude - is altitude without binding to Home point alt. In need for several situations:
 - distinguish your altitude from the altitude of the aircraft using ADBS data on height >3000-5000ft. The use of such a height makes it possible to control flight levels, since the closer the planes are to each other, the more equal the atmospheric pressure is overboard;
 - know the altitude in case the controller is rebooted in the air;
 - see the height of the take-off point before arm;