### PR TITLE
Remove UBLOX7 option

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -656,7 +656,6 @@ var FC = {
     getGpsProtocols: function () {
         return [
             'UBLOX',
-            'UBLOX7',
             'MSP',
             'FAKE'
         ];


### PR DESCRIPTION
UBLOX7 is not longer an option in INAV 8.0.0, as it has been merged in UBLOX.