### PR TITLE
Restore checkMSPPortCount and showMSPWarning functions in ports tab

### DIFF
--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -47,7 +47,7 @@ TABS.ports.initialize = function (callback) {
     }
 
     function showMSPWarning() {
-        if (mspWarningModal) {
+        if (mspWarningModal && typeof mspWarningModal.open === 'function') {
             mspWarningModal.open();
         }
     }


### PR DESCRIPTION
### **User description**
## Summary
- Restore checkMSPPortCount() and showMSPWarning() functions that were lost during merge conflict resolution
- These functions warn users when more than 2 MSP ports are configured

## Root cause
Functions were added in commit 92ee3431 but lost in subsequent merge conflicts (8ccf4f83, 895c526c).


___

### **PR Type**
Bug fix


___

### **Description**
- Restore checkMSPPortCount() function to count MSP ports

- Restore showMSPWarning() function to display warnings

- Functions were lost during merge conflict resolution

- Warn users when more than 2 MSP ports configured


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Merge Conflict"] -->|"Lost Functions"| B["Missing MSP Validation"]
  B -->|"PR Fix"| C["Restored checkMSPPortCount"]
  B -->|"PR Fix"| D["Restored showMSPWarning"]
  C -->|"Enables"| E["Port Count Validation"]
  D -->|"Enables"| E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ports.js</strong><dd><code>Restore MSP port validation and warning functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tabs/ports.js

<ul><li>Added checkMSPPortCount() function to count active MSP port checkboxes<br> <li> Added showMSPWarning() function to display MSP warning modal<br> <li> Functions iterate through port configurations and check MSP checkbox <br>states<br> <li> Supports excluding specific checkbox from count for "before" state <br>comparison</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2436/files#diff-aac9aa235c7b2dd923066864ee70b9c8f787b2c0f377fa5ad0344eb688712e4a">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

