### PR TITLE
Add `Relative wind offset` to IPF

### DIFF
--- a/js/logicConditionOperantTypes.js
+++ b/js/logicConditionOperantTypes.js
@@ -69,6 +69,7 @@ const OPERAND_TYPES = {
             46: "Minimum Ground Speed [m/s]",
             47: "Horizontal Wind Speed [cm/s]",
             48: "Wind Direction [deg]",
+            49: "Relative Wind Offset [deg]",
         }
     },
     3: {


### PR DESCRIPTION
### **User description**
Added `Relative wind offset` which gives the relative difference in degrees between the wind heading and aircraft heading. 0 degrees is flying directly in to the headwind. -180 to 1 degree(s) signifies a counter-clockwise offset.


___

### **PR Type**
Enhancement


___

### **Description**
- Added "Relative Wind Offset [deg]" operand type to IPF

- Provides relative difference in degrees between wind and aircraft heading

- 0 degrees indicates flying directly into headwind

- Negative values (-180 to -1) signify counter-clockwise offset


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["IPF Logic Conditions"] -- "adds new operand type" --> B["Relative Wind Offset [deg]"]
  B -- "calculates" --> C["Wind vs Aircraft Heading Difference"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logicConditionOperantTypes.js</strong><dd><code>Add Relative Wind Offset operand type entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/logicConditionOperantTypes.js

<ul><li>Added new operand type entry 49 for "Relative Wind Offset [deg]"<br> <li> Inserted into OPERAND_TYPES object under appropriate section<br> <li> Maintains existing operand type numbering and structure</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2426/files#diff-36a6dd5e5b1f33d723d3a585d61b215b598c72e50757401ca43353fa98ddb0ef">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

