### PR TITLE
Update Font Manager button

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -4442,7 +4442,7 @@
         "message": "Upload Font"
     },
     "osd_font_manager": {
-        "message": "Font Manager"
+        "message": "Analogue Font Manager"
     },
     "uploadingCharacters": {
         "message": "Uploading..."


### PR DESCRIPTION
Add "Analogue" to the Font Manager button. To help stop people thinking it is used with digital systems.