### PR TITLE
vtx: fetch powerlevel count from fc

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -354,6 +354,9 @@ var FC = {
             power: 0,
             pitmode: 0,
             low_power_disarm: 0,
+            band_count: 0,
+            channel_count: 0,
+            power_count: 0,
         };
 
         this.ADVANCED_CONFIG = {

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1148,6 +1148,11 @@ var mspHelper = (function () {
                     // Ignore wether the VTX is ready for now
                     offset++;
                     FC.VTX_CONFIG.low_power_disarm = data.getUint8(offset++);
+                    // Assume we got a vtx table
+                    offset++;
+                    FC.VTX_CONFIG.band_count = data.getUint8(offset++);
+                    FC.VTX_CONFIG.channel_count = data.getUint8(offset++);
+                    FC.VTX_CONFIG.power_count = data.getUint8(offset++);
                 }
                 break;
             case MSPCodes.MSP_ADVANCED_CONFIG:

--- a/js/vtx.js
+++ b/js/vtx.js
@@ -18,17 +18,7 @@ var VTX = (function() {
 
     self.CHANNEL_MIN = 1;
     self.CHANNEL_MAX = 8;
-
-    self.getMinPower = function(vtxDev) {
-        return 1;
-    }
-
-    self.getMaxPower = function(vtxDev) {
-        if ((vtxDev == self.DEV_SMARTAUDIO) || (vtxDev == self.DEV_TRAMP)) {
-            return 5;
-        }
-        return 3;
-    }
+    self.POWER_MIN = 1;
 
     self.LOW_POWER_DISARM_MIN = 0;
     self.LOW_POWER_DISARM_MAX = 2;

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -165,9 +165,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             var vtx_power = $('#vtx_power');
             vtx_power.empty();
-            var minPower = VTX.getMinPower(FC.VTX_CONFIG.device_type);
-            var maxPower = VTX.getMaxPower(FC.VTX_CONFIG.device_type);
-            for (var ii = minPower; ii <= maxPower; ii++) {
+            for (var ii = VTX.POWER_MIN; ii <= FC.VTX_CONFIG.power_count; ii++) {
                 var option = $('<option value="' + ii + '">' + ii + '</option>');
                 if (ii == FC.VTX_CONFIG.power) {
                     option.prop('selected', true);


### PR DESCRIPTION
instead of duplicating the logic to determine the number of power levels, we fetch them from the fc
needs https://github.com/iNavFlight/inav/pull/10395