### PR TITLE
outputs.js: Update from sliders 10X per second, not 100X

### DIFF
--- a/tabs/outputs.js
+++ b/tabs/outputs.js
@@ -570,7 +570,7 @@ TABS.outputs.initialize = function (callback) {
 
                         buffering_set_motor = [];
                         buffer_delay = false;
-                    }, 10);
+                    }, 100);
                 }
             });
         }


### PR DESCRIPTION
After this commit:
6b5440f437d92b95ecfe6f948241518516e9a13a remove msp_balanced_interval

the Outputs tab was trying to update the motors every 10ms as the slider is moved.
It can't do 100 MSP round-trips per second, so fell apart as shown in this video.

https://github.com/user-attachments/assets/71638f8a-33af-4c76-b8ba-e38039f654ba

PR sets it to max 10 updates per second as the slider is moved, which MSP can handle.

