### PR TITLE
Enable virtual pitot when a GNSS module is setup in the wizard

### DIFF
--- a/js/wizard_save_framework.js
+++ b/js/wizard_save_framework.js
@@ -31,7 +31,7 @@ var wizardSaveFramework = (function () {
 
                 serialPortHelper.set(config.value.port, 'GPS', config.value.baud);
                 mspHelper.saveSerialPorts(function () {
-                    features.execute(callback);
+                    features.execute(self.enableVirtulaPitot(config, callback));
                 });
                 break;
             case 'gpsProtocol':
@@ -40,6 +40,14 @@ var wizardSaveFramework = (function () {
             default:
                 callback();
                 break;
+        }
+    };
+
+    self.enableVirtulaPitot = function (config, callback) {
+        if (config.value.port != '-1') {
+            mspHelper.setSetting('pitot_hardware', "VIRTUAL", callback);
+        } else {
+            callback();
         }
     };
 


### PR DESCRIPTION
Fixes https://github.com/iNavFlight/inav-configurator/issues/2231

Virtual pitot was enabled by default. But this caused issues if a GNSS module wasn't set up. This PR enables the virtual pitot when a GNSS module is set up as part of the setup wizard.