### PR TITLE
Allow a power index range of 0-4 for MSP VTX devices

### DIFF
--- a/js/vtx.js
+++ b/js/vtx.js
@@ -30,7 +30,8 @@ var VTX = (function() {
     self.getMaxPower = function(vtxDev) {
         if ((vtxDev == self.DEV_SMARTAUDIO) || (vtxDev == self.DEV_TRAMP)) {
             return 5;
-        } else if (vtxDev == self.DEV_MSP) {
+        }     
+        if (vtxDev == self.DEV_MSP) {
             return 4;
         }
         return 3;

--- a/js/vtx.js
+++ b/js/vtx.js
@@ -3,6 +3,7 @@ var VTX = (function() {
 
     self.DEV_SMARTAUDIO = 3;
     self.DEV_TRAMP = 4;
+    self.DEV_MSP = 6;
     self.DEV_UNKNOWN = 0xFF;
 
     self.BANDS = [
@@ -20,12 +21,17 @@ var VTX = (function() {
     self.CHANNEL_MAX = 8;
 
     self.getMinPower = function(vtxDev) {
+        if (vtxDev == self.DEV_MSP) {
+            return 0;
+        }
         return 1;
     }
 
     self.getMaxPower = function(vtxDev) {
         if ((vtxDev == self.DEV_SMARTAUDIO) || (vtxDev == self.DEV_TRAMP)) {
             return 5;
+        } else if (vtxDev == self.DEV_MSP) {
+            return 4
         }
         return 3;
     }

--- a/js/vtx.js
+++ b/js/vtx.js
@@ -31,7 +31,7 @@ var VTX = (function() {
         if ((vtxDev == self.DEV_SMARTAUDIO) || (vtxDev == self.DEV_TRAMP)) {
             return 5;
         } else if (vtxDev == self.DEV_MSP) {
-            return 4
+            return 4;
         }
         return 3;
     }


### PR DESCRIPTION
To compliment the iNav VTX updates, this change will allow the correct number of power levels to be selected in the configurator.