### PR TITLE
Mission control fixes

### DIFF
--- a/js/fwApproach.js
+++ b/js/fwApproach.js
@@ -65,7 +65,7 @@ let FwApproach = function (number, approachAltAsl = 0, landAltAsl = 0, approachD
     self.setIsSeaLevelRef = function (data) {
         isSeaLevelRef = data;
     }
-    
+
     self.getElevation = function() {
         return elevation;
     }
@@ -87,7 +87,7 @@ let FwApproach = function (number, approachAltAsl = 0, landAltAsl = 0, approachD
     self.getElevationFromServer = async function (lon, lat, globalSettings) {
         let elevation = "N/A";
         if (globalSettings.mapProviderType == 'bing') {
-            let elevationEarthModel = $('#elevationEarthModel').prop("checked") ? "sealevel" : "ellipsoid";
+            let elevationEarthModel = $('#elevationEarthModel').prop("checked") ? "ellipsoid" : "sealevel";
 
             const response = await fetch('http://dev.virtualearth.net/REST/v1/Elevation/List?points='+lat+','+lon+'&heights='+elevationEarthModel+'&key='+globalSettings.mapApiKey);
             const myJson = await response.json();

--- a/js/waypointCollection.js
+++ b/js/waypointCollection.js
@@ -442,7 +442,7 @@ let WaypointCollection = function () {
 
         let elevation = "N/A";
         if (globalSettings.mapProviderType == 'bing') {
-            let elevationEarthModel = $('#elevationEarthModel').prop("checked") ? "sealevel" : "ellipsoid";
+            let elevationEarthModel = $('#elevationEarthModel').prop("checked") ? "ellipsoid" : "sealevel";
 
             if (point2measure.length >1) {
                 const response = await fetch('http://dev.virtualearth.net/REST/v1/Elevation/Polyline?points='+point2measure+'&heights='+elevationEarthModel+'&samples='+String(samples+1)+'&key='+globalSettings.mapApiKey);

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -468,7 +468,7 @@ TABS.mission_control.initialize = function (callback) {
     function loadSettings() {
         chrome.storage.local.get('missionPlannerSettings', function (result) {
             if (result.missionPlannerSettings) {
-                if (result.missionPlannerSettings.fwApproachLength == undefined && settings.fwApproachLength) {
+                if (!result.missionPlannerSettings.fwApproachLength && settings.fwApproachLength) {
                     result.missionPlannerSettings.fwApproachLength = settings.fwApproachLength;
                     result.missionPlannerSettings.maxDistSH = settings.maxDistSH;
                     result.missionPlannerSettings.fwLoiterRadius = settings.fwLoiterRadius;

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1283,8 +1283,6 @@ TABS.mission_control.initialize = function (callback) {
         } else {
             $('#missionDistance').text(lengthMission[lengthMission.length -1] != -1 ? lengthMission[lengthMission.length -1].toFixed(1) : 'infinite');
         }
-
-
     }
 
     function paintLine(pos1, pos2, pos2ID, color='#1497f1', lineDash=0, lineText="", selection=true, arrow=false) {
@@ -3130,7 +3128,13 @@ TABS.mission_control.initialize = function (callback) {
         /////////////////////////////////////////////
         $('#saveSettings').on('click', function () {
             let oldSafeRadiusSH = settings.safeRadiusSH;
-            settings = { speed: Number($('#MPdefaultPointSpeed').val()), alt: Number($('#MPdefaultPointAlt').val()), safeRadiusSH: Number($('#MPdefaultSafeRangeSH').val()), fwApproachAlt: Number($('#MPdefaultFwApproachAlt').val()), fwLandAlt: Number($('#MPdefaultLandAlt').val()), fwApproachLength: settings.fwApproachLength, maxDistSH: settings.maxDistSH, fwLoiterRadius: settings.fwLoiterRadius, bingDemModel: settings.bingDemModel};
+
+            // update only default settings
+            settings.alt = Number($('#MPdefaultPointAlt').val());
+            settings.speed = Number($('#MPdefaultPointSpeed').val());
+            settings.safeRadiusSH = Number($('#MPdefaultSafeRangeSH').val());
+            settings.fwApproachAlt = Number($('#MPdefaultFwApproachAlt').val());
+            settings.fwLandAlt = Number($('#MPdefaultLandAlt').val());
 
             saveSettings();
 


### PR DESCRIPTION
Fixes problems with Mission Control default settings not saving and another problems with settings read from FC getting scrubbed when the same settings are subsequently loaded locally from Chrome. At least this is what happens on Windows builds.

Also fixes some changes from https://github.com/iNavFlight/inav-configurator/pull/1904 that seemed to have been removed for some reason (breaking the PR).

Corrects changes from https://github.com/iNavFlight/inav-configurator/pull/1898 that missed swapping ellipsoid and sealevel datums in one function which was also then carried across to #1960.

Closes https://github.com/iNavFlight/inav-configurator/issues/1978