### PR TITLE
add BBL SERVO logging option

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1238,16 +1238,16 @@
     "configurationGimbal": {
         "message": "Serial Gimbal"
     },
-    "configurationGimbalSensitivity": { 
+    "configurationGimbalSensitivity": {
         "message":"Gimbal sensitivity"
     },
-    "configurationGimbalPanChannel": { 
+    "configurationGimbalPanChannel": {
         "message":"Pan channel (yaw)"
     },
-    "configurationGimbalTiltChannel": { 
+    "configurationGimbalTiltChannel": {
         "message":"Tilt channel (pitch)"
     },
-    "configurationGimbalRollChannel": { 
+    "configurationGimbalRollChannel": {
         "message":"Roll channel"
     },
     "configurationHeadtracker": {
@@ -5217,6 +5217,9 @@
     },
     "BLACKBOX_FEATURE_GYRO_PEAKS_YAW": {
         "message": "Gyro Noise peak freq. Yaw"
+    },
+    "BLACKBOX_FEATURE_SERVOS": {
+        "message": "Servos output"
     },
     "axisRoll": {
         "message": "Roll"

--- a/tabs/onboard_logging.js
+++ b/tabs/onboard_logging.js
@@ -38,6 +38,7 @@ TABS.onboard_logging.initialize = function (callback) {
         "BLACKBOX_FEATURE_GYRO_PEAKS_ROLL",
         "BLACKBOX_FEATURE_GYRO_PEAKS_PITCH",
         "BLACKBOX_FEATURE_GYRO_PEAKS_YAW",
+        "BLACKBOX_FEATURE_SERVOS",
     ];
 
     if (GUI.active_tab != 'onboard_logging') {


### PR DESCRIPTION
Adds SERVO to the set of BBL optional fields. (see also https://github.com/iNavFlight/inav/pull/10272)