### PR TITLE
Fix DFU flash: ensure cleanup callback runs on USB error

### DIFF
--- a/js/protocols/stm32usbdfu.js
+++ b/js/protocols/stm32usbdfu.js
@@ -444,6 +444,8 @@ STM32DFU_protocol.prototype.controlTransfer = function (direction, request, valu
             }
         }).catch(() => {
             console.log('USB controlTransfer IN failed for request ' + request + '!');
+            // Call callback with error to ensure cleanup happens
+            callback([], -1);
         });
     } else {
         // length is ignored


### PR DESCRIPTION
### **User description**
## Problem

After DFU flashing completes successfully, users cannot reconnect to the flight controller without restarting the configurator.

## Root Cause

In `stm32usbdfu.js`, when the final USB controlTransfer fails (expected when device reboots after successful flash), the error handler logs the error but doesn't call the callback. This leaves `GUI.connect_lock = true`, preventing reconnection.

## Solution

Call the callback with an error code even when USB transfer fails, ensuring `cleanup()` runs and `GUI.connect_lock` gets cleared.

## Testing

- Flashed firmware via DFU successfully
- Verified reconnection works immediately after flash without restarting configurator
- No regressions in DFU flashing behavior

## Files Changed

- `js/protocols/stm32usbdfu.js` (+2 lines)


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation



