### PR TITLE
Make optimized logic condition loading compatible with earlier 9.0-RCx or master

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -472,24 +472,31 @@ var mspHelper = (function () {
                 break;
 
             case MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_SINGLE:
-                FC.LOGIC_CONDITIONS.put(new LogicCondition(
-                    data.getInt8(0),
-                    data.getInt8(1),
-                    data.getUint8(2),
-                    data.getUint8(3),
-                    data.getInt32(4, true),
-                    data.getUint8(8),
-                    data.getInt32(9, true),
-                    data.getInt8(13)
-                ));
+                if (data.byteLength >= 14 && !dataHandler.unsupported) {
+                    FC.LOGIC_CONDITIONS.put(new LogicCondition(
+                        data.getInt8(0),
+                        data.getInt8(1),
+                        data.getUint8(2),
+                        data.getUint8(3),
+                        data.getInt32(4, true),
+                        data.getUint8(8),
+                        data.getInt32(9, true),
+                        data.getInt8(13)
+                    ));
+                } else {
+                    console.warn('MSP2_INAV_LOGIC_CONDITIONS_SINGLE: unexpected response (byteLength=' + data.byteLength + ', unsupported=' + dataHandler.unsupported + ')');
+                }
                 break;
 
             case MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_CONFIGURED:
                 // 8-byte bitmask: lower 32 bits first, then upper 32 bits
-                FC.LOGIC_CONDITIONS_CONFIGURED_MASK = {
-                    lower: data.getUint32(0, true),
-                    upper: data.getUint32(4, true)
-                };
+                // Older firmware returns unsupported/empty - that's expected, mask stays null
+                if (data.byteLength >= 8 && !dataHandler.unsupported) {
+                    FC.LOGIC_CONDITIONS_CONFIGURED_MASK = {
+                        lower: data.getUint32(0, true),
+                        upper: data.getUint32(4, true)
+                    };
+                }
                 break;
 
             case MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_STATUS:
@@ -2438,69 +2445,86 @@ var mspHelper = (function () {
     };
 
     self.loadLogicConditions = function (callback) {
-        if (semver.gte(FC.CONFIG.flightControllerVersion, "5.0.0")) {
+        // Helper function for legacy path: fetch all 64 conditions one by one
+        function loadAllConditionsLegacy() {
             FC.LOGIC_CONDITIONS.flush();
+            let idx = 0;
+            MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_SINGLE, [idx], false, nextLogicCondition);
 
-            // Check if firmware supports the optimized CONFIGURED mask (9.0.0+)
-            if (semver.gte(FC.CONFIG.flightControllerVersion, "9.0.0")) {
-                // Optimized path: first get the configured mask, then only fetch configured conditions
-                MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_CONFIGURED, false, false, function() {
-                    const mask = FC.LOGIC_CONDITIONS_CONFIGURED_MASK;
-                    const maxConditions = FC.LOGIC_CONDITIONS.getMaxLogicConditionCount();
-                    let idx = 0;
-
-                    function processNextCondition() {
-                        while (idx < maxConditions) {
-                            // Check if this condition is configured (non-default)
-                            const isConfigured = (idx < 32) ?
-                                (mask.lower & (1 << idx)) !== 0 :
-                                (mask.upper & (1 << (idx - 32))) !== 0;
-
-                            if (isConfigured) {
-                                // Fetch from firmware - handler will put() it
-                                MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_SINGLE, [idx], false, function() {
-                                    idx++;
-                                    processNextCondition();
-                                });
-                                return; // Wait for async MSP response
-                            } else {
-                                // Not configured - put default directly and continue loop
-                                FC.LOGIC_CONDITIONS.put(new LogicCondition(
-                                    0,      // enabled
-                                    -1,     // activatorId
-                                    0,      // operation
-                                    0,      // operandAType
-                                    0,      // operandAValue
-                                    0,      // operandBType
-                                    0,      // operandBValue
-                                    0       // flags
-                                ));
-                                idx++;
-                            }
-                        }
-                        // All conditions processed
-                        if (callback) callback();
-                    }
-
-                    processNextCondition();
-                });
-            } else {
-                // Legacy path for 5.0.0 - 8.x: fetch all 64 conditions
-                let idx = 0;
-                MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_SINGLE, [idx], false, nextLogicCondition);
-
-                function nextLogicCondition() {
-                    idx++;
-                    if (idx < FC.LOGIC_CONDITIONS.getMaxLogicConditionCount() - 1) {
-                        MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_SINGLE, [idx], false, nextLogicCondition);
-                    } else {
-                        MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_SINGLE, [idx], false, callback);
-                    }
+            function nextLogicCondition() {
+                idx++;
+                if (idx < FC.LOGIC_CONDITIONS.getMaxLogicConditionCount() - 1) {
+                    MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_SINGLE, [idx], false, nextLogicCondition);
+                } else {
+                    MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_SINGLE, [idx], false, callback);
                 }
             }
-        } else {
-            MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS, false, false, callback);
         }
+
+        // Try to get the optimized CONFIGURED mask with timeout fallback
+        FC.LOGIC_CONDITIONS_CONFIGURED_MASK = null;
+        let maskResponseReceived = false;
+
+        // Set up timeout fallback - if no response in 500ms, use legacy path
+        const fallbackTimeout = setTimeout(function() {
+            if (!maskResponseReceived) {
+                maskResponseReceived = true;
+                loadAllConditionsLegacy();
+            }
+        }, 500);
+
+        MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_CONFIGURED, false, false, function() {
+            if (maskResponseReceived) return; // Timeout already triggered legacy path
+            maskResponseReceived = true;
+            clearTimeout(fallbackTimeout);
+
+            const mask = FC.LOGIC_CONDITIONS_CONFIGURED_MASK;
+
+            if (mask) {
+                // Optimized path: use the configured mask to only fetch configured conditions
+                FC.LOGIC_CONDITIONS.flush();
+                const maxConditions = FC.LOGIC_CONDITIONS.getMaxLogicConditionCount();
+                let idx = 0;
+
+                function processNextCondition() {
+                    while (idx < maxConditions) {
+                        // Check if this condition is configured (non-default)
+                        const isConfigured = (idx < 32) ?
+                            (mask.lower & (1 << idx)) !== 0 :
+                            (mask.upper & (1 << (idx - 32))) !== 0;
+
+                        if (isConfigured) {
+                            // Fetch from firmware - handler will put() it
+                            MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_SINGLE, [idx], false, function() {
+                                idx++;
+                                processNextCondition();
+                            });
+                            return; // Wait for async MSP response
+                        } else {
+                            // Not configured - put default directly and continue loop
+                            FC.LOGIC_CONDITIONS.put(new LogicCondition(
+                                0,      // enabled
+                                -1,     // activatorId
+                                0,      // operation
+                                0,      // operandAType
+                                0,      // operandAValue
+                                0,      // operandBType
+                                0,      // operandBValue
+                                0       // flags
+                            ));
+                            idx++;
+                        }
+                    }
+                    // All conditions processed
+                    if (callback) callback();
+                }
+
+                processNextCondition();
+            } else {
+                // Legacy path: mask not available, fetch all 64 conditions
+                loadAllConditionsLegacy();
+            }
+        });
     }
 
     self.sendLogicConditions = function (onCompleteCallback) {

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -3554,7 +3554,10 @@ TABS.osd = {};
 TABS.osd.initialize = function (callback) {
 
     mspHelper.loadServoMixRules();
-    mspHelper.loadLogicConditions();
+    mspHelper.loadLogicConditions(function() {
+        // Refresh LC dropdowns now that conditions are loaded
+        $('select.lc, select.ico_lc').html(getLCoptions());
+    });
 
     if (GUI.active_tab != 'osd') {
         GUI.active_tab = 'osd';
@@ -4168,6 +4171,10 @@ function getGVoptions(){
 
 function getLCoptions(){
     var result = '';
+    // Return empty if conditions aren't fully loaded yet - callback will refresh
+    if (FC.LOGIC_CONDITIONS.getCount() < FC.LOGIC_CONDITIONS.getMaxLogicConditionCount()) {
+        return result;
+    }
     for(var i = 0; i < FC.LOGIC_CONDITIONS.getMaxLogicConditionCount(); i++) {
         if (FC.LOGIC_CONDITIONS.isEnabled(i)) {
             result += `<option value="` + i + `">LC ` + i + `</option>`;


### PR DESCRIPTION
### **User description**
## Summary

Replace semver version checks with runtime capability detection for loading logic conditions. This makes the optimized loading path work with firmware builds from earlier 9.0 release candidates or master branch that support `MSP2_INAV_LOGIC_CONDITIONS_CONFIGURED`.

Fixes an issue with #2465 

## Changes

### MSPHelper.js - loadLogicConditions()
- Remove hardcoded version checks (5.0.0, 9.0.0)
- Always try the optimized CONFIGURED mask path first
- Fall back to legacy path (fetch all 64) if:
  - Firmware returns unsupported/empty response
  - No response within 500ms timeout
- Add bounds checking to MSP handlers to prevent crashes on invalid data

### tabs/osd.js
- Add callback to `loadLogicConditions()` that refreshes LC dropdowns after load completes
- Add guard in `getLCoptions()` to return empty if conditions not yet loaded

## Approach

Instead of checking firmware version to decide which loading path to use, the configurator now:
1. Sends `MSP2_INAV_LOGIC_CONDITIONS_CONFIGURED` regardless of version
2. If firmware responds with valid 8-byte mask → use optimized path
3. If firmware returns unsupported/empty OR times out after 500ms → use legacy path

This is more robust than version checking because it works with:
- Official 9.0.0+ releases (optimized path)
- Earlier 9.0 RCs that may have had the MSP command (optimized path)
- Master branch builds (optimized path if supported)
- Older firmware without the command (legacy fallback)

## Testing

- Tested with INAV 9.0.0 SITL (optimized path works)
- Tested with older firmware (legacy fallback works)
- OSD tab LC dropdowns populate correctly in both cases

## Files Changed

- `js/msp/MSPHelper.js` - Refactored loadLogicConditions(), added bounds checking
- `tabs/osd.js` - Added callback for LC dropdown refresh


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace hardcoded version checks with runtime capability detection

- Add 500ms timeout fallback for optimized logic condition loading path

- Add bounds checking to prevent crashes on invalid MSP responses

- Refresh LC dropdowns after conditions load completes in OSD tab


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["loadLogicConditions()"] -->|"Send MSP2_INAV_LOGIC_CONDITIONS_CONFIGURED"| B["Await Response"]
  B -->|"500ms timeout"| C["Legacy Path: Fetch all 64"]
  B -->|"Mask received"| D["Optimized Path: Fetch configured only"]
  C --> E["Populate LC dropdowns"]
  D --> E
  E --> F["Callback: Refresh UI"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MSPHelper.js</strong><dd><code>Runtime capability detection for logic condition loading</code>&nbsp; </dd></summary>
<hr>

js/msp/MSPHelper.js

<ul><li>Remove semver version checks (5.0.0, 9.0.0) from <code>loadLogicConditions()</code><br> <li> Always attempt optimized <code>MSP2_INAV_LOGIC_CONDITIONS_CONFIGURED</code> path <br>first with 500ms timeout<br> <li> Fall back to legacy path if timeout or no mask response received<br> <li> Add bounds checking to <code>MSP2_INAV_LOGIC_CONDITIONS_SINGLE</code> and <br><code>MSP2_INAV_LOGIC_CONDITIONS_CONFIGURED</code> handlers<br> <li> Add console warnings for unexpected/invalid responses</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2467/files#diff-d006b63aa45117eed77ad8b4f1bb6c267d50798748974998302028eacd01673c">+93/-69</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>osd.js</strong><dd><code>Add callback and guard for LC dropdown refresh</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tabs/osd.js

<ul><li>Add callback to <code>loadLogicConditions()</code> to refresh LC dropdowns after <br>load completes<br> <li> Add guard in <code>getLCoptions()</code> to return empty string if conditions not <br>fully loaded yet<br> <li> Prevents dropdown population before async loading finishes</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2467/files#diff-cd81907a0c9960d9561f9ca8a2eb5c95069f69456485620e79877ce2576043f7">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

