### PR TITLE
Fix granularity of FW level trim

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -119,12 +119,9 @@ var Settings = (function () {
                     input.val(s.value);
                     input.attr('maxlength', s.setting.max);
                 } else if (input.data('presentation') == 'range') {
-                    
                     GUI.sliderize(input, s.value, s.setting.min, s.setting.max);
-
                 } else if (s.setting.type == 'float') {
                     input.attr('type', 'number');
-
                     let dataStep = input.data("step");
 
                     if (typeof dataStep === 'undefined') {
@@ -153,7 +150,7 @@ var Settings = (function () {
                 }
 
                 // If data is defined, We want to convert this value into 
-                // something matching the units        
+                // something matching the units
                 self.convertToUnitSetting(input, inputUnit);
 
                 input.data('setting-info', s.setting);
@@ -313,40 +310,40 @@ var Settings = (function () {
         //unitConversionTable[toUnit][fromUnit] -> factor
         const unitRatioTable = {
             'cm' : {
-                'm' : 100, 
+                'm' : 100.0, 
                 'ft' : 30.48
             },
             'm' : {
-                'm' : 1,
+                'm' : 1.0,
                 'ft' : 0.3048
             },
             'm-lrg' : {
-                'km' : 1000,
+                'km' : 1000.0,
                 'mi' : 1609.344,
-                'nm' : 1852
+                'nm' : 1852.0
             },
             'cms' : { // Horizontal speed
                 'kmh' : 27.77777777777778, 
                 'kt': 51.44444444444457, 
                 'mph' : 44.704,
-                'ms' : 100
+                'ms' : 100.0
             },
             'v-cms' : { // Vertical speed
-                'ms' : 100,
+                'ms' : 100.0,
                 'hftmin' : 50.8,
                 'fts' : 30.48
             },
             'msec-nc' : {
-                'msec-nc' : 1
+                'msec-nc' : 1.0
             },
             'msec' : {
-                'sec' : 1000
+                'sec' : 1000.0
             },
             'dsec' : {
-                'sec' : 10
+                'sec' : 10.0
             },
             'mins' : {
-                'hours' : 60
+                'hours' : 60.0
             },
             'tzmins' : {
                 'tzhours' : 'TZHOURS'
@@ -358,16 +355,16 @@ var Settings = (function () {
                 'deg' : 0.1
             },
             'decideg' : {
-                'deg' : 10
+                'deg' : 10.0
             },
             'decideg-lrg' : {
-                'deg' : 10
+                'deg' : 10.0
             },
             'decadegps' : {
                 'degps' : 0.1
             },
             'decidegc' : {
-                'degc' : 10,
+                'degc' : 10.0,
                 'degf' : 'FAHREN'
             },
         };
@@ -491,8 +488,8 @@ var Settings = (function () {
         let decimalPlaces = 0;
         // Update the step, min, and max; as we have the multiplier here.
         if (element.attr('type') == 'number') {
-            let step = parseFloat(element.attr('step')) || 1;
-            
+            let step = parseFloat(element.data("step")) || parseFloat(element.attr('step')) || 1;
+
             if (multiplier !== 1) { 
                 decimalPlaces = Math.min(Math.ceil(multiplier / 100), 3);
                 // Add extra decimal place for non-integer conversions.
@@ -500,6 +497,8 @@ var Settings = (function () {
                     decimalPlaces++;
                 }
                 step = 1 / Math.pow(10, decimalPlaces);
+            } else { 
+                decimalPlaces = this.countDecimals(step);
             }
             element.attr('step', step.toFixed(decimalPlaces));
 
@@ -603,8 +602,8 @@ var Settings = (function () {
         // verify if number 0.000005 is represented as "5e-6"
         if (text.indexOf('e-') > -1) {
           let [base, trail] = text.split('e-');
-          let deg = parseInt(trail, 10);
-          return deg;
+          let decimals = parseInt(trail, 10);
+          return decimals;
         }
         // count decimals for number in representation like "0.123456"
         if (Math.floor(value) !== value) {

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -889,7 +889,7 @@
                         <tr>
                             <th data-i18n="pidTuning_fw_level_pitch_trim"></th>
                             <td>
-                                <div class="pidTuning_number"><input id="fwLevelTrim" class="rate-tpa_input" data-setting="fw_level_pitch_trim" data-unit="deg" /></div>
+                                <div class="pidTuning_number"><input id="fwLevelTrim" type="number" class="rate-tpa_input" data-setting="fw_level_pitch_trim" data-unit="deg" data-step="0.001" /></div>
                                 <div for="fwLevelTrim" class="helpicon cf_tip" data-i18n_title="pidTuning_fw_level_pitch_trim_help"></div>
                             </td>
                         </tr>


### PR DESCRIPTION
### **User description**
Fixes #2420

I have found a bug that stopped FW level trim being shown as a float, even if set to a float. It would have affected any units that didn't require a conversion.

I did look at adding a slider. But there was an issue with it having a number with decimal places. It would show them when you used the slider. But not when you entered the page. I will take a look at some point. But, to be honest, it's getting late and this fixed the decimal places issue raised.

With regard to the original issue
- I have set it to 3 decimal places, to match the CLI.
- I will look in to getting the slider working, probably in another PR. This fix may affect other data, so should go in straight away.
- History and logging changes is something that you'd have to do yourself. It's not in the scope of INAV to maintain history of changes to parameters. It would just waste a lot of memory. Potentially if SD card drivers are improved. Logging changes to parameter could happen on there. But I think that's a fair way off.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix FW level trim displaying as integer instead of float

- Add explicit decimal step attribute to trim input field

- Ensure decimal places preserved when no unit conversion applied

- Standardize numeric literals to float format in conversion tables


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FW Level Trim Input"] -->|Add data-step attribute| B["Preserve Decimal Places"]
  C["Unit Conversion Logic"] -->|Check multiplier == 1| D["Apply countDecimals to step"]
  E["Numeric Conversion Tables"] -->|Standardize to float| F["Consistent decimal handling"]
  B --> G["Display as float with 3 decimals"]
  D --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.js</strong><dd><code>Decimal handling and unit conversion table standardization</code></dd></summary>
<hr>

js/settings.js

<ul><li>Fixed decimal place handling when multiplier equals 1 by calling <br><code>countDecimals(step)</code><br> <li> Changed step attribute lookup to prioritize <code>data("step")</code> over <br><code>attr('step')</code><br> <li> Standardized numeric literals in <code>unitRatioTable</code> to float format (e.g., <br><code>100</code> to <code>100.0</code>)<br> <li> Updated variable name from <code>deg</code> to <code>decimals</code> in <code>countDecimals</code> function <br>for clarity<br> <li> Removed unnecessary whitespace in conditional blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2421/files#diff-6bae0462aba087b0196acddf217d3c8ff408cc0d5d76ca6c79b8041580c47fad">+20/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pid_tuning.html</strong><dd><code>Add number type and decimal step to trim input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tabs/pid_tuning.html

<ul><li>Added <code>type="number"</code> attribute to FW level trim input element<br> <li> Added <code>data-step="0.001"</code> attribute to enforce 3 decimal place <br>granularity<br> <li> Ensures trim value displays and accepts float values with proper <br>precision</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2421/files#diff-f3d3509aecda8da37613cf000ade974594d5e921f6c3222a21d73a6894f329d5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

