### PR TITLE
servo mixer send uint values

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -439,10 +439,10 @@ var mspHelper = (function () {
                 if (data.byteLength % 6 === 0) {
                     for (let i = 0; i < data.byteLength; i += 6) {
                         FC.SERVO_RULES.put(new ServoMixRule(
-                            data.getInt8(i),
-                            data.getInt8(i + 1),
+                            data.getUint8(i),
+                            data.getUint8(i + 1),
                             data.getInt16(i + 2, true),
-                            data.getInt8(i + 4),
+                            data.getUint8(i + 4),
                             data.getInt8(i + 5)
                         ));
                     }


### PR DESCRIPTION
In the servo mixer, the following are **UN**signed ints:

Servo number
Input source
Speed

Because they populate a servoMixer_t:
https://github.com/iNavFlight/inav/blob/d1ef85e82d8aa5bb8b85e518893c8e4f6ab61d6e/src/main/flight/servos.h#L128

They are read as unsigned values:
https://github.com/iNavFlight/inav/blob/d1ef85e82d8aa5bb8b85e518893c8e4f6ab61d6e/src/main/fc/fc_msp.c#L2271


See:
https://github.com/iNavFlight/inav-configurator/issues/2324