### PR TITLE
Update default WP Radius

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -579,7 +579,7 @@ helper.defaultsDialog = (function () {
             },
             {
                 key: "nav_wp_radius",
-                value: 5000
+                value: 800
             },
             {
                 key: "nav_wp_max_safe_distance",
@@ -788,7 +788,7 @@ helper.defaultsDialog = (function () {
             },
             {
                 key: "nav_wp_radius",
-                value: 5000
+                value: 1000
             },
             {
                 key: "nav_wp_max_safe_distance",


### PR DESCRIPTION
With better AHRS and Sensor fusion since 6.0 and 7.1, the WP radius for fixed wings can be much smaller for more precise waypoint navigation. This also helps Fixed Wing Autoland to use shorter approaches with later turns.