### PR TITLE
Remove MSC button that never worked

### DIFF
--- a/tabs/onboard_logging.html
+++ b/tabs/onboard_logging.html
@@ -152,7 +152,6 @@
                                     <div class="legend"></div>
                                 </li>
                             </ul><bbr />
-                            <a class="require-msc-ready regular-button onboardLoggingRebootMsc" href="#" i18n="cliMscBtn"></a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The MSC button was added, but never connected to anything.

Remove it for now, so it can be added later, once we implement the supporting MSP messages.