### PR TITLE
MacOS Ci Fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
             path: ./out/make/*arm64*.dmg
 
     build-mac:
-        runs-on: macos-15
+        runs-on: macos-15-intel
         steps:
         - uses: actions/checkout@v4
         - name: Setup environment


### PR DESCRIPTION
### **User description**
From Github:
 The macOS-13 based runner images are being deprecated. For more details, see https://github.com/actions/runner-images/issues/13046.


___

### **PR Type**
Enhancement


___

### **Description**
- Update macOS CI runners from deprecated versions

- Replace `macos-13` with `macos-15` for ARM64 builds

- Replace `macos-13` with `macos-15-intel` for Intel builds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["macOS-13 runners<br/>deprecated"] -- "ARM64 job" --> B["macos-15"]
  A -- "Intel job" --> C["macos-15-intel"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Update macOS runner versions in CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Updated <code>build-mac-arm64</code> job runner from <code>macos-13</code> to <code>macos-15</code><br> <li> Updated <code>build-mac</code> job runner from <code>macos-13</code> to <code>macos-15-intel</code><br> <li> Addresses deprecation of macOS-13 based runner images</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2427/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

