### PR TITLE
Fix bold text for <strong> (in translations) in non-English languages

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1394,6 +1394,7 @@ dialog {
     padding-top: 4px;
     margin-bottom: 0;
     float: left;
+    font-weight: bold;
 }
 
 /* Fixed area at the Bottom */

--- a/src/css/opensans_webfontkit/fonts.css
+++ b/src/css/opensans_webfontkit/fonts.css
@@ -99,20 +99,20 @@ em {
 em strong {
     font-family: 'open_sansbold_italic';
     font-style:normal;
-    font-weight: normal;
+    font-weight: bold;
 }
 
 /*noinspection CssNoGenericFontName*/
 strong em {
     font-family: 'open_sansbold_italic';
     font-style:normal;
-    font-weight: normal;
+    font-weight: bold;
 }
 
 /*noinspection CssNoGenericFontName*/
 strong {
     font-family: 'open_sansbold';
-    font-weight: normal;
+    font-weight: bold;
     font-style: normal;
 }
 

--- a/src/css/tabs/failsafe.css
+++ b/src/css/tabs/failsafe.css
@@ -53,6 +53,7 @@
     font-size: 13px;
     margin-top: 15px;
     margin-bottom: 5px;
+    font-weight: bold;
 }
 
 .tab-failsafe .radioarea {


### PR DESCRIPTION
### **User description**
There was no such problem with the English language.   
Example of a non-English locale before and after   

<details>
<summary>spoiler</summary>

<img width="1919" height="1020" alt="image" src="https://github.com/user-attachments/assets/131ec5f7-8c6b-491c-a348-98cfb35836ef" />

<img width="1919" height="1018" alt="image" src="https://github.com/user-attachments/assets/c88fd8ec-4490-4bcc-b944-7316af5da09f" />

<img width="1919" height="1020" alt="image" src="https://github.com/user-attachments/assets/231b5469-6267-4703-8edd-541f8f20ee30" />

</details>


___

### **PR Type**
Bug fix


___

### **Description**
- Fix bold text rendering for `<strong>` tags in non-English languages

- Add missing `font-weight: bold` to `.spacer_box_title` class

- Correct `font-weight` property in Open Sans font definitions

- Add `font-weight: bold` to `.tab-failsafe .subline` class


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CSS Font Definitions"] -->|Add font-weight bold| B["strong, em strong, strong em"]
  C["UI Components"] -->|Add font-weight bold| D[".spacer_box_title, .tab-failsafe .subline"]
  B --> E["Correct Bold Rendering"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.css</strong><dd><code>Add bold font weight to spacer box title</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/css/main.css

<ul><li>Add <code>font-weight: bold</code> to <code>.spacer_box_title</code> class<br> <li> Ensures bold styling is applied to spacer box titles</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2415/files#diff-36ebfd7bbcd72a8d3e81092b646f4c4427ad2496c2bc1d428c7b5e0ba29430f9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fonts.css</strong><dd><code>Correct font-weight for strong text elements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/css/opensans_webfontkit/fonts.css

<ul><li>Change <code>font-weight: normal</code> to <code>font-weight: bold</code> for <code>strong</code> selector<br> <li> Change <code>font-weight: normal</code> to <code>font-weight: bold</code> for <code>em strong</code> selector<br> <li> Change <code>font-weight: normal</code> to <code>font-weight: bold</code> for <code>strong em</code> selector<br> <li> Fixes bold text rendering in Open Sans web font definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2415/files#diff-8ad55416c7622dc5e4a35b5fc53388af8840f9adc2f43fd441e53b8aea85a71a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>failsafe.css</strong><dd><code>Add bold font weight to failsafe subline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/css/tabs/failsafe.css

<ul><li>Add <code>font-weight: bold</code> to <code>.tab-failsafe .subline</code> class<br> <li> Ensures subline text in failsafe tab displays with bold styling</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2415/files#diff-829de467413b865f67ad84978fe1d18f12caa54280391530064b2ff53303eec2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

