### PR TITLE
Fit width of sensor according to width of text

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -277,7 +277,7 @@ input[type="number"]::-webkit-inner-spin-button {
 #sensor-status li {
     float: left;
     height: 67px;
-    width: 35px;
+    min-width: 33px;
     line-height: 18px;
     text-align: center;
     border: 1px solid #373737;
@@ -297,9 +297,7 @@ input[type="number"]::-webkit-inner-spin-button {
 #sensor-status li .opflowicon,
 #sensor-status li .sonaricon,
 #sensor-status li .airspeedicon {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    background-position-x: center;
 }
 
 .gyroicon {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -277,7 +277,7 @@ input[type="number"]::-webkit-inner-spin-button {
 #sensor-status li {
     float: left;
     height: 67px;
-    width: 33px;
+    width: 35px;
     line-height: 18px;
     text-align: center;
     border: 1px solid #373737;
@@ -287,6 +287,19 @@ input[type="number"]::-webkit-inner-spin-button {
     padding-left: 5px;
     padding-right: 5px;
     text-shadow: 0 1px rgba(0, 0, 0, 1.0);
+}
+
+#sensor-status li .gyroicon,
+#sensor-status li .accicon,
+#sensor-status li .magicon,
+#sensor-status li .baroicon,
+#sensor-status li .gpsicon,
+#sensor-status li .opflowicon,
+#sensor-status li .sonaricon,
+#sensor-status li .airspeedicon {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .gyroicon {


### PR DESCRIPTION
This PR truncates text in the sensors block.

Before:
<img width="393" alt="screenshot 2024-09-22 at 11 11 06" src="https://github.com/user-attachments/assets/42820058-87cb-453c-95ce-7cf49f97cab7">

After:
<img width="381" alt="screenshot 2024-09-22 at 11 17 38" src="https://github.com/user-attachments/assets/9fa27d9c-46c1-496a-9fb3-5d6ec190b681">
