### PR TITLE
ADD APM32 MCU USB_DFU

### DIFF
--- a/js/port_handler.js
+++ b/js/port_handler.js
@@ -8,7 +8,8 @@ const ConnectionSerial = require('./connection/connectionSerial');
 
 var usbDevices =  [
     { 'vendorId': 1155, 'productId': 57105}, 
-    { 'vendorId': 11836, 'productId': 57105}
+    { 'vendorId': 11836, 'productId': 57105},
+    { 'vendorId': 12619, 'productId': 262}, // APM32 DFU Bootloader
 ];
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -48,7 +48,8 @@
         "alwaysOnTopWindows",
         {"usbDevices": [
             {"vendorId": 1155, "productId": 57105},
-            {"vendorId": 11836, "productId": 57105}
+            {"vendorId": 11836, "productId": 57105},
+            {'vendorId': 12619, 'productId': 262} // APM32 DFU Bootloader
         ]}
     ],
 


### PR DESCRIPTION
By modifying port_handler.js and manifest.json, you can add the VendorID and ProductID corresponding to APM32 so that it can directly support the firmware download of APM32 series MCU，https://global.geehy.com/