### PR TITLE
clear separation between mixer preset and wizard

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -2096,7 +2096,7 @@
         "message": "Mixer <span style=\"color: #37a8db\">saved</span>"
     },
     "mixerWizard": {
-        "message": "Mixer wizard"
+        "message": "Motor Mixer Wizard"
     },
     "mixerWizardInfo": {
         "message": "<ol><li>Remove propellers</li><li>Connect LiPo and use Outputs Tab to test all motors</li><li>Note the position of each motor (motor #1 - Left Top and so on)</li><li>Fill the table below</li></ol>"

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -71,9 +71,6 @@
 
                             <div class="mixer-load-button">
                                 <div id="needToUpdateMixerMessage" class="is-hidden" data-i18n="mixerNotLoaded"></div>
-                                <div class="btn default_btn narrow green is-hidden">
-                                    <a id="mixer-wizard" href="#" data-i18n="mixerWizard"></a>
-                                </div>
                                 <div class="btn default_btn narrow red">
                                     <a id="load-and-apply-mixer-button" href="#" data-i18n="mixerLoadAndApplyPresetRules"></a>
                                 </div>
@@ -87,6 +84,17 @@
                         </div>
                     </div>
                 </div>
+                <div class="platform-type gui_box grey">
+                    <div class="gui_box_titlebar">
+                        <div class="spacer_box_title" data-i18n="mixerWizard"></div>
+                    </div>
+
+                <div class="spacer_box">
+                    <div class="btn default_btn narrow green is-hidden">
+                        <a id="mixer-wizard" href="#" data-i18n="mixerWizard"></a>
+                    </div>
+                </div>
+              </div>
             </div>
         </div>
         <div class="clear-both"></div>
@@ -264,7 +272,8 @@
                 </table>
             </div>
         </div>
-        <div class="modal__buttons">
+
+        <div class="modal__buttons--upbottom">
             <a id="wizard-execute-button" class="modal__button modal__button--main" data-i18n="mixerWizardModalApply"></a>
         </div>
     </div>

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -84,17 +84,17 @@
                         </div>
                     </div>
                 </div>
-                <div class="platform-type gui_box grey">
+                <div class="platform-type gui_box grey" id="mixer-wizard-gui_box" is-hidden>
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title" data-i18n="mixerWizard"></div>
                     </div>
-
-                <div class="spacer_box">
-                    <div class="btn default_btn narrow green is-hidden">
-                        <a id="mixer-wizard" href="#" data-i18n="mixerWizard"></a>
+                
+                    <div class="spacer_box">
+                        <div class="btn default_btn narrow green">
+                            <a id="mixer-wizard" href="#" data-i18n="mixerWizard"></a>
+                        </div>
                     </div>
                 </div>
-              </div>
             </div>
         </div>
         <div class="clear-both"></div>

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -696,9 +696,9 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
             FC.MIXER_CONFIG.appliedMixerPreset = presetId;
 
             if (currentMixerPreset.id == 3) {
-                $wizardButton.parent().removeClass("is-hidden");
+                $("#mixer-wizard-gui_box").removeClass("is-hidden");
             } else {
-                $wizardButton.parent().addClass("is-hidden");
+                $("#mixer-wizard-gui_box").addClass("is-hidden");
             }
 
             if (FC.MIXER_CONFIG.platformType == PLATFORM.AIRPLANE && currentMixerPreset.id != loadedMixerPresetID) {


### PR DESCRIPTION
Moves the mixer wizard button out of the mixer preset section because of user confusion.
Users expected the mixer preset stuff like "load and apply" to be tied to mixer wizard because of the way the elements were positioned on screen.  They would try to "load and apply" the results of the wizard, etc.

Now:
![image](https://github.com/user-attachments/assets/0759fc70-f0da-4ee6-8bf4-df6a333c48ea)
