### PR TITLE
Fix for the non-finishing defaults box

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inav-configurator",
-  "version": "7.1.0",
+  "version": "7.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inav-configurator",
-      "version": "7.1.0",
+      "version": "7.1.2",
       "license": "GPL-3.0",
       "dependencies": {
         "archiver": "^2.0.3",


### PR DESCRIPTION
This fixes the state where the defaults dialog settings never completely save with 7.1.1.

This is not an ideal fix. There is something somewhere that is not abiding be promises and callbacks. So the parts that need to be asynchronous are not. This is a bit of a dirty fix. But it works and sets all 3 control and battery profile with the default settings for the chosen preset.