### PR TITLE
Fix motor number positioning in Mixer tab

### DIFF
--- a/src/css/tabs/mixer.css
+++ b/src/css/tabs/mixer.css
@@ -121,6 +121,10 @@
 }
 
 
+.tab-mixer .mixerPreview {
+    position: relative;
+}
+
 .motorNumber {
     position: absolute;
     font-size: 1.4em;

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -453,6 +453,14 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
             }
         }
 
+        const $img = $("#motor-mixer-preview-img");
+        const imgHeight = $img.height();
+
+        // Skip positioning if image hasn't loaded yet (height would be 0)
+        if (imgHeight === 0) {
+            return;
+        }
+
         for (const i in rules) {
             if (rules.hasOwnProperty(i)) {
                 const rule = rules[i];
@@ -462,14 +470,14 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
                     continue;
                 }
 
-                let top_px = 30;
+                let top_px = 28;
                 let left_px = 28;
                 if (rule.getRoll() < -0.5) {
-                  left_px = $("#motor-mixer-preview-img").width() - 42;
+                  left_px = $img.width() - 42;
                 }
 
                 if (rule.getPitch() > 0.5) {
-                  top_px = $("#motor-mixer-preview-img").height() - 42;
+                  top_px = imgHeight - 44;
                 }
                 $("#motorNumber"+index).css("left", left_px + "px");
                 $("#motorNumber"+index).css("top", top_px + "px");
@@ -657,9 +665,18 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
             const isReversed = motorDirectionCheckbox.val() == 1 && (FC.MIXER_CONFIG.platformType == PLATFORM.MULTIROTOR || FC.MIXER_CONFIG.platformType == PLATFORM.TRICOPTER);
 
             import(`./../resources/motor_order/${currentMixerPreset.image}${isReversed ? "_reverse" : ""}.svg`).then(({default: path}) => {
-                $('.mixerPreview img').attr('src', path);
+                const $img = $('.mixerPreview img');
+                $img.attr('src', path);
+                // Wait for image to load before positioning motor numbers
+                $img.off('load.motorNumbers').on('load.motorNumbers', function() {
+                    labelMotorNumbers();
+                });
+                // If image is already cached, load event won't fire, so check complete
+                if ($img[0].complete) {
+                    labelMotorNumbers();
+                }
             });
-            
+
             renderServoOutputImage();
         };
 
@@ -720,7 +737,6 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
             }
 
             updateRefreshButtonStatus();
-            labelMotorNumbers();
             updateMotorDirection();
         });
 


### PR DESCRIPTION
### **User description**
## Summary
Fixes motor numbers (1-4) appearing in wrong positions on the quad preview image in the Mixer tab.

## Problem
`labelMotorNumbers()` was called before the SVG image loaded, causing `image.height()` to return 0. This resulted in negative top positions (-42px) for rear motors, placing them above the visible area.

## Changes
- **mixer.js**: 
  - `labelMotorNumbers()` now returns early if image height is 0 (not yet loaded)
  - Moved `labelMotorNumbers()` call into image load handler in `updateMotorDirection()`
  - Handles cached images that won't fire load event
  - Adjusted vertical positioning by 2px for better alignment

## Testing
- Verified motor numbers 1-4 now overlay correctly on quad motor positions
- Tested with Quad X preset
- Confirmed positioning updates when changing presets


___

### **PR Type**
Bug fix


___

### **Description**
- Fix motor number positioning in Mixer tab quad preview

- Add CSS position:relative to mixerPreview container

- Move labelMotorNumbers() call into image load handler

- Adjust vertical positioning and handle cached images


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Motor numbers positioning issue"] --> B["CSS: Add position:relative"]
  A --> C["JS: Timing - image not loaded"]
  B --> D["Motor numbers align correctly"]
  C --> E["Move labelMotorNumbers to load handler"]
  E --> D
  C --> F["Handle cached images"]
  F --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mixer.js</strong><dd><code>Move motor number positioning to image load handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tabs/mixer.js

<ul><li>Added early return in <code>labelMotorNumbers()</code> if image height is 0<br> <li> Moved <code>labelMotorNumbers()</code> call into image load event handler in <br><code>updateMotorDirection()</code><br> <li> Added handling for cached images using <code>$img[0].complete</code> check<br> <li> Adjusted vertical positioning from 30px to 28px and rear motor offset <br>from -42 to -44<br> <li> Removed direct <code>labelMotorNumbers()</code> call from preset change handler<br> <li> Cached <code>$img</code> selector reference for performance</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2475/files#diff-f1bbc6ab2941ef2805134eef08a05ab9c1e1038d8d7722e4d4fce959c120482b">+22/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mixer.css</strong><dd><code>Add position:relative to mixerPreview container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/css/tabs/mixer.css

<ul><li>Added <code>position: relative</code> to <code>.tab-mixer .mixerPreview</code> container<br> <li> Ensures absolutely positioned motor numbers are relative to the image <br>container</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2475/files#diff-47f829c744af38918480ddcb55f07b31255f23946a19e528d11a8081643055f0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

