### PR TITLE
speed up OSD tab loading if there are too many custom OSD elements.

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -3549,6 +3549,7 @@ function createCustomElements(){
     }
 
     var customElementsContainer = $('#osdCustomElements');
+    var init = true;
 
     for(var i = 0; i < FC.OSD_CUSTOM_ELEMENTS.settings.customElementsCount; i++){
         var label = $('<label>');
@@ -3606,7 +3607,9 @@ function createCustomElements(){
                 var valueBlock = $('.' + $(this).data('valueCellClass'))
                 valueBlock.find('.value').hide();
                 valueBlock.find('.' + dataValue).show();
-                updateOSDCustomElementsDisplay();
+                if(!init){
+                    updateOSDCustomElementsDisplay();
+                }
             });
         }
 
@@ -3636,6 +3639,7 @@ function createCustomElements(){
 
     fillCustomElementsValues();
     customElementsInitCallback();
+    init = false;
 }
 
 function updateOSDCustomElementsDisplay() {


### PR DESCRIPTION
Fix for https://github.com/iNavFlight/inav-configurator/issues/2209