### PR TITLE
Fix issue with opening external links in app's window.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, Menu, MenuItem } = require('electron');
+const { app, BrowserWindow, ipcMain, Menu, MenuItem, shell } = require('electron');
 const windowStateKeeper = require('electron-window-state');
 const path = require('path');
 const Store = require('electron-store');
@@ -148,6 +148,12 @@ function createWindow() {
   });
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    // Open links starts with https:// in default browser
+    if (url.startsWith('https://')) {
+      shell.openExternal(url);
+      return { action: 'deny' };
+    }
+
     return {
       action: 'allow',
       overrideBrowserWindowOptions: {


### PR DESCRIPTION
<img width="1483" alt="screenshot 2024-06-23 at 16 19 41" src="https://github.com/iNavFlight/inav-configurator/assets/80717202/316db82c-7c25-4a0d-861c-07a665f2da1f">

Fixed issue when all links in the configurator lead to the internal electron window.  After this fix all links that start with `https://` and have `target="_blank"` will open in default system browser (But not like on the screenshot).