### PR TITLE
Fix sensor status not update when 'Keep current settings'

### DIFF
--- a/js/defaults_dialog.js
+++ b/js/defaults_dialog.js
@@ -192,8 +192,9 @@ var defaultsDialog = (function () {
     };
 
     privateScope.setSettings = function (selectedDefaultPreset) {
-        
-        periodicStatusUpdater.stop();
+        if(selectedDefaultPreset.reboot) {
+            periodicStatusUpdater.stop();
+        }
         
         var currentControlProfile = parseInt($("#profilechange").val());
         var currentBatteryProfile = parseInt($("#batteryprofilechange").val());


### PR DESCRIPTION
If we choose "Keep current settings (Not recommended)", then `periodicStatusUpdater.stop()`. This will cause the sensor status icons not to update, replugging the USB did not solve the problem. The only way is closing and reopening the INAV Configurator. So if we choose a non-rebooted option, we should not let the periodicStatusUpdater stop.