### PR TITLE
Warn if too many MSP Ports

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1286,6 +1286,9 @@
     "portsHelp": {
         "message": "<strong>Note:</strong> not all combinations are valid.  When the flight controller firmware detects this the serial port configuration will be reset."
     },
+    "portsMSPWarning": {
+        "message": "<strong>Caution:</strong><p>Putting MSP on more than two UART ports may interfere with USB communication. Consider removing MSP from a port where it is not needed.</p>"
+    },
     "portsFirmwareUpgradeRequired": {
         "message": "Firmware upgrade <span style=\"color: red\">required</span>."
     },

--- a/tabs/ports.html
+++ b/tabs/ports.html
@@ -62,3 +62,8 @@
         </tbody>
     </table>
 </div>
+
+<div id="mspWarningContent" class="is-hidden">
+    <p data-i18n="portsMSPWarning"></p>
+</div>
+

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -9,12 +9,14 @@ const { GUI, TABS } = require('./../js/gui');
 const FC = require('./../js/fc');
 const i18n = require('./../js/localization');
 const serialPortHelper = require('./../js/serialPortHelper');
+const jBox = require('../js/libraries/jBox/jBox.min');
 
 TABS.ports = {};
 
 TABS.ports.initialize = function (callback) {
 
     var columns = ['data', 'logging', 'sensors', 'telemetry', 'rx', 'peripherals'];
+    var mspWarningModal;
 
     if (GUI.active_tab != 'ports') {
         GUI.active_tab = 'ports';
@@ -23,6 +25,34 @@ TABS.ports.initialize = function (callback) {
     mspHelper.loadSerialPorts(function () {
         GUI.load(path.join(__dirname, "ports.html"), on_tab_loaded_handler)
     });
+
+    function checkMSPPortCount(excludeCheckbox) {
+        let mspCount = 0;
+
+        $('.tab-ports .portConfiguration').each(function () {
+            const $portConfig = $(this);
+
+            // Check each MSP checkbox in this port configuration
+            $portConfig.find('input:checkbox[value="MSP"]').each(function() {
+                const $checkbox = $(this);
+                // Skip the checkbox we're currently changing (to get "before" count)
+                if (excludeCheckbox && $checkbox.is(excludeCheckbox)) {
+                    return;
+                }
+                if ($checkbox.is(':checked')) {
+                    mspCount++;
+                }
+            });
+        });
+
+        return mspCount;
+    }
+
+    function showMSPWarning() {
+        if (mspWarningModal) {
+            mspWarningModal.open();
+        }
+    }
 
     function update_ui() {
 
@@ -152,6 +182,16 @@ TABS.ports.initialize = function (callback) {
             return;
         }
 
+        // Check if MSP checkbox was just checked
+        if ($cT.is('input[type="checkbox"]') && $cT.val() === 'MSP' && $cT.is(':checked')) {
+            // Count MSP ports excluding the one being changed to get "before" count
+            const mspCountBefore = checkMSPPortCount($cT);
+            // If we already had 2+ and are adding another, show warning
+            if (mspCountBefore >= 2) {
+                showMSPWarning();
+            }
+        }
+
         if (rule && rule.isUnique) {
             let $selects = $cT.closest('tr').find('.function-select');
             $selects.each(function (index, element) {
@@ -181,6 +221,22 @@ TABS.ports.initialize = function (callback) {
        i18n.localize();;
 
         update_ui();
+
+        // Initialize the MSP warning modal
+        mspWarningModal = new jBox('Modal', {
+            width: 480,
+            height: 200,
+            closeButton: 'title',
+            animation: false,
+            title: i18n.getMessage('portsMspWarningTitle') || 'MSP Port Warning',
+            content: $('#mspWarningContent')
+        });
+
+        // Check if more than 2 MSP ports are already configured on load
+        const initialMspCount = checkMSPPortCount();
+        if (initialMspCount > 2) {
+            showMSPWarning();
+        }
 
         $('a.save').on('click', on_save_handler);
 
@@ -268,5 +324,6 @@ function updateDefaultBaud(baudSelect, column) {
 }
 
 TABS.ports.cleanup = function (callback) {
+    $('.jBox-wrapper').remove();
     if (callback) callback();
 };


### PR DESCRIPTION
Select MSP on three UARTs can mean it is no longer available on the USB VCP, because there is a limit of three total.
Warn the user about this if they select three, and suggest that they remove MSP from an unused UART.