### PR TITLE
Add feature: Local map overlays for mission planner

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -76,6 +76,8 @@ function createWindow() {
     },
   });
 
+  mainWindow.webContents.openDevTools();
+
   mainWindow.webContents.on('context-menu', (_, props) => {
     const menu = new Menu()  ;
     menu.append(new MenuItem({ label: "Undo", role: "undo", accelerator: 'CmdOrCtrl+Z', visible: props.isEditable }));

--- a/js/main.js
+++ b/js/main.js
@@ -76,8 +76,6 @@ function createWindow() {
     },
   });
 
-  mainWindow.webContents.openDevTools();
-
   mainWindow.webContents.on('context-menu', (_, props) => {
     const menu = new Menu()  ;
     menu.append(new MenuItem({ label: "Undo", role: "undo", accelerator: 'CmdOrCtrl+Z', visible: props.isEditable }));

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5937,7 +5937,7 @@
         "message": "Error loading AssistNow data."
     },
     "layerVisibilitySelectBoxTitle": {
-        "message": "Select Visible Layers"
+        "message": "Layer Visibility"
     },
     "layerVisibilitySelectCancel": {
         "message": "Cancel"

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5935,5 +5935,14 @@
     },
     "gpsAssistnowLoadDataError": {
         "message": "Error loading AssistNow data."
+    },
+    "layerVisibilitySelectBoxTitle": {
+        "message": "Select Visible Layers"
+    },
+    "layerVisibilitySelectCancel": {
+        "message": "Cancel"
+    },
+    "layerVisibilitySelectHide": {
+        "message": "Hide"
     }
 }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5944,5 +5944,11 @@
     },
     "layerVisibilitySelectHide": {
         "message": "Hide"
+    },
+    "layerVisibilityWindowLayerSave": {
+        "message": "Save"
+    },
+    "layerVisibilityWindowLayerDelete": {
+        "message": "Delete"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "@electron-forge/maker-rpm": "^7.2.0",
         "@electron-forge/maker-wix": "^7.2.0",
         "@electron-forge/maker-zip": "^7.2.0",
-        "@electron/packager": "^18.3.3",
         "electron": "28.1.4",
         "node-gyp": "^10.1.0"
       }
@@ -536,11 +535,10 @@
       }
     },
     "node_modules/@electron/packager": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.3.3.tgz",
-      "integrity": "sha512-hGXzwbUdxv49XvlYwlVPC6W6j6WaXUAzKkYyyTeiwdhxvHFMfQSEJxVHsQpqMFzZZ7wrr7iqiokOFZ/qkgEzUQ==",
+      "version": "18.3.2",
+      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.3.2.tgz",
+      "integrity": "sha512-orjylavppgIh24qkNpWm2B/LQUpCS/YLOoKoU+eMK/hJgIhShLDsusPIQzgUGVwNCichu8/zPAGfdQZXHG0gtw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "@electron/get": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@electron-forge/maker-rpm": "^7.2.0",
         "@electron-forge/maker-wix": "^7.2.0",
         "@electron-forge/maker-zip": "^7.2.0",
+        "@electron/packager": "^18.3.3",
         "electron": "28.1.4",
         "node-gyp": "^10.1.0"
       }
@@ -535,10 +536,11 @@
       }
     },
     "node_modules/@electron/packager": {
-      "version": "18.3.2",
-      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.3.2.tgz",
-      "integrity": "sha512-orjylavppgIh24qkNpWm2B/LQUpCS/YLOoKoU+eMK/hJgIhShLDsusPIQzgUGVwNCichu8/zPAGfdQZXHG0gtw==",
+      "version": "18.3.3",
+      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.3.3.tgz",
+      "integrity": "sha512-hGXzwbUdxv49XvlYwlVPC6W6j6WaXUAzKkYyyTeiwdhxvHFMfQSEJxVHsQpqMFzZZ7wrr7iqiokOFZ/qkgEzUQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "@electron/get": "^3.0.0",

--- a/src/css/tabs/mission_planer.css
+++ b/src/css/tabs/mission_planer.css
@@ -285,6 +285,11 @@
       float: left;
     }
 */
+.layer-vis-select {
+    top: 160px;
+    left: .5em;
+}
+
 .mission-control-settings {
     top: 65px;
     left: .5em;

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -65,6 +65,21 @@
                     </div>
                 </div>
 
+                <div id="layerVisibilitySelect" class="gui_box grey" style="display: none">
+                    <div class="gui_box_titlebar">
+                        <div class="spacer_box_title" data-i18n="layerVisibilitySelectBoxTitle"></div>
+                        <div class="btnMenu btnMenuIcon  save_btn">
+                            <div id="showHideVisibilityButton">
+                                <a class="ic_hide" href="#" i18n_title="layerVisibilitySelectHide"></a>
+                            </div>
+                            <a id="cancelVisibility" class="ic_cancel" href="#" i18n_title="layerVisibilitySelectCancel"></a>
+                        </div>
+                        <div class="spacer" id="layerSelectContent">
+
+                        </div>
+                    </div>
+                </div>
+
                 <div id="missionPlannerSettings" class="gui_box grey" style="display: none">
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title" data-i18n="missionDefaultSettingsHead"></div>

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -469,7 +469,7 @@
             </div>
         </div>
         <div class="cf_column threefourth_left" style="height: 100%;">
-            <div id="geo_info">&nbsp;</div>
+            <div id="geo_info" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">&nbsp;</div>
             <div id="missionMap"></div>
             <div id="missionPlannerElevation" class="gui_box grey" style="display: none">
                 <div class="gui_box_titlebar">

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -65,7 +65,7 @@
                     </div>
                 </div>
 
-                <div id="layerVisibilitySelect" class="gui_box grey" style="display: none">
+                <div id="layerVisibilitySelect" class="config-section gui_box grey" style="display: none">
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title" data-i18n="layerVisibilitySelectBoxTitle"></div>
                         <div class="btnMenu btnMenuIcon  save_btn">
@@ -74,9 +74,10 @@
                             </div>
                             <a id="cancelVisibility" class="ic_cancel" href="#" i18n_title="layerVisibilitySelectCancel"></a>
                         </div>
-                        <div class="spacer" id="layerSelectContent">
+                    </div>
+                    <div class="spacer_box" id="layerSelectContent">
 
-                        </div>
+
                     </div>
                 </div>
 

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -469,6 +469,7 @@
             </div>
         </div>
         <div class="cf_column threefourth_left" style="height: 100%;">
+            <div id="geo_info">&nbsp;</div>
             <div id="missionMap"></div>
             <div id="missionPlannerElevation" class="gui_box grey" style="display: none">
                 <div class="gui_box_titlebar">

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -29,6 +29,7 @@ const SerialBackend = require('./../js/serial_backend');
 const { distanceOnLine, wrap_360, calculate_new_cooridatnes } = require('./../js/helpers');
 const Plotly = require('./../js/libraries/plotly-latest.min');
 const interval = require('./../js/intervals');
+const {generateFilename} = require("../js/helpers");
 
 var MAX_NEG_FW_LAND_ALT = -2000; // cm
 
@@ -1746,12 +1747,20 @@ TABS.mission_control.initialize = function (callback) {
 
             var feature = map.forEachFeatureAtPixel(evt.pixel,
                 function (feature, layer) {
-                    return feature;
+                    if(layer.get("no_interaction") != true){
+                        return feature;
+                    }
+                    // for features from layers that have this set to true, ignore their existence.
+                    // This currently applies only to files the user has dragged onto the map.
                 });
 
             tempMarker = map.forEachFeatureAtPixel(evt.pixel,
                 function (feature, layer) {
-                    return layer;
+                    if(layer.get("no_interaction") != true){
+                        return layer;
+                    }
+                    // for features from layers that have this set to true, ignore their existence.
+                    // This currently applies only to files the user has dragged onto the map.
                 });
 
             if (feature) {
@@ -1989,11 +1998,13 @@ TABS.mission_control.initialize = function (callback) {
                     features: event.features,
                 });
                 GUI.log("adding file to map");
-                map.addLayer(
-                    new ol.layer.Vector({
-                        source: vectorSource,
-                    }),
-                );
+
+                let temp_layer = new ol.layer.Vector({
+                    source: vectorSource,
+                });
+                temp_layer.set("no_interaction", true, true);
+
+                map.addLayer(temp_layer);
             });
             map.addInteraction(dragAndDropInteraction);
         }

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2125,7 +2125,7 @@ TABS.mission_control.initialize = function (callback) {
             });
 
             vectorLayer.set("no_interaction", saved_layer.no_interaction, true); // stops custom dragging controls for waypoints from preventing the user panning the map
-            vectorLayer.set("show_info_on_hover", saved_layer.show_info_on_hover, true); // allows info box to work with this feature
+            vectorLayer.set("show_info_on_hover", saved_layer.show_info_on_hover); // allows info box to work with this feature
             vectorLayer.set("is_vis_toggleable", saved_layer.is_vis_toggleable, true); // allows user to hide this layer in visibility selector
             vectorLayer.set("name", saved_layer.name, true); // name for visibility toggler
             map.addLayer(vectorLayer);
@@ -2173,10 +2173,10 @@ TABS.mission_control.initialize = function (callback) {
                 let temp_layer = new ol.layer.Vector({
                     source: vectorSource,
                 });
-                temp_layer.set("no_interaction", true, true); // stops custom dragging controls for waypoints from preventing the user panning the map
-                temp_layer.set("show_info_on_hover", true, true); // allows info box to work with this feature
-                temp_layer.set("is_vis_toggleable", true, true); // allows user to hide this layer in visibility selector
-                temp_layer.set("name", file_name, true); // name for visibility toggler
+                temp_layer.set("no_interaction", true); // stops custom dragging controls for waypoints from preventing the user panning the map
+                temp_layer.set("show_info_on_hover", true); // allows info box to work with this feature
+                temp_layer.set("is_vis_toggleable", true); // allows user to hide this layer in visibility selector
+                temp_layer.set("name", file_name); // name for visibility toggler
                 map.addLayer(temp_layer);
                 updateLayerVisibilitySelectOptions();
             });
@@ -2191,7 +2191,7 @@ TABS.mission_control.initialize = function (callback) {
          */
         const displayFeatureInfo = function (pixel) {
             const features = [];
-            map.forEachFeatureAtPixel(pixel, function (feature) {
+            map.forEachFeatureAtPixel(pixel, function (feature) { //TODO: This does not include the features I actually want
                 if (feature.get('show_info_on_hover') === true){
                     features.push(feature);
                 }

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1437,21 +1437,23 @@ TABS.mission_control.initialize = function (callback) {
         map.getLayers().forEach(layer => {
             if (layer.get("is_vis_toggleable") === true) {
                 let layer_name = layer.get("name");
-                let is_visible = layer.getVisible();
+                let is_visible = !!layer.getVisible();
                 GUI.log("adding to options: " + layer_name);
                 GUI.log("is visible? " + (is_visible ? "true" : "false"));
 
                 let element_id = "layerVisOption_" + layer_name;
-                $('#layerSelectContent').append('\
+
+                let element_str = '\
                 <div class="point">\
                     <label class="point-label" for="' + element_id + '">' + layer_name + '</label>\
-                    <input id="' + element_id + '" type="checkbox" checked="' + (is_visible ? "true" : "false") + '">\
-                </div>\
-                ');
+                    <input id="' + element_id + '" type="checkbox"' + (is_visible ? "checked=\"true\"" : "") + '">\
+                </div>';
+
+                $('#layerSelectContent').append(element_str);
                 let element = document.getElementById(element_id);
                 element.addEventListener("change", function () {
                     GUI.log("setting visibility of layer: " + layer_name + " to " + (element.checked ? "true" : "false"));
-                    layer.setVisible(layer.getVisible(element.checked));
+                    layer.setVisible(element.checked);
                 });
             }
         })

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2101,7 +2101,8 @@ TABS.mission_control.initialize = function (callback) {
             console.log("found saved layer: ");
             console.log(saved_layer.name);
 
-            var features = (new ol.format.GeoJSON()).readFeatures(saved_layer.layer_data);
+            let features = (new ol.format.GeoJSON()).readFeatures(saved_layer.layer_data);
+
             var vectorSource = new ol.source.Vector({
                 features: features,
                 format: new ol.format.GeoJSON()

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1591,7 +1591,7 @@ TABS.mission_control.initialize = function (callback) {
 
         });
         GUI.switchery();
-        i18n.localize();;
+        i18n.localize();
         return waypoint;
     }
 

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -29,7 +29,6 @@ const SerialBackend = require('./../js/serial_backend');
 const { distanceOnLine, wrap_360, calculate_new_cooridatnes } = require('./../js/helpers');
 const Plotly = require('./../js/libraries/plotly-latest.min');
 const interval = require('./../js/intervals');
-const {generateFilename} = require("../js/helpers");
 
 var MAX_NEG_FW_LAND_ALT = -2000; // cm
 

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1444,18 +1444,18 @@ TABS.mission_control.initialize = function (callback) {
                 let element_id = "layerVisOption_" + layer_name;
 
                 let element_str = '\
-                <div class="checkbox">\
-                    <label class="point-label" for="' + element_id + '"><span ' + layer_name + '>' + layer_name + '</span></label>\
-                    <input id="' + element_id + '" type="checkbox" data-live="true" class="toggle"' + (is_visible ? "checked=\"true\"" : "") + '">\
-                    <div class="default_btn">\
-                        <a id="' + element_id + '_Save" href="#" i18n="layerVisibilityWindowLayerSave"></a>\
+                <div class="point">\
+                    <div class="checkbox">\
+                        <label class="point-label" for="' + element_id + '"><span ' + layer_name + '>' + layer_name + '</span></label>\
+                        <input id="' + element_id + '" type="checkbox" data-live="true" class="toggle"' + (is_visible ? "checked=\"true\"" : "") + '">\
                     </div>\
                     <div class="default_btn">\
-                        <a id="' + element_id + '_Delete" href="#" i18n="layerVisibilityWindowLayerDelete"></a>\
+                        <a id="' + element_id + '_Save" href="#" i18n="layerVisibilityWindowLayerSave">Save</a>\
+                    </div>\
+                    <div class="default_btn">\
+                        <a id="' + element_id + '_Delete" href="#" i18n="layerVisibilityWindowLayerDelete">Delete</a>\
                     </div>\
                 </div>';
-
-
 
                 $('#layerSelectContent').append(element_str);
                 let element = document.getElementById(element_id);
@@ -1463,9 +1463,27 @@ TABS.mission_control.initialize = function (callback) {
                     GUI.log("setting visibility of layer: " + layer_name + " to " + (element.checked ? "true" : "false"));
                     layer.setVisible(element.checked);
                 });
+                let save_element = document.getElementById(element_id + "_Save");
+                save_element.addEventListener("click", function () {
+                    save_layer_to_disk(layer);
+                });
+
             }
         })
         GUI.switchery();
+    }
+
+    function save_layer_to_disk(layer){
+        let custom_overlay_list = store.get("custom_overlay_list");
+        if(custom_overlay_list === undefined){
+            custom_overlay_list = [];
+        }
+        let layer_to_save = JSON.stringify(layer) // TODO: ERROR
+        let name = layer.get("name");
+        custom_overlay_list.push(layer_to_save);
+        GUI.log("saving layer...");
+        store.set("custom_overlay_list", custom_overlay_list);
+        GUI.log("saved layer: " + name);
     }
 
     function renderWaypointOptionsTable(waypoint) {
@@ -2098,12 +2116,6 @@ TABS.mission_control.initialize = function (callback) {
         }
         setInteraction();
 
-        function save_layer_to_disk(layer){
-            const userDataPath = app.getPath("userData")
-            let layer_to_save = JSON.stringify(layer)
-            let name = layer.get("name");
-            fs.writeFile(`${userDataPath}/iNavMapOverlay_${name}.json`, layer_to_save)
-        }
 
         /**
          * Populates info box with names of all features marked to display info that the mouse is over

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2004,7 +2004,9 @@ TABS.mission_control.initialize = function (callback) {
         const displayFeatureInfo = function (pixel) {
             const features = [];
             map.forEachFeatureAtPixel(pixel, function (feature) {
-                features.push(feature);
+                if (feature.get('name') !== "Null Island"){
+                    features.push(feature);
+                }
             });
             if (features.length > 0) {
                 const info = [];

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1447,7 +1447,15 @@ TABS.mission_control.initialize = function (callback) {
                 <div class="checkbox">\
                     <label class="point-label" for="' + element_id + '"><span ' + layer_name + '>' + layer_name + '</span></label>\
                     <input id="' + element_id + '" type="checkbox" data-live="true" class="toggle"' + (is_visible ? "checked=\"true\"" : "") + '">\
+                    <div class="default_btn">\
+                        <a id="' + element_id + 'Save" href="#" i18n="Save"></a>\
+                    </div>\
+                    <div class="default_btn">\
+                        <a id="' + element_id + 'Delete" href="#" i18n="Delete"></a>\
+                    </div>\
                 </div>';
+
+
 
                 $('#layerSelectContent').append(element_str);
                 let element = document.getElementById(element_id);
@@ -2044,6 +2052,17 @@ TABS.mission_control.initialize = function (callback) {
         // Add drag and drop support for GEO files
         //////////////////////////////////////////////////////////////////////////////////////////////
 
+        // write file
+
+
+        // read file
+        // const path = app.getPath("userData")
+        // fs.readFile(path, {encoding: 'utf-8'}, (err,data)=> {
+        // if (err)return null
+        // updateGlobalStore(JSON.parse(data))
+        // })
+
+
         let dragAndDropInteraction;
 
         function setInteraction() {
@@ -2078,6 +2097,13 @@ TABS.mission_control.initialize = function (callback) {
             map.addInteraction(dragAndDropInteraction);
         }
         setInteraction();
+
+        function save_layer_to_disk(layer){
+            const userDataPath = app.getPath("userData")
+            let layer_to_save = JSON.stringify(layer)
+            let name = layer.get("name");
+            fs.writeFile(`${userDataPath}/iNavMapOverlay_${name}.json`, layer_to_save)
+        }
 
         /**
          * Populates info box with names of all features marked to display info that the mouse is over

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1467,7 +1467,10 @@ TABS.mission_control.initialize = function (callback) {
                 save_element.addEventListener("click", function () {
                     save_layer_to_disk(layer);
                 });
-
+                let delete_element = document.getElementById(element_id + "_Delete");
+                delete_element.addEventListener("click", function () {
+                    remove_layer_from_disk(layer.get("name"));
+                });
             }
         })
         GUI.switchery();
@@ -1507,7 +1510,7 @@ TABS.mission_control.initialize = function (callback) {
     function remove_layer_from_disk(layer_name){
         let custom_overlay_list = store.get("custom_overlay_list");
         let new_custom_overlay_list = custom_overlay_list.filter(
-            (layer_element) => layer_element.get("name") !== layer_name);
+            (layer_element) => layer_element.name !== layer_name);
         store.set("custom_overlay_list", new_custom_overlay_list);
     }
 

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1486,6 +1486,13 @@ TABS.mission_control.initialize = function (callback) {
         GUI.log("saved layer: " + name);
     }
 
+    function remove_layer_from_disk(layer_name){
+        let custom_overlay_list = store.get("custom_overlay_list");
+        let new_custom_overlay_list = custom_overlay_list.filter(
+            (layer_element) => layer_element.get("name") !== layer_name);
+        store.set("custom_overlay_list", new_custom_overlay_list);
+    }
+
     function renderWaypointOptionsTable(waypoint) {
         /*
          * Process Waypoint Options table UI

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2004,6 +2004,7 @@ TABS.mission_control.initialize = function (callback) {
                 });
                 temp_layer.set("no_interaction", true, true);
 
+                temp_layer.set("show_info_on_hover", true, true); // allows info box to work with this feature
                 map.addLayer(temp_layer);
             });
             map.addInteraction(dragAndDropInteraction);
@@ -2014,7 +2015,7 @@ TABS.mission_control.initialize = function (callback) {
         const displayFeatureInfo = function (pixel) {
             const features = [];
             map.forEachFeatureAtPixel(pixel, function (feature) {
-                if (feature.get('name') !== "Null Island"){
+                if (feature.get('show_info_on_hover') === true){
                     features.push(feature);
                 }
             });

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2109,7 +2109,6 @@ TABS.mission_control.initialize = function (callback) {
         }
 
 
-        // store.set("custom_overlay_list", [])
         for(let saved_layer of store.get("custom_overlay_list")){
             console.log("found saved layer: ");
             console.log(saved_layer.name);
@@ -2125,7 +2124,7 @@ TABS.mission_control.initialize = function (callback) {
                 temp_feature.set("show_info_on_hover", saved_layer.show_info_on_hover);
             });
 
-            var vectorLayer = new ol.layer.Vector({
+            const vectorLayer = new ol.layer.Vector({
                 title: saved_layer.name,
                 source: vectorSource
             });
@@ -2143,57 +2142,39 @@ TABS.mission_control.initialize = function (callback) {
         // Add drag and drop support for GEO files
         //////////////////////////////////////////////////////////////////////////////////////////////
 
-        // write file
 
-
-        // read file
-        // const path = app.getPath("userData")
-        // fs.readFile(path, {encoding: 'utf-8'}, (err,data)=> {
-        // if (err)return null
-        // updateGlobalStore(JSON.parse(data))
-        // })
-
-
-        let dragAndDropInteraction;
-
-        function setInteraction() {
-            if (dragAndDropInteraction) {
-                map.removeInteraction(dragAndDropInteraction);
-            }
-            dragAndDropInteraction = new ol.interaction.DragAndDrop({
-                formatConstructors: [
-                    ol.format.GPX,
-                    ol.format.GeoJSON,
-                    ol.format.IGC,
-                    ol.format.KML,
-                    ol.format.TopoJSON,
-                ],
+        let dragAndDropInteraction = new ol.interaction.DragAndDrop({
+            formatConstructors: [
+                ol.format.GPX,
+                ol.format.GeoJSON,
+                ol.format.IGC,
+                ol.format.KML,
+                ol.format.TopoJSON,
+            ],
+        });
+        dragAndDropInteraction.on('addfeatures', function (event) {
+            const vectorSource = new ol.source.Vector({
+                features: event.features,
             });
-            dragAndDropInteraction.on('addfeatures', function (event) {
-                const vectorSource = new ol.source.Vector({
-                    features: event.features,
-                });
 
-                vectorSource.forEachFeature(function (temp_feature) {
-                    temp_feature.set("show_info_on_hover", true);
-                });
-
-                let file_name = event.file.name;
-                GUI.log("adding file to map: " + file_name);
-
-                let temp_layer = new ol.layer.Vector({
-                    source: vectorSource,
-                });
-                temp_layer.set("no_interaction", true); // stops custom dragging controls for waypoints from preventing the user panning the map
-                temp_layer.set("show_info_on_hover", true); // allows info box to work with this feature
-                temp_layer.set("is_vis_toggleable", true); // allows user to hide this layer in visibility selector
-                temp_layer.set("name", file_name); // name for visibility toggler
-                map.addLayer(temp_layer);
-                updateLayerVisibilitySelectOptions();
+            vectorSource.forEachFeature(function (temp_feature) {
+                temp_feature.set("show_info_on_hover", true);
             });
-            map.addInteraction(dragAndDropInteraction);
-        }
-        setInteraction();
+
+            let file_name = event.file.name;
+            GUI.log("adding file to map: " + file_name);
+
+            let temp_layer = new ol.layer.Vector({
+                source: vectorSource,
+            });
+            temp_layer.set("no_interaction", true); // stops custom dragging controls for waypoints from preventing the user panning the map
+            temp_layer.set("show_info_on_hover", true); // allows info box to work with this feature
+            temp_layer.set("is_vis_toggleable", true); // allows user to hide this layer in visibility selector
+            temp_layer.set("name", file_name); // name for visibility toggler
+            map.addLayer(temp_layer);
+            updateLayerVisibilitySelectOptions();
+        });
+        map.addInteraction(dragAndDropInteraction);
 
 
         /**

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2177,6 +2177,7 @@ TABS.mission_control.initialize = function (callback) {
                 temp_layer.set("is_vis_toggleable", true, true); // allows user to hide this layer in visibility selector
                 temp_layer.set("name", file_name, true); // name for visibility toggler
                 map.addLayer(temp_layer);
+                updateLayerVisibilitySelectOptions();
             });
             map.addInteraction(dragAndDropInteraction);
         }

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1965,6 +1965,69 @@ TABS.mission_control.initialize = function (callback) {
             })
         });
 
+        //////////////////////////////////////////////////////////////////////////////////////////////
+        // Add drag and drop support for GEO files
+        //////////////////////////////////////////////////////////////////////////////////////////////
+
+        let dragAndDropInteraction;
+
+        function setInteraction() {
+            if (dragAndDropInteraction) {
+                map.removeInteraction(dragAndDropInteraction);
+            }
+            dragAndDropInteraction = new ol.interaction.DragAndDrop({
+                formatConstructors: [
+                    ol.format.GPX,
+                    ol.format.GeoJSON,
+                    ol.format.IGC,
+                    ol.format.KML,
+                    ol.format.TopoJSON,
+                ],
+            });
+            dragAndDropInteraction.on('addfeatures', function (event) {
+                const vectorSource = new ol.source.Vector({
+                    features: event.features,
+                });
+                GUI.alert("adding file");
+                map.addLayer(
+                    new ol.layer.Vector({
+                        source: vectorSource,
+                    }),
+                );
+                map.getView().fit(vectorSource.getExtent());
+            });
+            map.addInteraction(dragAndDropInteraction);
+        }
+        setInteraction();
+
+
+        const displayFeatureInfo = function (pixel) {
+            const features = [];
+            map.forEachFeatureAtPixel(pixel, function (feature) {
+                features.push(feature);
+            });
+            if (features.length > 0) {
+                const info = [];
+                let i, ii;
+                for (i = 0, ii = features.length; i < ii; ++i) {
+                    info.push(features[i].get('name'));
+                }
+                document.getElementById('geo_info').innerHTML = info.join(', ') || '&nbsp';
+            } else {
+                document.getElementById('geo_info').innerHTML = '&nbsp;';
+            }
+        };
+
+        map.on('pointermove', function (evt) {
+            if (evt.dragging) {
+                return;
+            }
+            const pixel = map.getEventPixel(evt.originalEvent);
+            displayFeatureInfo(pixel);
+        });
+
+
+
         //////////////////////////////////////////////////////////////////////////
         // Set the attribute link to open on an external browser window, so
         // it doesn't interfere with the configurator.

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1732,7 +1732,7 @@ TABS.mission_control.initialize = function (callback) {
             var button = document.createElement('button');
 
             button.innerHTML = ' ';
-            button.style = 'background: url(\'./images/CF_template_white.svg\') no-repeat 1px -1px;background-color: rgba(0,60,136,.5);';
+            button.style = 'background: url(\'./images/icons/cf_icon_gps_white.svg\') no-repeat 1px -1px;background-color: rgba(0,60,136,.5);';
 
             var handleShowSettings = function () {
                 updateLayerVisibilitySelectOptions();
@@ -1870,7 +1870,7 @@ TABS.mission_control.initialize = function (callback) {
 
             var feature = map.forEachFeatureAtPixel(evt.pixel,
                 function (feature, layer) {
-                    if(layer.get("no_interaction") != true){
+                    if(layer.get("no_interaction") !== true){
                         return feature;
                     }
                     // for features from layers that have this set to true, ignore their existence.
@@ -2108,11 +2108,7 @@ TABS.mission_control.initialize = function (callback) {
             store.set("custom_overlay_list", []);
         }
 
-
         for(let saved_layer of store.get("custom_overlay_list")){
-            console.log("found saved layer: ");
-            console.log(saved_layer.name);
-
             let features = (new ol.format.GeoJSON()).readFeatures(saved_layer.layer_data);
 
             var vectorSource = new ol.source.Vector({
@@ -2132,7 +2128,8 @@ TABS.mission_control.initialize = function (callback) {
             vectorLayer.set("no_interaction", saved_layer.no_interaction, true); // stops custom dragging controls for waypoints from preventing the user panning the map
             vectorLayer.set("show_info_on_hover", saved_layer.show_info_on_hover); // allows info box to work with this feature
             vectorLayer.set("is_vis_toggleable", saved_layer.is_vis_toggleable, true); // allows user to hide this layer in visibility selector
-            vectorLayer.set("name", saved_layer.name, true); // name for visibility toggler
+            vectorLayer.set("name", saved_layer.name, true); // name for visibility toggle
+
             map.addLayer(vectorLayer);
         }
 
@@ -2183,7 +2180,7 @@ TABS.mission_control.initialize = function (callback) {
          */
         const displayFeatureInfo = function (pixel) {
             const features = [];
-            map.forEachFeatureAtPixel(pixel, function (feature) { //TODO: This does not include the features I actually want
+            map.forEachFeatureAtPixel(pixel, function (feature) {
                 if (feature.get('show_info_on_hover') === true){
                     features.push(feature);
                 }

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1448,10 +1448,10 @@ TABS.mission_control.initialize = function (callback) {
                     <label class="point-label" for="' + element_id + '"><span ' + layer_name + '>' + layer_name + '</span></label>\
                     <input id="' + element_id + '" type="checkbox" data-live="true" class="toggle"' + (is_visible ? "checked=\"true\"" : "") + '">\
                     <div class="default_btn">\
-                        <a id="' + element_id + 'Save" href="#" i18n="Save"></a>\
+                        <a id="' + element_id + '_Save" href="#" i18n="layerVisibilityWindowLayerSave"></a>\
                     </div>\
                     <div class="default_btn">\
-                        <a id="' + element_id + 'Delete" href="#" i18n="Delete"></a>\
+                        <a id="' + element_id + '_Delete" href="#" i18n="layerVisibilityWindowLayerDelete"></a>\
                     </div>\
                 </div>';
 

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2002,8 +2002,7 @@ TABS.mission_control.initialize = function (callback) {
                 let temp_layer = new ol.layer.Vector({
                     source: vectorSource,
                 });
-                temp_layer.set("no_interaction", true, true);
-
+                temp_layer.set("no_interaction", true, true); // stops custom dragging controls for waypoints from preventing the user panning the map
                 temp_layer.set("show_info_on_hover", true, true); // allows info box to work with this feature
                 map.addLayer(temp_layer);
             });
@@ -2011,7 +2010,10 @@ TABS.mission_control.initialize = function (callback) {
         }
         setInteraction();
 
-
+        /**
+         * Populates info box with names of all features marked to display info that the mouse is over
+         * @param pixel the pixel the mouse is over
+         */
         const displayFeatureInfo = function (pixel) {
             const features = [];
             map.forEachFeatureAtPixel(pixel, function (feature) {

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2101,6 +2101,11 @@ TABS.mission_control.initialize = function (callback) {
         // Add previously saved GEO files
         //////////////////////////////////////////////////////////////////////////////////////////////
 
+        if(store.get("custom_overlay_list") === undefined) {
+            store.set("custom_overlay_list", []);
+        }
+
+
         // store.set("custom_overlay_list", [])
         for(let saved_layer of store.get("custom_overlay_list")){
             console.log("found saved layer: ");

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1444,11 +1444,11 @@ TABS.mission_control.initialize = function (callback) {
                 let element_id = "layerVisOption_" + layer_name;
 
                 let element_str = '\
-                <div class="point">\
+                <div>\
                     <hr>\
                     <div class="checkbox">\
                         <label class="point-label" for="' + element_id + '"><span ' + layer_name + '>' + layer_name + '</span></label>\
-                        <input id="' + element_id + '" type="checkbox" data-live="true" class="toggle"' + (is_visible ? "checked=\"true\"" : "") + '">\
+                        <input id="' + element_id + '" type="checkbox" data-live="true" class="togglemedium"' + (is_visible ? "checked=\"true\"" : "") + '">\
                     </div>\
                     <div class="default_btn">\
                         <a id="' + element_id + '_Save" href="#" i18n="layerVisibilityWindowLayerSave">Save</a>\
@@ -1733,8 +1733,8 @@ TABS.mission_control.initialize = function (callback) {
             button.style = 'background: url(\'./images/CF_template_white.svg\') no-repeat 1px -1px;background-color: rgba(0,60,136,.5);';
 
             var handleShowSettings = function () {
-                $('#layerVisibilitySelect').fadeIn(300);
                 updateLayerVisibilitySelectOptions();
+                $('#layerVisibilitySelect').fadeIn(300);
             };
 
             button.addEventListener('click', handleShowSettings, false);

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2091,6 +2091,36 @@ TABS.mission_control.initialize = function (callback) {
             })
         });
 
+
+        //////////////////////////////////////////////////////////////////////////////////////////////
+        // Add previously saved GEO files
+        //////////////////////////////////////////////////////////////////////////////////////////////
+
+        // store.set("custom_overlay_list", [])
+        for(let saved_layer of store.get("custom_overlay_list")){
+            console.log("found saved layer: ");
+            console.log(saved_layer.name);
+
+            var features = (new ol.format.GeoJSON()).readFeatures(saved_layer.layer_data);
+            var vectorSource = new ol.source.Vector({
+                features: features,
+                format: new ol.format.GeoJSON()
+            });
+
+            var vectorLayer = new ol.layer.Vector({
+                title: saved_layer.name,
+                source: vectorSource
+            });
+
+            vectorLayer.set("no_interaction", saved_layer.no_interaction, true); // stops custom dragging controls for waypoints from preventing the user panning the map
+            vectorLayer.set("show_info_on_hover", saved_layer.show_info_on_hover, true); // allows info box to work with this feature
+            vectorLayer.set("is_vis_toggleable", saved_layer.is_vis_toggleable, true); // allows user to hide this layer in visibility selector
+            vectorLayer.set("name", saved_layer.name, true); // name for visibility toggler
+            map.addLayer(vectorLayer);
+        }
+
+
+
         //////////////////////////////////////////////////////////////////////////////////////////////
         // Add drag and drop support for GEO files
         //////////////////////////////////////////////////////////////////////////////////////////////

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1469,7 +1469,7 @@ TABS.mission_control.initialize = function (callback) {
                 });
                 let delete_element = document.getElementById(element_id + "_Delete");
                 delete_element.addEventListener("click", function () {
-                    remove_layer_from_disk(layer.get("name"));
+                    remove_layer_from_disk(layer);
                 });
             }
         })
@@ -1507,11 +1507,13 @@ TABS.mission_control.initialize = function (callback) {
         GUI.log("saved layer: " + name);
     }
 
-    function remove_layer_from_disk(layer_name){
+    function remove_layer_from_disk(layer){
         let custom_overlay_list = store.get("custom_overlay_list");
         let new_custom_overlay_list = custom_overlay_list.filter(
-            (layer_element) => layer_element.name !== layer_name);
+            (layer_element) => layer_element.name !== layer.get("name"));
         store.set("custom_overlay_list", new_custom_overlay_list);
+        map.removeLayer(layer);
+        updateLayerVisibilitySelectOptions();
     }
 
     function renderWaypointOptionsTable(waypoint) {

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1444,9 +1444,9 @@ TABS.mission_control.initialize = function (callback) {
                 let element_id = "layerVisOption_" + layer_name;
 
                 let element_str = '\
-                <div class="point">\
-                    <label class="point-label" for="' + element_id + '">' + layer_name + '</label>\
-                    <input id="' + element_id + '" type="checkbox"' + (is_visible ? "checked=\"true\"" : "") + '">\
+                <div class="checkbox">\
+                    <label class="point-label" for="' + element_id + '"><span ' + layer_name + '>' + layer_name + '</span></label>\
+                    <input id="' + element_id + '" type="checkbox" data-live="true" class="toggle"' + (is_visible ? "checked=\"true\"" : "") + '">\
                 </div>';
 
                 $('#layerSelectContent').append(element_str);
@@ -1457,6 +1457,7 @@ TABS.mission_control.initialize = function (callback) {
                 });
             }
         })
+        GUI.switchery();
     }
 
     function renderWaypointOptionsTable(waypoint) {

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1445,6 +1445,7 @@ TABS.mission_control.initialize = function (callback) {
 
                 let element_str = '\
                 <div class="point">\
+                    <hr>\
                     <div class="checkbox">\
                         <label class="point-label" for="' + element_id + '"><span ' + layer_name + '>' + layer_name + '</span></label>\
                         <input id="' + element_id + '" type="checkbox" data-live="true" class="toggle"' + (is_visible ? "checked=\"true\"" : "") + '">\

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1437,9 +1437,7 @@ TABS.mission_control.initialize = function (callback) {
         map.getLayers().forEach(layer => {
             if (layer.get("is_vis_toggleable") === true) {
                 let layer_name = layer.get("name");
-                let is_visible = !!layer.getVisible();
-                GUI.log("adding to options: " + layer_name);
-                GUI.log("is visible? " + (is_visible ? "true" : "false"));
+                let is_visible = layer.getVisible();
 
                 let element_id = "layerVisOption_" + layer_name;
 
@@ -1463,7 +1461,6 @@ TABS.mission_control.initialize = function (callback) {
                 $('#layerSelectContent').append(element_str);
                 let element = document.getElementById(element_id);
                 element.addEventListener("change", function () {
-                    GUI.log("setting visibility of layer: " + layer_name + " to " + (element.checked ? "true" : "false"));
                     layer.setVisible(element.checked);
                 });
                 let save_element = document.getElementById(element_id + "_Save");
@@ -2117,7 +2114,7 @@ TABS.mission_control.initialize = function (callback) {
             });
 
             vectorSource.forEachFeature(function (temp_feature) {
-                temp_feature.set("show_info_on_hover", saved_layer.show_info_on_hover);
+                temp_feature.set("show_info_on_hover", saved_layer.show_info_on_hover); // `show info on hover` is saved to the layer, but is read per feature.
             });
 
             const vectorLayer = new ol.layer.Vector({

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1994,7 +1994,6 @@ TABS.mission_control.initialize = function (callback) {
                         source: vectorSource,
                     }),
                 );
-                map.getView().fit(vectorSource.getExtent());
             });
             map.addInteraction(dragAndDropInteraction);
         }

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1450,11 +1450,13 @@ TABS.mission_control.initialize = function (callback) {
                         <label class="point-label" for="' + element_id + '"><span ' + layer_name + '>' + layer_name + '</span></label>\
                         <input id="' + element_id + '" type="checkbox" data-live="true" class="togglemedium"' + (is_visible ? "checked=\"true\"" : "") + '">\
                     </div>\
-                    <div class="default_btn">\
-                        <a id="' + element_id + '_Save" href="#" i18n="layerVisibilityWindowLayerSave">Save</a>\
-                    </div>\
-                    <div class="default_btn">\
-                        <a id="' + element_id + '_Delete" href="#" i18n="layerVisibilityWindowLayerDelete">Delete</a>\
+                    <div>\
+                        <div class="default_btn">\
+                            <a id="' + element_id + '_Save" href="#" i18n="layerVisibilityWindowLayerSave">Save</a>\
+                        </div>\
+                        <div class="default_btn">\
+                            <a id="' + element_id + '_Delete" href="#" i18n="layerVisibilityWindowLayerDelete">Delete</a>\
+                        </div>\
                     </div>\
                 </div>';
 
@@ -2119,6 +2121,10 @@ TABS.mission_control.initialize = function (callback) {
                 format: new ol.format.GeoJSON()
             });
 
+            vectorSource.forEachFeature(function (temp_feature) {
+                temp_feature.set("show_info_on_hover", saved_layer.show_info_on_hover);
+            });
+
             var vectorLayer = new ol.layer.Vector({
                 title: saved_layer.name,
                 source: vectorSource
@@ -2167,6 +2173,11 @@ TABS.mission_control.initialize = function (callback) {
                 const vectorSource = new ol.source.Vector({
                     features: event.features,
                 });
+
+                vectorSource.forEachFeature(function (temp_feature) {
+                    temp_feature.set("show_info_on_hover", true);
+                });
+
                 let file_name = event.file.name;
                 GUI.log("adding file to map: " + file_name);
 

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1435,7 +1435,7 @@ TABS.mission_control.initialize = function (callback) {
         $('#layerSelectContent').empty();
 
         map.getLayers().forEach(layer => {
-            if (layer.get("is_vis_toggleable") === true) {
+            if (layer.get("is_vis_toggleable") === true) { // for every layer that has `is_vis_toggleable` set to true:
                 let layer_name = layer.get("name");
                 let is_visible = layer.getVisible();
 
@@ -1460,7 +1460,7 @@ TABS.mission_control.initialize = function (callback) {
 
                 $('#layerSelectContent').append(element_str);
                 let element = document.getElementById(element_id);
-                element.addEventListener("change", function () {
+                element.addEventListener("change", function () { // when the switch is toggled, update the layer's visibility on the map to reflect the state of the switch
                     layer.setVisible(element.checked);
                 });
                 let save_element = document.getElementById(element_id + "_Save");
@@ -1488,7 +1488,7 @@ TABS.mission_control.initialize = function (callback) {
         }
 
         var writer = new ol.format.GeoJSON();
-        let geojsonStr = writer.writeFeatures(layer.getSource().getFeatures());
+        let geojsonStr = writer.writeFeatures(layer.getSource().getFeatures());  // save the features of the custom layer in a GEOJSON format
 
         let name = layer.get("name");
 
@@ -1498,7 +1498,7 @@ TABS.mission_control.initialize = function (callback) {
             show_info_on_hover: layer.get("show_info_on_hover"),
             is_vis_toggleable: layer.get("is_vis_toggleable"),
             layer_data: geojsonStr
-        }
+        } // wrap the feature data with some extra info
 
 
         custom_overlay_list.push(saved_layer);
@@ -1720,6 +1720,7 @@ TABS.mission_control.initialize = function (callback) {
         ol.inherits(app.PlannerSettingsControl, ol.control.Control);
 
         /**
+         * Responsible for adding the button that brings up the custom layer menu
          * @constructor
          * @extends {ol.control.Control}
          * @param {Object=} opt_options Control options.
@@ -2101,7 +2102,7 @@ TABS.mission_control.initialize = function (callback) {
         // Add previously saved GEO files
         //////////////////////////////////////////////////////////////////////////////////////////////
 
-        if(store.get("custom_overlay_list") === undefined) {
+        if(store.get("custom_overlay_list") === undefined) {  // For new installations, add this to electron store
             store.set("custom_overlay_list", []);
         }
 
@@ -2152,7 +2153,7 @@ TABS.mission_control.initialize = function (callback) {
             });
 
             vectorSource.forEachFeature(function (temp_feature) {
-                temp_feature.set("show_info_on_hover", true);
+                temp_feature.set("show_info_on_hover", true);  // This tag is read per feature, but is also stored on the layer
             });
 
             let file_name = event.file.name;
@@ -2166,13 +2167,15 @@ TABS.mission_control.initialize = function (callback) {
             temp_layer.set("is_vis_toggleable", true); // allows user to hide this layer in visibility selector
             temp_layer.set("name", file_name); // name for visibility toggler
             map.addLayer(temp_layer);
-            updateLayerVisibilitySelectOptions();
+            updateLayerVisibilitySelectOptions();  // add the new layer to the list of layers in the menu
         });
         map.addInteraction(dragAndDropInteraction);
 
 
         /**
-         * Populates info box with names of all features marked to display info that the mouse is over
+         * Populates info box with names of all features marked to display info that the mouse is over.
+         *
+         * Lets you identify flight zones and such
          * @param pixel the pixel the mouse is over
          */
         const displayFeatureInfo = function (pixel) {

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1988,7 +1988,7 @@ TABS.mission_control.initialize = function (callback) {
                 const vectorSource = new ol.source.Vector({
                     features: event.features,
                 });
-                GUI.alert("adding file");
+                GUI.log("adding file to map");
                 map.addLayer(
                     new ol.layer.Vector({
                         source: vectorSource,

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1450,7 +1450,8 @@ TABS.mission_control.initialize = function (callback) {
                 ');
                 let element = document.getElementById(element_id);
                 element.addEventListener("change", function () {
-
+                    GUI.log("setting visibility of layer: " + layer_name + " to " + (element.checked ? "true" : "false"));
+                    layer.setVisible(layer.getVisible(element.checked));
                 });
             }
         })

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1473,14 +1473,32 @@ TABS.mission_control.initialize = function (callback) {
         GUI.switchery();
     }
 
+
+    /**
+     *
+     * @param {ol.layer.Vector} layer
+     */
     function save_layer_to_disk(layer){
         let custom_overlay_list = store.get("custom_overlay_list");
         if(custom_overlay_list === undefined){
             custom_overlay_list = [];
         }
-        let layer_to_save = JSON.stringify(layer) // TODO: ERROR
+
+        var writer = new ol.format.GeoJSON();
+        let geojsonStr = writer.writeFeatures(layer.getSource().getFeatures());
+
         let name = layer.get("name");
-        custom_overlay_list.push(layer_to_save);
+
+        let saved_layer = {
+            name: name,
+            no_interaction: layer.get("no_interaction"),
+            show_info_on_hover: layer.get("show_info_on_hover"),
+            is_vis_toggleable: layer.get("is_vis_toggleable"),
+            layer_data: geojsonStr
+        }
+
+
+        custom_overlay_list.push(saved_layer);
         GUI.log("saving layer...");
         store.set("custom_overlay_list", custom_overlay_list);
         GUI.log("saved layer: " + name);


### PR DESCRIPTION
This PR makes it possible for the user to drag and drop a GEO file containing property lines, trails, waypoints, flight restricted areas, or anything else on to the map. The change does not affect anything about the actual mission and is purely for visual reference. 

While the feature is similar to GEO-fencing, an upcoming rumored addition to iNav, this allows the user to easily import existing data in almost any applicable format (GEOJSON, KML, GPX, TOPOJSON, and IGC) to be able to more easily identify or plan around various landmarks in mission planner.

To put it bluntly, I am not a JS dev, and some conventions may be missing. Especially those specific to this project. But I did my best to emulate the style in the rest of the project, if not with more comments. If there are any issues I am in the iNav discord under the name BeanTime, and I'm always open to suggestions or changes that need to be made.