### PR TITLE
Add ability to add GEO files to mission planner map.

### DIFF
--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -469,7 +469,7 @@
             </div>
         </div>
         <div class="cf_column threefourth_left" style="height: 100%;">
-            <div id="geo_info">&nbsp;</div>
+            <div id="geo_info" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">&nbsp;</div>
             <div id="missionMap"></div>
             <div id="missionPlannerElevation" class="gui_box grey" style="display: none">
                 <div class="gui_box_titlebar">

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -469,6 +469,7 @@
             </div>
         </div>
         <div class="cf_column threefourth_left" style="height: 100%;">
+            <div id="geo_info">&nbsp;</div>
             <div id="missionMap"></div>
             <div id="missionPlannerElevation" class="gui_box grey" style="display: none">
                 <div class="gui_box_titlebar">

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -29,6 +29,7 @@ const SerialBackend = require('./../js/serial_backend');
 const { distanceOnLine, wrap_360, calculate_new_cooridatnes } = require('./../js/helpers');
 const Plotly = require('./../js/libraries/plotly-latest.min');
 const interval = require('./../js/intervals');
+const {generateFilename} = require("../js/helpers");
 
 var MAX_NEG_FW_LAND_ALT = -2000; // cm
 
@@ -1746,12 +1747,20 @@ TABS.mission_control.initialize = function (callback) {
 
             var feature = map.forEachFeatureAtPixel(evt.pixel,
                 function (feature, layer) {
-                    return feature;
+                    if(layer.get("no_interaction") != true){
+                        return feature;
+                    }
+                    // for features from layers that have this set to true, ignore their existence.
+                    // This currently applies only to files the user has dragged onto the map.
                 });
 
             tempMarker = map.forEachFeatureAtPixel(evt.pixel,
                 function (feature, layer) {
-                    return layer;
+                    if(layer.get("no_interaction") != true){
+                        return layer;
+                    }
+                    // for features from layers that have this set to true, ignore their existence.
+                    // This currently applies only to files the user has dragged onto the map.
                 });
 
             if (feature) {
@@ -1989,11 +1998,13 @@ TABS.mission_control.initialize = function (callback) {
                     features: event.features,
                 });
                 GUI.log("adding file to map");
-                map.addLayer(
-                    new ol.layer.Vector({
-                        source: vectorSource,
-                    }),
-                );
+
+                let temp_layer = new ol.layer.Vector({
+                    source: vectorSource,
+                });
+                temp_layer.set("no_interaction", true, true);
+
+                map.addLayer(temp_layer);
             });
             map.addInteraction(dragAndDropInteraction);
         }

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -29,7 +29,6 @@ const SerialBackend = require('./../js/serial_backend');
 const { distanceOnLine, wrap_360, calculate_new_cooridatnes } = require('./../js/helpers');
 const Plotly = require('./../js/libraries/plotly-latest.min');
 const interval = require('./../js/intervals');
-const {generateFilename} = require("../js/helpers");
 
 var MAX_NEG_FW_LAND_ALT = -2000; // cm
 

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2004,7 +2004,9 @@ TABS.mission_control.initialize = function (callback) {
         const displayFeatureInfo = function (pixel) {
             const features = [];
             map.forEachFeatureAtPixel(pixel, function (feature) {
-                features.push(feature);
+                if (feature.get('name') !== "Null Island"){
+                    features.push(feature);
+                }
             });
             if (features.length > 0) {
                 const info = [];

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2004,6 +2004,7 @@ TABS.mission_control.initialize = function (callback) {
                 });
                 temp_layer.set("no_interaction", true, true);
 
+                temp_layer.set("show_info_on_hover", true, true); // allows info box to work with this feature
                 map.addLayer(temp_layer);
             });
             map.addInteraction(dragAndDropInteraction);
@@ -2014,7 +2015,7 @@ TABS.mission_control.initialize = function (callback) {
         const displayFeatureInfo = function (pixel) {
             const features = [];
             map.forEachFeatureAtPixel(pixel, function (feature) {
-                if (feature.get('name') !== "Null Island"){
+                if (feature.get('show_info_on_hover') === true){
                     features.push(feature);
                 }
             });

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1965,6 +1965,69 @@ TABS.mission_control.initialize = function (callback) {
             })
         });
 
+        //////////////////////////////////////////////////////////////////////////////////////////////
+        // Add drag and drop support for GEO files
+        //////////////////////////////////////////////////////////////////////////////////////////////
+
+        let dragAndDropInteraction;
+
+        function setInteraction() {
+            if (dragAndDropInteraction) {
+                map.removeInteraction(dragAndDropInteraction);
+            }
+            dragAndDropInteraction = new ol.interaction.DragAndDrop({
+                formatConstructors: [
+                    ol.format.GPX,
+                    ol.format.GeoJSON,
+                    ol.format.IGC,
+                    ol.format.KML,
+                    ol.format.TopoJSON,
+                ],
+            });
+            dragAndDropInteraction.on('addfeatures', function (event) {
+                const vectorSource = new ol.source.Vector({
+                    features: event.features,
+                });
+                GUI.alert("adding file");
+                map.addLayer(
+                    new ol.layer.Vector({
+                        source: vectorSource,
+                    }),
+                );
+                map.getView().fit(vectorSource.getExtent());
+            });
+            map.addInteraction(dragAndDropInteraction);
+        }
+        setInteraction();
+
+
+        const displayFeatureInfo = function (pixel) {
+            const features = [];
+            map.forEachFeatureAtPixel(pixel, function (feature) {
+                features.push(feature);
+            });
+            if (features.length > 0) {
+                const info = [];
+                let i, ii;
+                for (i = 0, ii = features.length; i < ii; ++i) {
+                    info.push(features[i].get('name'));
+                }
+                document.getElementById('geo_info').innerHTML = info.join(', ') || '&nbsp';
+            } else {
+                document.getElementById('geo_info').innerHTML = '&nbsp;';
+            }
+        };
+
+        map.on('pointermove', function (evt) {
+            if (evt.dragging) {
+                return;
+            }
+            const pixel = map.getEventPixel(evt.originalEvent);
+            displayFeatureInfo(pixel);
+        });
+
+
+
         //////////////////////////////////////////////////////////////////////////
         // Set the attribute link to open on an external browser window, so
         // it doesn't interfere with the configurator.

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2002,8 +2002,7 @@ TABS.mission_control.initialize = function (callback) {
                 let temp_layer = new ol.layer.Vector({
                     source: vectorSource,
                 });
-                temp_layer.set("no_interaction", true, true);
-
+                temp_layer.set("no_interaction", true, true); // stops custom dragging controls for waypoints from preventing the user panning the map
                 temp_layer.set("show_info_on_hover", true, true); // allows info box to work with this feature
                 map.addLayer(temp_layer);
             });
@@ -2011,7 +2010,10 @@ TABS.mission_control.initialize = function (callback) {
         }
         setInteraction();
 
-
+        /**
+         * Populates info box with names of all features marked to display info that the mouse is over
+         * @param pixel the pixel the mouse is over
+         */
         const displayFeatureInfo = function (pixel) {
             const features = [];
             map.forEachFeatureAtPixel(pixel, function (feature) {

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1994,7 +1994,6 @@ TABS.mission_control.initialize = function (callback) {
                         source: vectorSource,
                     }),
                 );
-                map.getView().fit(vectorSource.getExtent());
             });
             map.addInteraction(dragAndDropInteraction);
         }

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1988,7 +1988,7 @@ TABS.mission_control.initialize = function (callback) {
                 const vectorSource = new ol.source.Vector({
                     features: event.features,
                 });
-                GUI.alert("adding file");
+                GUI.log("adding file to map");
                 map.addLayer(
                     new ol.layer.Vector({
                         source: vectorSource,


### PR DESCRIPTION
I basically just stole the example from openlayers, and then fixed a bug where the custom drag handler for waypoints was interfering with panning over imported zones.

This feature is the bare minimum, but it does work, and mostly importantly it doesn't change any functionality. The only way a user would even find out this change was made is if they happen to drag a KML or other geo-file over the map.

Why did I add this? 
I was doing WP mission over a massive plot of land and had trouble identifying landmarks, as well as making sure to stay on 'my' side of the property line. I have the property lines and trails and waypoints saved as KML files for a different project, and figured it would also be useful for staying out of restricted airspace. The advantages for surveying would also be numerous.

"Isn't this just budget GeoZones?"
Yes. But also no. GeoZones will be priceless for staying out of certain zones, but I believe there is an advantage to keeping some features only visible locally in the configurator. While I am trying to work with the developer working on GeoZones to add support for importing them from other geo-files, like KML, the fact that this feature is so unobtrusive makes me think that even if I am the only person in the world who will ever use it, it's still worth it. GeoZones are also limited by the on-board EEPROM, meaning my example of the property line wouldn't work because it has too many vertices.