### PR TITLE
Set the width of the Modes Tab to 100%

### DIFF
--- a/src/css/tabs/auxiliary.css
+++ b/src/css/tabs/auxiliary.css
@@ -1,5 +1,6 @@
 .tab-auxiliary {
     float: left;
+    width: 100%;
 }
 
 .tab-auxiliary .help {


### PR DESCRIPTION
I found that the display width of the Modes Tab is determined by the width of the yellow prompt word at the top, and it usually looks fine on small screens. Once displayed on a large screen, there will be a blank space to the right of the Tab.
![image](https://github.com/user-attachments/assets/31b8ee29-e366-4e23-8c3e-fb78b203aae9)

When its width is set to 100%, it can fill the entire screen.
![image](https://github.com/user-attachments/assets/ec4efeca-381c-456d-844c-fcb7ea3ae5ec)

