### PR TITLE
Consolidate the old `PIDProfile` and `Profile` in to `Control Profile`

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,16 +95,6 @@
                             <div class="legend" i18n="sensorDataFlashFreeSpace"></div>
                         </li>
                     </ul>
-                    <div id="mixer_profile_change">
-                        <div class="dropdown  dropdown-dark">
-                            <form name="mixer-profile-change" id="mixer-profile-change">
-                                <select class="dropdown-select" id="mixerprofilechange">
-                                <option value="0" i18n="mixerProfile1"></option>
-                                <option value="1" i18n="mixerProfile2"></option>
-                                </select>
-                            </form>
-                        </div>
-                    </div>
                     <div id="profile_change">
                         <div class="dropdown dropdown-dark">
                             <form name="profile-change" id="profile-change">
@@ -113,6 +103,16 @@
                                     <option value="0" i18n="sensorProfile1"></option>
                                     <option value="1" i18n="sensorProfile2"></option>
                                     <option value="2" i18n="sensorProfile3"></option>
+                                </select>
+                            </form>
+                        </div>
+                    </div>
+                    <div id="mixer_profile_change">
+                        <div class="dropdown  dropdown-dark">
+                            <form name="mixer-profile-change" id="mixer-profile-change">
+                                <select class="dropdown-select" id="mixerprofilechange">
+                                <option value="0" i18n="mixerProfile1"></option>
+                                <option value="1" i18n="mixerProfile2"></option>
                                 </select>
                             </form>
                         </div>

--- a/js/logicConditionOperantTypes.js
+++ b/js/logicConditionOperantTypes.js
@@ -53,13 +53,13 @@ const OPERAND_TYPES = {
             30: "CRSF SNR",
             31: "GPS Valid Fix",
             32: "Loiter Radius [cm]",
-            33: "Active PIDProfile",
+            33: "Active Control Profile",
             34: "Battery cells",
             35: "AGL status [0/1]",
             36: "AGL [cm]",
             37: "Rangefinder [cm]",
             38: "Active MixerProfile",
-            39: "MixerTransition Active",
+            39: "Mixer Transition Active",
             40: "Yaw [deg]",
             41: "FW Land State"
         }

--- a/js/logicConditionOperators.js
+++ b/js/logicConditionOperators.js
@@ -242,6 +242,13 @@ const LOGIC_OPERATORS = {
         output: "boolean"
     },
 
+    39: {
+        name: "Set Heading Target",
+        operandType: "Set Flight Parameter",
+        hasOperand: [true, false],
+        output: "raw"
+    },
+
     41: {
         name: "Override Loiter Radius",
         operandType: "Set Flight Parameter",
@@ -249,7 +256,7 @@ const LOGIC_OPERATORS = {
         output: "boolean"
     },
     42: {
-        name: "Set Profile",
+        name: "Set Control Profile",
         operandType: "Set Flight Parameter",
         hasOperand: [true, false],
         output: "boolean"

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1319,7 +1319,7 @@ var mspHelper = (function () {
                 console.log('Looptime saved');
                 break;
             case MSPCodes.MSP_SET_RESET_CURR_PID:
-                console.log('Current PID profile reset');
+                console.log('Current Control profile reset');
                 break;
             case MSPCodes.MSP_SET_3D:
                 console.log('3D settings saved');

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5132,10 +5132,10 @@
         "message": "Enable if the motor direction is reversed and the props are mounted in the opposite direction."
     },
     "mixer_pid_profile_linking": {
-        "message": "PID Profile will use same index as Mixer Profile index"
+        "message": "Control Profile will use same index as Mixer Profile index"
     },
     "mixer_pid_profile_linking_hint": {
-        "message": "mixer_pid_profile_linking: Enable on both Mixer Profile if you want PID Profile switching handled by Mixer Profile switching(Recommend in vtol/mixed plaform type setup)"
+        "message": "mixer_pid_profile_linking: Enable on both Mixer Profile if you want Control Profile switching handled by Mixer Profile switching(Recommend in vtol/mixed plaform type setup)"
     },
     "blackboxFields": {
         "message": "Blackbox fields"
@@ -5459,13 +5459,13 @@
         "message": "Mixer Profile 2"
     },
     "sensorProfile1": {
-        "message": "PID Profile 1"
+        "message": "Control Profile 1"
     },
     "sensorProfile2": {
-        "message": "PID Profile 2"
+        "message": "Control Profile 2"
     },
     "sensorProfile3": {
-        "message": "PID Profile 3"
+        "message": "Control Profile 3"
     },
     "sensorBatteryProfile1": {
         "message": "Battery Profile 1"

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1700,7 +1700,7 @@ dialog {
 
 }
 
-#mixer_profile_change {
+#profile_change {
     color: white;
     margin-top: 16px;
     width: 130px;
@@ -1709,7 +1709,7 @@ dialog {
     line-height: 12px;
 }
 
-#profile_change {
+#mixer_profile_change {
     color: white;
     margin-top: 16px;
     width: 130px;


### PR DESCRIPTION
- Consolidate the old `PIDProfile` and `Profile` in to `Control Profile`
- Improve consistency by maintaining the order of `Control Profile`, `Mixer Profile`, and `Battery Profile`.
- Added missing `Set Heading Target` operator to the programming UI

Firmware https://github.com/iNavFlight/inav/pull/10102