### PR TITLE
Get latest release instead of list of all releases in version checker

### DIFF
--- a/js/appUpdater.js
+++ b/js/appUpdater.js
@@ -10,12 +10,11 @@ var appUpdater = appUpdater || {};
 
 appUpdater.checkRelease = function (currVersion) {
     var modalStart;
-    $.get('https://api.github.com/repos/iNavFlight/inav-configurator/releases', function (releaseData) {
+    $.get('https://api.github.com/repos/iNavFlight/inav-configurator/releases/latest', function (releaseData) {
         GUI.log(i18n.getMessage('loadedReleaseInfo'));
-        //Git return sorted list, 0 - last release
 
-        let newVersion = releaseData[0].tag_name;
-        let newPrerelase = releaseData[0].prerelease;
+        let newVersion = releaseData.tag_name;
+        let newPrerelase = releaseData.prerelease;
 
         if (newPrerelase == false && semver.gt(newVersion, currVersion)) {
             GUI.log(newVersion, app.getVersion());


### PR DESCRIPTION
It is possible to retrieve the desired release directly instead of the approach when you get a whole list of releases and then get the latest one from the sorted list.

Currently, the number of releases retrieved from `/repos/iNavFlight/inav-configurator/releases` equals to 29. That's approximately **600KB** of data retrieved every check in json.
After this update the size of loaded json through `/repos/iNavFlight/inav-configurator/releases/latest` is about **24KB** 