### PR TITLE
Remove GPS serial configuration note

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1184,9 +1184,6 @@
     "configurationGPSubxSbas": {
         "message": "Ground Assistance Type"
     },
-    "configurationGPSHelp": {
-        "message": "<strong>Note:</strong> Remember to configure a Serial Port (via Ports tab) when using GPS feature."
-    },
     "receiverType": {
         "message": "Receiver type"
     },

--- a/tabs/gps.html
+++ b/tabs/gps.html
@@ -9,12 +9,6 @@
                         <div class="spacer_box_title" data-i18n="configurationGPS"></div>
                     </div>
                     <div class="spacer_box">
-                        <div class="note">
-                            <div class="note_spacer">
-                                <p data-i18n="configurationGPSHelp"></p>
-                            </div>
-                        </div>
-
                         <div class="checkbox">
                             <input type="checkbox" data-bit="7" class="feature toggle" name="GPS" title="GPS" id="feature-7">
                             <label for="feature-7"><span data-i18n="featureGPS"></span></label>


### PR DESCRIPTION
Now that we can configure the GPS serial port in the GPS tab itself, I think this message is not very useful...
![Captura de Tela 2024-06-01 às 19 11 37](https://github.com/iNavFlight/inav-configurator/assets/25625982/07835d42-744d-4ce4-9f81-097327dab43e)
