### PR TITLE
fix OSD bug, no HD variants in select

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1635,6 +1635,12 @@ var mspHelper = (function (gui) {
 
                 var index = 0;
 
+                if(data.byteLength == 0){
+                    OSD_CUSTOM_ELEMENTS.settings.customElementsCount = 0;
+                    OSD_CUSTOM_ELEMENTS.settings.customElementTextSize = 0;
+                    return;
+                }
+
                 OSD_CUSTOM_ELEMENTS.settings.customElementsCount = data.getUint8(index++);
                 OSD_CUSTOM_ELEMENTS.settings.customElementTextSize = data.getUint8(index++);
 

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -2147,7 +2147,10 @@ OSD.reload = function(callback) {
         });
     });
 
-    MSP.send_message(MSPCodes.MSP2_INAV_CUSTOM_OSD_ELEMENTS);
+    if(semver.gte(CONFIG.flightControllerVersion, '7.1.0'))
+    {
+        MSP.send_message(MSPCodes.MSP2_INAV_CUSTOM_OSD_ELEMENTS);
+    }
 };
 
 OSD.updateSelectedLayout = function(new_layout) {
@@ -3384,13 +3387,16 @@ TABS.osd.initialize = function (callback) {
             GUI.content_ready(callback);
         });
 
-        mspHelper.loadOsdCustomElements(createCustomElements);
+        if(semver.gte(CONFIG.flightControllerVersion, '7.1.0')) {
+            mspHelper.loadOsdCustomElements(createCustomElements);
+        }
     }));
 };
 
 function createCustomElements(){
     if(OSD_CUSTOM_ELEMENTS.settings.customElementsCount == 0){
         $('.custom-element-container').remove();
+        return;
     }
 
     var customElementsContainer = $('#osdCustomElements');
@@ -3602,6 +3608,7 @@ function customElementGetDataForRow(row){
     switch (parseInt(elementVisibilityType.val())){
         case 1:
             visibilityValue = parseInt(valueVisibilityCell.find('.gv').find(':selected').val());
+            break;
         case 2:
             visibilityValue = parseInt(valueVisibilityCell.find('.lc').find(':selected').val());
             break;


### PR DESCRIPTION
from facebook, channel **INAV Fixed Wing Test-Chamber**

Rodrigo:
Anyone else not being able to select the HD OSD (Avatar, HDZero, DJIWTF, BFCOMPAT) on the 7.1.0 configurator?

