### PR TITLE
Fix profile change not working

### DIFF
--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -532,7 +532,7 @@ $(function() {
         mixerprofile_e.on('change', function () {
             var mixerprofile = parseInt($(this).val());
             MSP.send_message(MSPCodes.MSP2_INAV_SELECT_MIXER_PROFILE, [mixerprofile], false, function () {
-                GUI.log(i18n.getMessage('loadedMixerProfile', [mixerprofile + 1]));
+                GUI.log(i18n.getMessage('setMixerProfile', [mixerprofile + 1]));
                 MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, function () {
                     GUI.log(i18n.getMessage('deviceRebooting'));
                     GUI.handleReconnect();
@@ -545,7 +545,7 @@ $(function() {
         profile_e.on('change', function () {
             var profile = parseInt($(this).val());
             MSP.send_message(MSPCodes.MSP_SELECT_SETTING, [profile], false, function () {
-                GUI.log(i18n.getMessage('pidTuning_LoadedProfile', [profile + 1]));
+                GUI.log(i18n.getMessage('setControlProfile', [profile + 1]));
             });
         });
 
@@ -554,7 +554,7 @@ $(function() {
         batteryprofile_e.on('change', function () {
             var batteryprofile = parseInt($(this).val());
             MSP.send_message(MSPCodes.MSP2_INAV_SELECT_BATTERY_PROFILE, [batteryprofile], false, function () {
-                GUI.log(i18n.getMessage('loadedBatteryProfile', [batteryprofile + 1]));
+                GUI.log(i18n.getMessage('setBatteryProfile', [batteryprofile + 1]));
             });
         });
 

--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -163,6 +163,7 @@ var defaultsDialog = (function () {
     };
 
     privateScope.reboot = function () {
+        periodicStatusUpdater.resume();
 
         GUI.tab_switch_cleanup(function () {
             MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, function () {
@@ -177,7 +178,6 @@ var defaultsDialog = (function () {
     };
 
     privateScope.finalize = function (selectedDefaultPreset) {
-
         if (selectedDefaultPreset.wizardPages) {
             privateScope.wizard(selectedDefaultPreset, 0);
         } else {
@@ -221,60 +221,26 @@ var defaultsDialog = (function () {
             });
         });
 
-        
-        chain.push(function (callback) {
-            MSP.send_message(MSPCodes.MSP_SELECT_SETTING, [0], false, callback);
-        });
-        controlProfileSettings.forEach(input => {
+        // Set control and battery parameters on all 3 profiles
+        for (let profileIdx = 0; profileIdx < 3; profileIdx++){
             chain.push(function (callback) {
-                mspHelper.setSetting(input.key, input.value, callback);
+                MSP.send_message(MSPCodes.MSP_SELECT_SETTING, [profileIdx], false, callback);
             });
-        });
+            controlProfileSettings.forEach(input => {
+                chain.push(function (callback) {
+                    mspHelper.setSetting(input.key, input.value, callback);
+                });
+            });
 
-        chain.push(function (callback) {
-            MSP.send_message(MSPCodes.MSP_SELECT_SETTING, [1], false, callback);
-        });
-        controlProfileSettings.forEach(input => {
             chain.push(function (callback) {
-                mspHelper.setSetting(input.key, input.value, callback);
+                MSP.send_message(MSPCodes.MSP2_INAV_SELECT_BATTERY_PROFILE, [profileIdx], false, callback);
             });
-        });
-
-        chain.push(function (callback) {
-            MSP.send_message(MSPCodes.MSP_SELECT_SETTING, [2], false, callback);
-        });
-        controlProfileSettings.forEach(input => {
-            chain.push(function (callback) {
-                mspHelper.setSetting(input.key, input.value, callback);
+            batterySettings.forEach(input => {
+                chain.push(function (callback) {
+                    mspHelper.setSetting(input.key, input.value, callback);
+                });
             });
-        });    
-
-        chain.push(function (callback) {
-            MSP.send_message(MSPCodes.MSP2_INAV_SELECT_BATTERY_PROFILE, [0], false, callback);
-        });
-        batterySettings.forEach(input => {
-            chain.push(function (callback) {
-                mspHelper.setSetting(input.key, input.value, callback);
-            });
-        });
-
-        chain.push(function (callback) {
-            MSP.send_message(MSPCodes.MSP2_INAV_SELECT_BATTERY_PROFILE, [1], false, callback);
-        });
-        batterySettings.forEach(input => {
-            chain.push(function (callback) {
-                mspHelper.setSetting(input.key, input.value, callback);
-            });
-        });
-
-        chain.push(function (callback) {
-            MSP.send_message(MSPCodes.MSP2_INAV_SELECT_BATTERY_PROFILE, [2], false, callback);
-        });
-        batterySettings.forEach(input => {
-            chain.push(function (callback) {
-                mspHelper.setSetting(input.key, input.value, callback);
-            });
-        });
+        }
         
         // Set Mixers
         if (selectedDefaultPreset.mixerToApply) {

--- a/js/gui.js
+++ b/js/gui.js
@@ -1,7 +1,6 @@
 'use strict';
 const { dialog } = require("@electron/remote");
 
-
 const CONFIGURATOR = require('./data_storage');
 const Switchery = require('./libraries/switchery/switchery')
 const MSP = require('./msp');
@@ -54,6 +53,12 @@ var GUI_control = function () {
         'ez_tune'
     ];
     this.allowedTabs = this.defaultAllowedTabsWhenDisconnected;
+
+    this.PROFILES_CHANGED = {
+        'CONTROL' : 1,
+        'BATTERY' : 2,
+        'MIXER'   : 4
+    };
 
     // check which operating system is user running
     if (navigator.appVersion.indexOf("Win") != -1)          this.operating_system = "Windows";
@@ -263,10 +268,16 @@ GUI_control.prototype.updateProfileChange = function(refresh) {
     $('#mixerprofilechange').val(FC.CONFIG.mixer_profile);
     $('#profilechange').val(FC.CONFIG.profile);
     $('#batteryprofilechange').val(FC.CONFIG.battery_profile);
-    if (refresh) {
-        GUI.log(i18n.getMessage('loadedMixerProfile', [FC.CONFIG.mixer_profile + 1]));
-        GUI.log(i18n.getMessage('pidTuning_LoadedProfile', [FC.CONFIG.profile + 1]));
-        GUI.log(i18n.getMessage('loadedBatteryProfile', [FC.CONFIG.battery_profile + 1]));
+    if (refresh > 0) {
+        if (refresh & GUI.PROFILES_CHANGED.CONTROL) {
+            GUI.log(i18n.getMessage('pidTuning_LoadedProfile', [FC.CONFIG.profile + 1]));
+        }
+        if (refresh & GUI.PROFILES_CHANGED.MIXER) {
+            GUI.log(i18n.getMessage('loadedMixerProfile', [FC.CONFIG.mixer_profile + 1]));
+        }
+        if (refresh & GUI.PROFILES_CHANGED.BATTERY) {
+            GUI.log(i18n.getMessage('loadedBatteryProfile', [FC.CONFIG.battery_profile + 1]));
+        }
         GUI.updateActivatedTab();
     }
 };

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -73,7 +73,7 @@ var mspHelper = (function () {
             color;
         if (!dataHandler.unsupported || dataHandler.unsupported) switch (dataHandler.code) {
             case MSPCodes.MSPV2_INAV_STATUS:
-                let profile_changed = false;
+                let profile_changed = 0;
                 FC.CONFIG.cycleTime = data.getUint16(offset, true);
                 offset += 2;
                 FC.CONFIG.i2cError = data.getUint16(offset, true);
@@ -85,11 +85,15 @@ var mspHelper = (function () {
 
                 let profile_byte = data.getUint8(offset++)
                 let profile = profile_byte & 0x0F;
-                profile_changed |= (profile !== FC.CONFIG.profile) && (FC.CONFIG.profile !==-1);
+                if (profile !== FC.CONFIG.profile) {
+                    profile_changed |= GUI.PROFILES_CHANGED.CONTROL;
+                }
                 FC.CONFIG.profile = profile;
 
                 let battery_profile = (profile_byte & 0xF0) >> 4;
-                profile_changed |= (battery_profile !== FC.CONFIG.battery_profile) && (FC.CONFIG.battery_profile !==-1);
+                if (battery_profile !== FC.CONFIG.battery_profile) {
+                    profile_changed |= GUI.PROFILES_CHANGED.BATTERY;
+                }
                 FC.CONFIG.battery_profile = battery_profile;
 
                 FC.CONFIG.armingFlags = data.getUint32(offset, true);
@@ -99,11 +103,14 @@ var mspHelper = (function () {
                 //read mixer profile as the last byte in the the message
                 profile_byte = data.getUint8(dataHandler.message_length_expected - 1);
                 let mixer_profile = profile_byte & 0x0F;
-                profile_changed |= (mixer_profile !== FC.CONFIG.mixer_profile) && (FC.CONFIG.mixer_profile !==-1);
+                if (mixer_profile !== FC.CONFIG.mixer_profile) {
+                    profile_changed |= GUI.PROFILES_CHANGED.MIXER;
+                }
                 FC.CONFIG.mixer_profile = mixer_profile;
-
                 GUI.updateStatusBar();
-                GUI.updateProfileChange(profile_changed);
+                if (profile_changed > 0) {
+                    GUI.updateProfileChange(profile_changed);
+                }
                 break;
 
             case MSPCodes.MSP_ACTIVEBOXES:

--- a/js/periodicStatusUpdater.js
+++ b/js/periodicStatusUpdater.js
@@ -118,6 +118,10 @@ const mspQueue = require('./serial_queue');
         stoppped = true;
     }
 
+    publicScope.resume = function() {
+        stoppped = false;
+    }
+
     return publicScope;
 })();
 

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -97,7 +97,6 @@ var SerialBackend = (function () {
 
                 }, 7000);
             } else {
-
                 timeout.add('waiting_for_bootup', function waiting_for_bootup() {
                     MSP.send_message(MSPCodes.MSPV2_INAV_STATUS, false, false, function () {
                         //noinspection JSUnresolvedVariable

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1706,6 +1706,15 @@
     "loadedBatteryProfile": {
         "message": "Loaded Battery Profile: <strong style=\"color: #37a8db\">$1</strong>"
     },
+    "setControlProfile" : {
+        "message": "Set Control Profile: <strong style=\"color: #37a8db\">$1</strong>"
+    },
+    "setMixerProfile": {
+        "message": "Setting Mixer Profile: <strong style=\"color: #37a8db\">$1</strong>"
+    },
+    "setBatteryProfile": {
+        "message": "Setting Battery Profile: <strong style=\"color: #37a8db\">$1</strong>"
+    },
     "pidTuningDataRefreshed": {
         "message": "PID data <strong>refreshed</strong>"
     },


### PR DESCRIPTION
Initially, I thought that the profiles were not changing when you selected a new profile from the select box. It turns out that this was only happening after setting up from the defaults dialog. The problem was that the `periodicStatusUpdater` was being stopped to perform the parameter upload. But not re-started. I added a function to resume the updater, and everything works as it should. I made a few other changes:
- Tidied up the setting of the parameters for each profile
- Added specific `set` profile messages, rather than `loaded` being repeated
- Only show messages for the profiles that have changed, not all of them