### PR TITLE
Add UBLOX AssistNow support to configurator

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,6 +89,7 @@ sources.js = [
     './js/msp/MSPCodes.js',
     './js/msp/MSPHelper.js',
     './js/msp/MSPchainer.js',
+	'./js/ublox/UBLOX.js',
     './js/port_handler.js',
     './js/connection/connection.js',
     './js/connection/connectionBle.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,7 +89,7 @@ sources.js = [
     './js/msp/MSPCodes.js',
     './js/msp/MSPHelper.js',
     './js/msp/MSPchainer.js',
-	'./js/ublox/UBLOX.js',
+    './js/ublox/UBLOX.js',
     './js/port_handler.js',
     './js/connection/connection.js',
     './js/connection/connectionBle.js',

--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -81,6 +81,7 @@ $(function() {
         globalSettings.unitType = store.get('unit_type', UnitType.none);
         globalSettings.mapProviderType = store.get('map_provider_type', 'osm'); 
         globalSettings.mapApiKey = store.get('map_api_key', '');
+        globalSettings.assistnowApiKey = store.get('assistnow_api_key', '');
         globalSettings.proxyURL = store.get('proxyurl', 'http://192.168.1.222/mapproxy/service?');
         globalSettings.proxyLayer = store.get('proxylayer', 'your_proxy_layer_name');
         globalSettings.showProfileParameters = store.get('show_profile_parameters', 1);
@@ -340,6 +341,7 @@ $(function() {
                     $('#proxylayer').val(globalSettings.proxyLayer);
                     $('#showProfileParameters').prop('checked', globalSettings.showProfileParameters);
                     $('#cliAutocomplete').prop('checked', globalSettings.cliAutocomplete);
+                    $('#assistnow-api-key').val(globalSettings.assistnowApiKey);
                     
                     i18n.getLanguages().forEach(lng => {
                         $('#languageOption').append("<option value='{0}'>{1}</option>".format(lng, i18n.getMessage("language_" + lng)));
@@ -383,6 +385,11 @@ $(function() {
                         store.set('proxylayer', $(this).val());
                         globalSettings.proxyLayer = $(this).val();
                     });
+                    $('#assistnow-api-key').on('change', function () {
+                        store.set('assistnow_api_key', $(this).val());
+                        globalSettings.assistnowApiKey = $(this).val();
+                    });
+ 
                     $('#demoModeReset').on('click', function () {
                         SITLProcess.deleteEepromFile('demo.bin');
                     });

--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -78,6 +78,7 @@ $(function() {
             $('a', activeTab).trigger('click');
         }
 
+        globalSettings.store = store;
         globalSettings.unitType = store.get('unit_type', UnitType.none);
         globalSettings.mapProviderType = store.get('map_provider_type', 'osm'); 
         globalSettings.mapApiKey = store.get('map_api_key', '');
@@ -85,6 +86,8 @@ $(function() {
         globalSettings.proxyURL = store.get('proxyurl', 'http://192.168.1.222/mapproxy/service?');
         globalSettings.proxyLayer = store.get('proxylayer', 'your_proxy_layer_name');
         globalSettings.showProfileParameters = store.get('show_profile_parameters', 1);
+        globalSettings.assistnowOfflineData = store.get('assistnow_offline_data', []);
+        globalSettings.assistnowOfflineDate = store.get('assistnow_offline_date', 0);
         updateProfilesHighlightColours();
 
         var cliAutocomplete = store.get('cli_autocomplete', true);

--- a/js/globalSettings.js
+++ b/js/globalSettings.js
@@ -22,6 +22,13 @@ var globalSettings = {
     docsTreeLocation: 'master',
     cliAutocomplete: true,
     assistnowApiKey: null,
+    assistnowOfflineData: [],
+    assistnowOfflineDate: 0,
+    store: null,
+    saveAssistnowData:  function() {
+        this.store.set('assistnow_offline_data', this.assistnowOfflineData);
+        this.store.set('assistnow_offline_date', this.assistnowOfflineDate);
+    }
 };
 
 module.exports = { globalSettings, UnitType };

--- a/js/globalSettings.js
+++ b/js/globalSettings.js
@@ -21,6 +21,7 @@ var globalSettings = {
     // tree target for documents
     docsTreeLocation: 'master',
     cliAutocomplete: true,
+    assistnowApiKey: null,
 };
 
 module.exports = { globalSettings, UnitType };

--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -225,6 +225,8 @@ var MSPCodes = {
     MSP2_INAV_FW_APPROACH:              0x204A,
     MSP2_INAV_SET_FW_APPROACH:          0x204B,
 
+    MSP2_INAV_GPS_UBLOX_COMMAND:        0x2050,
+
     MSP2_INAV_RATE_DYNAMICS:            0x2060,
     MSP2_INAV_SET_RATE_DYNAMICS:        0x2061,
 

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1588,11 +1588,14 @@ var mspHelper = (function () {
                     FC.OSD_CUSTOM_ELEMENTS .items.push(customElement)
                 }
                 break;
+            case MSPCodes.MSP2_INAV_GPS_UBLOX_COMMAND:
+                // Just and ACK from the fc.
+                break;
 
             default:
-                console.log('Unknown code detected: ' + dataHandler.code);
+                console.log('Unknown code detected: 0x' + dataHandler.code.toString(16));
         } else {
-            console.log('FC reports unsupported message error: ' + dataHandler.code);
+            console.log('FC reports unsupported message error: 0x' + dataHandler.code.toString(16));
         }
 
         // trigger callbacks, cleanup/remove callback after trigger

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -3383,6 +3383,10 @@ var mspHelper = (function () {
         MSP.send_message(MSPCodes.MSP2_SET_CF_SERIAL_CONFIG, mspHelper.crunch(MSPCodes.MSP2_SET_CF_SERIAL_CONFIG), false, callback);
     };
 
+    self.sendUbloxCommand = function (ubloxData, callback) {
+        MSP.send_message(MSPCodes.MSP2_INAV_GPS_UBLOX_COMMAND, ubloxData, false, callback);
+    };
+
     return self;
 })();
 

--- a/js/ublox/UBLOX.js
+++ b/js/ublox/UBLOX.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const semver = require('semver');
+
+require('./../injected_methods');
+const { GUI } = require('./../gui');
+
+var ublox = (function () {
+    var self = {};
+    var assistnowOnline = null;
+    var assitnowOffline = null;
+    
+    self.init = function() {
+
+    };
+
+    self.loadAssitnowOffline = function(token) {
+
+    };
+
+    self.loadAssistnowOnline = function(token) {
+
+    }
+    
+});
+

--- a/js/ublox/UBLOX.js
+++ b/js/ublox/UBLOX.js
@@ -7,6 +7,7 @@ const jBox = require('./../libraries/jBox/jBox.min');
 const i18n = require('./../localization');
 const { GUI } = require('./../gui');
 const { globalSettings } = require('../globalSettings');
+const Store = require('electron-store');
 
 
 var ublox = (function () {
@@ -181,9 +182,16 @@ var ublox = (function () {
         console.log(url);
 
         function processOfflineData(data) {
-            assistnowOffline = splitUbloxData(data);
-            console.log("Assitnow offline commands:" + assistnowOffline.length);
-            callback(assistnowOffline);
+            if(globalSettings.assistnowOfflineData == null || ((Date.now() / 1000)-globalSettings.assistnowOfflineDate) > (60*60*24*3))  {
+                console.log("AssistnowOfflineData older than 3 days, refreshing.");
+                globalSettings.assistnowOfflineData = splitUbloxData(data);
+                globalSettings.assistnowOfflineDate = Math.floor(Date.now() / 1000);
+                globalSettings.saveAssistnowData();
+            } else {
+                console.log("AssitnowOfflineData newer than 3 days. Re-using.");
+            }
+            console.log("Assitnow offline commands:" + globalSettings.assistnowOfflineData.length);
+            callback(globalSettings.assistnowOfflineData);
         }
 
         getBinaryData(url, processOfflineData, loadError);

--- a/js/ublox/UBLOX.js
+++ b/js/ublox/UBLOX.js
@@ -63,8 +63,8 @@ var ublox = (function () {
     }
 
     function splitUbloxData(ubxBytesBuffer) {
-        console.log("type of data: " +typeof(ubxBytesBuffer));
-        console.log("splitUbloxData: " + ubxBytesBuffer.byteLength);
+        //console.log("type of data: " +typeof(ubxBytesBuffer));
+        //console.log("splitUbloxData: " + ubxBytesBuffer.byteLength);
         let ubxBytes = new DataView(ubxBytesBuffer);
 
         var ubxCommands = []
@@ -176,10 +176,9 @@ var ublox = (function () {
     // https://developer.thingstream.io/guides/location-services/assistnow-user-guide
     // Currently only supported for M8+ units
     self.loadAssistnowOffline = function(callback) {
-        // offline_url = "https://offline-live1.services.u-blox.com/GetOfflineData.ashx?token=" + offline_token + ";gnss=" + offline_gnss + ";format=" + fmt + ";period=" + period + ";resolution=1;alm=" + alm + ";"
 
         let url = `https://${ offlineServers[0] }/GetOfflineData.ashx?token=${globalSettings.assistnowApiKey};gnss=${offline_gnss};format=${fmt};period=${period};resolution=1;alm=${offline_alm};`
-        console.log(url);
+        //console.log(url);
 
         function processOfflineData(data) {
             if(globalSettings.assistnowOfflineData == null || ((Date.now() / 1000)-globalSettings.assistnowOfflineDate) > (60*60*24*3))  {
@@ -190,7 +189,7 @@ var ublox = (function () {
             } else {
                 console.log("AssitnowOfflineData newer than 3 days. Re-using.");
             }
-            console.log("Assitnow offline commands:" + globalSettings.assistnowOfflineData.length);
+            //console.log("Assitnow offline commands:" + globalSettings.assistnowOfflineData.length);
             callback(globalSettings.assistnowOfflineData);
         }
 
@@ -205,7 +204,7 @@ var ublox = (function () {
         function processOnlineData(data) {
             assistnowOnline = splitUbloxData(data);
 
-            console.log("Assitnow online commands:" + assistnowOnline.length);
+            //console.log("Assitnow online commands:" + assistnowOnline.length);
             callback(assistnowOnline);
         }
 
@@ -220,11 +219,11 @@ var ublox = (function () {
                 const payloadOffset = 6;
                 if (((ubxMessage[payloadOffset + 4] + 2000) == cy) && (ubxMessage[payloadOffset + 5] == cm) && (ubxMessage[payloadOffset + 6] == cd))
                 {
-                    console.log("UBX-MGA_ANO date matches");
+                    //console.log("UBX-MGA_ANO date matches");
                     return true;
                 }
             } else {
-                console.log("UBX-CMD: class: 0x" + ubxMessage[2].toString(16) + " id: 0x" + ubxMessage[3].toString(16));
+                //console.log("UBX-CMD: class: 0x" + ubxMessage[2].toString(16) + " id: 0x" + ubxMessage[3].toString(16));
                 return true;
             }
         

--- a/js/ublox/UBLOX.js
+++ b/js/ublox/UBLOX.js
@@ -169,7 +169,8 @@ var ublox = (function () {
 
 
     function loadError(event) {
-        GUI.alert("Error loading AssistNow data");
+        GUI.alert(i18n.getMessage("gpsAssistnowLoadDataError"));
+        console.log(i18n.getMessage("gpsAssistnowLoadDataError") + ':' + event.toString());
     }
 
     // For more info on assistnow, check:

--- a/js/ublox/UBLOX.js
+++ b/js/ublox/UBLOX.js
@@ -205,6 +205,25 @@ var ublox = (function () {
         getBinaryData(url, processOnlineData, loadError);
     }
 
+    self.isAssistnowDataRelevant = function(ubxMessage, cy, cm, cd) {
+        if ((ubxMessage[2] == 0x13 /*UBX_CLASS_MGA*/) && (ubxMessage[3] == 0x20 /*UBX_MGA_ANO*/))
+            {
+                // UBX-MGA-ANO
+                const payloadOffset = 6;
+                if (((ubxMessage[payloadOffset + 4] + 2000) == cy) && (ubxMessage[payloadOffset + 5] == cm) && (ubxMessage[payloadOffset + 6] == cd))
+                {
+                    console.log("UBX-MGA_ANO date matches");
+                    return true;
+                }
+            } else {
+                console.log("UBX-CMD: class: 0x" + ubxMessage[2].toString(16) + " id: 0x" + ubxMessage[3].toString(16));
+                return true;
+            }
+        
+            return false;
+    }
+
+
     return self;
 })();
 

--- a/js/ublox/UBLOX.js
+++ b/js/ublox/UBLOX.js
@@ -3,24 +3,190 @@
 const semver = require('semver');
 
 require('./../injected_methods');
+const jBox = require('./../libraries/jBox/jBox.min');
+const i18n = require('./../localization');
 const { GUI } = require('./../gui');
+const { globalSettings } = require('../globalSettings');
+
 
 var ublox = (function () {
     var self = {};
     var assistnowOnline = null;
-    var assitnowOffline = null;
+    var assistnowOffline = null;
+
+    // m7 = aid, not supported
+    // m8+ = mga
+    const fmt="mga";;
+    const gnss="gps,gal,bds,glo,qzss";
+
+    const onlineServers = [
+        'online-live1.services.u-blox.com',
+        'online-live2.services.u-blox.com',
+    ];
+
+    const period=5
+
+    const offline_gnss="gps,gal,bds,glo";
+    const offline_alm="gps,gal,bds,glo";
+
+    const offlineServers = [
+        'offline-live1.services.u-blox.com',
+        'offline-live2.services.u-blox.com'
+    ];
     
     self.init = function() {
 
     };
 
-    self.loadAssitnowOffline = function(token) {
+    var hasFirstHeader;
+    var hasSecondHeader;
+    var ubxClass;
+    var ubxId;
+    var lenLow;
+    var lenHigh;
+    var payloadLen;
+    var skipped;
+    var currentCommand;
 
+    function resetUbloxState() {
+        console.log("Reset ublox state");
+        hasFirstHeader = false;
+        hasSecondHeader = false;
+        ubxClass = false;
+        ubxId = false;
+        lenLow = false;
+        lenHigh = false;
+        payloadLen = 0;
+        skipped = 0;
+        currentCommand = [];
+    }
+
+    function splitUbloxData(ubxBytes) {
+        console.log("type of data: " +typeof(ubxBytes));
+        console.log("splitUbloxData: " + ubxBytes.length);
+
+        var ubxCommands = []
+        resetUbloxState()
+
+        for(var i = 0; i < ubxBytes.length;++i) {
+            let c = ubxBytes.charCodeAt(i);
+            //let c = ubxBytes[i];
+            if (!hasFirstHeader) {
+                if (c == 0xb5) {
+                    console.log("First header");
+                    hasFirstHeader = true;
+                    currentCommand.push(c);
+                    continue;
+                } 
+                else
+                {
+                    resetUbloxState();
+                    continue;
+                }
+            }
+            if (!hasSecondHeader) {
+                if (c == 0x62) {
+                    console.log("Second header");
+                    hasSecondHeader = true;
+                    currentCommand.push(c);
+                    continue;
+                }
+                else
+                {
+                    resetUbloxState();
+                    continue;
+                }
+            }
+            if (!ubxClass) {
+                ubxClass = true;
+                console.log("ubxClass: 0x"+ (c).toString(16));
+                currentCommand.push(c)
+                continue;
+            }
+            if (!ubxId) {
+                ubxId = true;
+                console.log("ubxId: 0x"+ (c).toString(16));
+                currentCommand.push(c);
+                continue;
+            }
+            if (!lenLow) {
+                console.log("Len low");
+                lenLow = true;
+                //(int) c
+                payloadLen = c;
+                currentCommand.push(c);
+                continue;
+            }
+            if (!lenHigh) {
+                console.log("Len high");
+                lenHigh = true;
+                // (int)c
+                payloadLen = (c << 8) | payloadLen;
+                console.log("Payload len " + payloadLen);
+                payloadLen += 2; // add crc bytes;
+                currentCommand.push(c);
+                continue
+            }
+            if (skipped < payloadLen - 1) {
+                console.log("payload + crc");
+                skipped = skipped + 1;
+                currentCommand.push(c);
+                continue;
+            }
+            if (skipped == payloadLen - 1) {
+                skipped = skipped + 1;
+                currentCommand.push(c);
+                ubxCommands.push(currentCommand);
+                console.log("Adding command");
+                resetUbloxState();
+                continue;
+            }
+        }
+        return ubxCommands
+    }
+
+    function processOnlineData(data) {
+        assistnowOnline = splitUbloxData(data);
+
+        console.log("Assitnow online commands:" + assistnowOnline.length);
+    }
+
+    function processOfflineData(data) {
+        assistnowOffline = splitUbloxData(data);
+        console.log("Assitnow offline commands:" + assistnowOffline.length);
+    }
+
+
+
+    // For more info on assistnow, check:
+    // https://developer.thingstream.io/guides/location-services/assistnow-user-guide
+    // Currently only supported for M8+ units
+    self.loadAssistnowOffline = function(callback) {
+        // offline_url = "https://offline-live1.services.u-blox.com/GetOfflineData.ashx?token=" + offline_token + ";gnss=" + offline_gnss + ";format=" + fmt + ";period=" + period + ";resolution=1;alm=" + alm + ";"
+
+        let url = `https://${ offlineServers[0] }/GetOfflineData.ashx?token=${globalSettings.assistnowApiKey};gnss=${offline_gnss};format=${fmt};period=${period};resolution=1;alm=${offline_alm};`
+        console.log(url);
+
+        $.get(url, processOfflineData).fail(function() {GUI.alert("Error loading Offline data")});
+
+        if(callback != null) {
+            callback("");
+        }
     };
 
-    self.loadAssistnowOnline = function(token) {
+    self.loadAssistnowOnline = function(callback) {
+        //url = "https://online-live1.services.u-blox.com/GetOnlineData.ashx?token=" + online_token + ";gnss=" + gnss + ";datatype=eph,alm,aux,pos;format=" + fmt + ";"
+        let url = `https://${ onlineServers[0] }/GetOnlineData.ashx?token=${globalSettings.assistnowApiKey};gnss=${ gnss };datatype=eph,alm,aux,pos;format=${ fmt }`;
 
+        $.get(url, processOnlineData).fail(function() {GUI.alert("Error loading Offline data")});
+
+        if(callback != null) {
+            callback("");
+        }
     }
-    
-});
 
+    return self;
+})();
+
+
+module.exports = ublox;

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5917,5 +5917,11 @@
     },
     "gpsOptionsAssistnowToken": {
         "message": "AssitNow Token"
+    },
+    "gpsLoadAssistnowOfflineButton": {
+        "message": "Load AssistNow Offline"
+    },
+    "gpsLoadAssistnowOnlineButton": {
+        "message": "Load AssistNow Online"
     }
 }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5932,5 +5932,8 @@
     },
     "gpsAssistnowUpdate": {
         "message": "AssistNow messages sent."
+    },
+    "gpsAssistnowLoadDataError": {
+        "message": "Error loading AssistNow data."
     }
 }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5925,12 +5925,12 @@
         "message": "Load AssistNow Online"
     },
     "gpsAssistnowStart": {
-        "message": "Assistnow data transfer starting..."
+        "message": "AssistNow data transfer starting..."
     },
     "gpsAssistnowDone": {
-        "message": "Assistnow data transfer complete."
+        "message": "AssistNow data transfer complete."
     },
     "gpsAssistnowUpdate": {
-        "message": "Assistnow messages sent."
+        "message": "AssistNow messages sent."
     }
 }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5923,5 +5923,14 @@
     },
     "gpsLoadAssistnowOnlineButton": {
         "message": "Load AssistNow Online"
+    },
+    "gpsAssistnowStart": {
+        "message": "Assistnow data transfer starting..."
+    },
+    "gpsAssistnowDone": {
+        "message": "Assistnow data transfer complete."
+    },
+    "gpsAssistnowUpdate": {
+        "message": "Assistnow messages sent."
     }
 }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5911,5 +5911,11 @@
     },
     "maintenanceFlushSettingsCache": {
         "message": "Flush settings cache"
+    },
+    "gpsOptions": {
+        "message": "GPS Options"
+    },
+    "gpsOptionsAssistnowToken": {
+        "message": "AssitNow Token"
     }
 }

--- a/tabs/gps.html
+++ b/tabs/gps.html
@@ -159,5 +159,11 @@
         <div class="btn save_btn">
             <a class="save" href="#" data-i18n="configurationButtonSave"></a>
         </div>
+        <div class="btn save_btn">
+            <a class="loadAssistnowOnline" href="#" data-i18n="gpsLoadAssistnowOnlineButton"></a>
+        </div>
+        <div class="btn save_btn">
+            <a class="loadAssistnowOffline" href="#" data-i18n="gpsLoadAssistnowOfflineButton"></a>
+        </div>
     </div>
 </div>

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -427,15 +427,25 @@ TABS.gps.initialize = function (callback) {
 
                 var ubloxChainer = MSPChainerClass();
                 var chain = [];
+                let d = new Date();
 
                 GUI.log(i18n.getMessage('gpsAssistnowStart'));
                 data.forEach((item) => {
                     chain.push(function (callback) {
                         //console.log("UBX command: " + item.length);
-                        mspHelper.sendUbloxCommand(item, callback);
+                        let callCallback = false;
+                        if (ublox.isAssistnowDataRelevant(item, d.getUTCFullYear(), d.getUTCMonth()+1, d.getUTCDate()+1)) {
+                            mspHelper.sendUbloxCommand(item, callback);
+                        } else {
+                            // Ignore msp command, but keep counter going.
+                            callCallback = true;
+                        }
                         totalSent++;
                         if((totalSent % 100) == 0) {
                             GUI.log(totalSent + '/' + total + ' ' + i18n.getMessage('gpsAssistnowUpdate'));
+                        }
+                        if(callCallback) {
+                            callback();
                         }
                     });
                 });

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -18,6 +18,7 @@ const features = require('./../js/feature_framework');
 const { globalSettings } = require('./../js/globalSettings');
 const jBox = require('./../js/libraries/jBox/jBox.min');
 const SerialBackend = require('../js/serial_backend');
+const ublox = require('../js/ublox/UBLOX');
 
 
 TABS.gps = {};
@@ -416,6 +417,29 @@ TABS.gps.initialize = function (callback) {
             features.execute(function () {
                 saveChainer.execute();
             });
+        });
+
+        function processUbloxData(data) {
+            if(data != null) {
+                // foreach data
+                //mspHelper.sendUbloxCommand(d);
+            }
+        }
+
+        $('a.loadAssistnowOnline').on('click', function () {
+            if(globalSettings.assistnowApiKey != null && globalSettings.assistnowApiKey != '') {
+                ublox.loadAssistnowOnline(processUbloxData);
+           } else {
+                GUI.alert("Assistnow Token not set!");
+            }
+        });
+
+        $('a.loadAssistnowOffline').on('click', function () {
+            if(globalSettings.assistnowApiKey != null && globalSettings.assistnowApiKey != '') {
+                ublox.loadAssistnowOffline(processUbloxData);
+            } else {
+                GUI.alert("Assistnow Token not set!");
+            }
         });
 
         GUI.content_ready(callback);

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -421,8 +421,33 @@ TABS.gps.initialize = function (callback) {
 
         function processUbloxData(data) {
             if(data != null) {
-                // foreach data
-                //mspHelper.sendUbloxCommand(d);
+                //console.log("processing data type: " + typeof(data));
+                let totalSent = 0;
+                let total = data.length;
+
+                var ubloxChainer = MSPChainerClass();
+                var chain = [];
+
+                GUI.log(i18n.getMessage('gpsAssistnowStart'));
+                data.forEach((item) => {
+                    chain.push(function (callback) {
+                        //console.log("UBX command: " + item.length);
+                        mspHelper.sendUbloxCommand(item, callback);
+                        totalSent++;
+                        if((totalSent % 100) == 0) {
+                            GUI.log(totalSent + '/' + total + ' ' + i18n.getMessage('gpsAssistnowUpdate'));
+                        }
+                    });
+                });
+                ubloxChainer.setChain(chain);
+                ubloxChainer.setExitPoint(function () {
+                    if ((totalSent % 100) != 0) {
+                        GUI.log(totalSent + '/' + total + ' ' + i18n.getMessage('gpsAssistnowUpdate'));
+                    }
+                    GUI.log(i18n.getMessage('gpsAssistnowDone'));
+                });
+
+                ubloxChainer.execute();
             }
         }
 

--- a/tabs/options.html
+++ b/tabs/options.html
@@ -97,5 +97,17 @@
                 </div>
             </div>
         </div>
+        <div class="options-section gui_box grey">
+            <div class="gui_box_titlebar">
+                <div class="spacer_box_title" data-i18n="gpsOptions"></div>
+            </div>
+
+            <div class="spacer_box settings">
+                <div class="number">
+                    <input type="password" id="assistnow-api-key" style="border: solid 1px black" />                
+                    <label for="assistnow-api-key" data-i18n="gpsOptionsAssistnowToken"></label>                    
+                </div>
+            </div>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Make use of iNavFlight/inav#9349 to send Assistnow messages to GPS.

Should help seeding gps info from the internet to speed up initial lock on M8+ GPS devices.

You will need to provide your own AssistNow token.

The configurator can cache AssistNow Offline information for up to 3 days. Currently, the information is not written to the GPS unit flash, so it needs to be applied after the fc has been turned on.

Information on how to register for a token is available at:
https://developer.thingstream.io/guides/location-services/assistnow-getting-started-guide


General information on AssistNow:
https://developer.thingstream.io/guides/location-services/assistnow-user-guide

Token can be setup on Application options:
<img width="573" alt="image" src="https://github.com/iNavFlight/inav-configurator/assets/23555060/bbcf6db8-c24a-4887-82b9-ebd970827deb">

Both AssistNow Online and Offline are supported.

<img width="889" alt="image" src="https://github.com/iNavFlight/inav-configurator/assets/23555060/a99a0281-d650-4594-9b19-043fc015495a">


Currently, both require an active internet connection, but AssistNow Offline is saved and can be re-used for 3 days (can probably be kept a bit longer).