### PR TITLE
Add Power Limiting UI to Configuration Tab

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1077,6 +1077,63 @@
     "configurationBatteryCapacityUnit": {
         "message": "Battery Capacity Unit"
     },
+    "configurationPowerLimits": {
+        "message": "Power Limiting"
+    },
+    "configurationPowerLimitsHelp": {
+        "message": "Limit battery current and power draw to protect your battery and ESCs. Set to 0 to disable. Units: dA (deci-amps) = A×10, dW (deci-watts) = W×10, ds (deci-seconds) = s×10."
+    },
+    "configurationPowerLimitsNote": {
+        "message": "Protects battery from over-current by smoothly reducing throttle. Requires current sensor. Set continuous and burst limits per your battery specs."
+    },
+    "configurationLimitContCurrent": {
+        "message": "Continuous Current Limit (dA)"
+    },
+    "configurationLimitContCurrentHelp": {
+        "message": "Maximum sustained current draw in deci-amps (dA). Example: 500 = 50A. Set to 0 to disable current limiting."
+    },
+    "configurationLimitBurstCurrent": {
+        "message": "Burst Current Limit (dA)"
+    },
+    "configurationLimitBurstCurrentHelp": {
+        "message": "Higher current allowed for short bursts (punch-outs, climbs). Example: 750 = 75A. Should be >= continuous limit."
+    },
+    "configurationLimitBurstCurrentTime": {
+        "message": "Burst Time (ds)"
+    },
+    "configurationLimitBurstCurrentTimeHelp": {
+        "message": "Duration burst current is allowed in deci-seconds (ds). Example: 100 = 10 seconds. After this time, limit falls to continuous."
+    },
+    "configurationLimitBurstCurrentFalldownTime": {
+        "message": "Burst Falldown Time (ds)"
+    },
+    "configurationLimitBurstCurrentFalldownTimeHelp": {
+        "message": "Smooth ramp-down time from burst to continuous limit in deci-seconds (ds). Example: 20 = 2 seconds."
+    },
+    "configurationLimitContPower": {
+        "message": "Continuous Power Limit (dW)"
+    },
+    "configurationLimitContPowerHelp": {
+        "message": "Maximum sustained power draw in deci-watts (dW). Example: 8000 = 800W. Set to 0 to disable power limiting. Requires voltage measurement."
+    },
+    "configurationLimitBurstPower": {
+        "message": "Burst Power Limit (dW)"
+    },
+    "configurationLimitBurstPowerHelp": {
+        "message": "Higher power allowed for short bursts. Example: 10000 = 1000W. Should be >= continuous limit."
+    },
+    "configurationLimitBurstPowerTime": {
+        "message": "Burst Time (ds)"
+    },
+    "configurationLimitBurstPowerTimeHelp": {
+        "message": "Duration burst power is allowed in deci-seconds (ds). Example: 50 = 5 seconds."
+    },
+    "configurationLimitBurstPowerFalldownTime": {
+        "message": "Burst Falldown Time (ds)"
+    },
+    "configurationLimitBurstPowerFalldownTimeHelp": {
+        "message": "Smooth ramp-down time from burst to continuous power limit in deci-seconds (ds). Example: 10 = 1 second."
+    },
     "configurationLaunch": {
         "message": "Fixed Wing Auto Launch Settings"
     },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1099,13 +1099,13 @@
         "message": "Higher current allowed for short bursts (punch-outs, climbs). Example: 750 = 75A. Should be >= continuous limit."
     },
     "configurationLimitBurstCurrentTime": {
-        "message": "Burst Time (ds)"
+        "message": "Burst Current Time (ds)"
     },
     "configurationLimitBurstCurrentTimeHelp": {
         "message": "Duration burst current is allowed in deci-seconds (ds). Example: 100 = 10 seconds. After this time, limit falls to continuous."
     },
     "configurationLimitBurstCurrentFalldownTime": {
-        "message": "Burst Falldown Time (ds)"
+        "message": "Burst Current Falldown Time (ds)"
     },
     "configurationLimitBurstCurrentFalldownTimeHelp": {
         "message": "Smooth ramp-down time from burst to continuous limit in deci-seconds (ds). Example: 20 = 2 seconds."
@@ -1123,13 +1123,13 @@
         "message": "Higher power allowed for short bursts. Example: 10000 = 1000W. Should be >= continuous limit."
     },
     "configurationLimitBurstPowerTime": {
-        "message": "Burst Time (ds)"
+        "message": "Burst Power Time (ds)"
     },
     "configurationLimitBurstPowerTimeHelp": {
         "message": "Duration burst power is allowed in deci-seconds (ds). Example: 50 = 5 seconds."
     },
     "configurationLimitBurstPowerFalldownTime": {
-        "message": "Burst Falldown Time (ds)"
+        "message": "Burst Power Falldown Time (ds)"
     },
     "configurationLimitBurstPowerFalldownTimeHelp": {
         "message": "Smooth ramp-down time from burst to continuous power limit in deci-seconds (ds). Example: 10 = 1 second."

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -1235,6 +1235,63 @@
     "configurationNoBand": {
         "message": "なし"
     },
+    "configurationPowerLimits": {
+        "message": "電力制限"
+    },
+    "configurationPowerLimitsHelp": {
+        "message": "バッテリーとESCを保護するために電流と電力の消費を制限します。0に設定すると無効になります。単位: dA（デシアンペア）= A×10、dW（デシワット）= W×10、ds（デシ秒）= s×10。"
+    },
+    "configurationPowerLimitsNote": {
+        "message": "スロットルを滑らかに絞ることでバッテリーの過電流を防止します。電流センサーが必要です。バッテリーの仕様に合わせて連続制限とバースト制限を設定してください。"
+    },
+    "configurationLimitContCurrent": {
+        "message": "連続電流制限 (dA)"
+    },
+    "configurationLimitContCurrentHelp": {
+        "message": "デシアンペア（dA）での最大持続電流。例：500 = 50A。電流制限を無効にするには0に設定。"
+    },
+    "configurationLimitBurstCurrent": {
+        "message": "バースト電流制限 (dA)"
+    },
+    "configurationLimitBurstCurrentHelp": {
+        "message": "短時間のバースト（急上昇など）に許容される高電流。例：750 = 75A。連続制限以上に設定してください。"
+    },
+    "configurationLimitBurstCurrentTime": {
+        "message": "バースト電流時間 (ds)"
+    },
+    "configurationLimitBurstCurrentTimeHelp": {
+        "message": "デシ秒（ds）でのバースト電流許容時間。例：100 = 10秒。この時間を超えると連続制限に戻ります。"
+    },
+    "configurationLimitBurstCurrentFalldownTime": {
+        "message": "バースト電流低下時間 (ds)"
+    },
+    "configurationLimitBurstCurrentFalldownTimeHelp": {
+        "message": "バースト制限から連続制限へのデシ秒（ds）での滑らかな移行時間。例：20 = 2秒。"
+    },
+    "configurationLimitContPower": {
+        "message": "連続電力制限 (dW)"
+    },
+    "configurationLimitContPowerHelp": {
+        "message": "デシワット（dW）での最大持続電力。例：8000 = 800W。電力制限を無効にするには0に設定。電圧測定が必要です。"
+    },
+    "configurationLimitBurstPower": {
+        "message": "バースト電力制限 (dW)"
+    },
+    "configurationLimitBurstPowerHelp": {
+        "message": "短時間のバーストに許容される高電力。例：10000 = 1000W。連続制限以上に設定してください。"
+    },
+    "configurationLimitBurstPowerTime": {
+        "message": "バースト電力時間 (ds)"
+    },
+    "configurationLimitBurstPowerTimeHelp": {
+        "message": "デシ秒（ds）でのバースト電力許容時間。例：50 = 5秒。"
+    },
+    "configurationLimitBurstPowerFalldownTime": {
+        "message": "バースト電力低下時間 (ds)"
+    },
+    "configurationLimitBurstPowerFalldownTimeHelp": {
+        "message": "バースト制限から連続電力制限へのデシ秒（ds）での滑らかな移行時間。例：10 = 1秒。"
+    },
     "configurationVTXNoBandHelp": {
         "message": "VTXの周波数が手動で設定されています。バンドを選択すると設定された周波数が上書きされます。"
     },

--- a/locale/ru/messages.json
+++ b/locale/ru/messages.json
@@ -5788,6 +5788,63 @@
     "configurationNoBand": {
         "message": "Отсутствует"
     },
+    "configurationPowerLimits": {
+        "message": "Ограничение мощности"
+    },
+    "configurationPowerLimitsHelp": {
+        "message": "Ограничьте потребление тока и мощности для защиты аккумулятора и регуляторов. Установите 0 для отключения. Единицы: dA (деци-ампер) = А×10, dW (деци-ватт) = Вт×10, ds (деци-секунда) = с×10."
+    },
+    "configurationPowerLimitsNote": {
+        "message": "Защищает аккумулятор от перегрузки по току, плавно уменьшая газ. Требует датчик тока. Задайте непрерывные и пиковые ограничения согласно спецификации аккумулятора."
+    },
+    "configurationLimitContCurrent": {
+        "message": "Непрерывный ток (dA)"
+    },
+    "configurationLimitContCurrentHelp": {
+        "message": "Максимальный постоянный ток в деци-амперах (dA). Пример: 500 = 50А. Установите 0 для отключения ограничения тока."
+    },
+    "configurationLimitBurstCurrent": {
+        "message": "Пиковый ток (dA)"
+    },
+    "configurationLimitBurstCurrentHelp": {
+        "message": "Повышенный ток допускается на короткое время (резкие манёвры, набор высоты). Пример: 750 = 75А. Должен быть >= непрерывного."
+    },
+    "configurationLimitBurstCurrentTime": {
+        "message": "Время пикового тока (ds)"
+    },
+    "configurationLimitBurstCurrentTimeHelp": {
+        "message": "Продолжительность пикового тока в деци-секундах (ds). Пример: 100 = 10 секунд. По истечении снижается до непрерывного."
+    },
+    "configurationLimitBurstCurrentFalldownTime": {
+        "message": "Время снижения тока (ds)"
+    },
+    "configurationLimitBurstCurrentFalldownTimeHelp": {
+        "message": "Время плавного снижения от пикового до непрерывного ограничения в деци-секундах (ds). Пример: 20 = 2 секунды."
+    },
+    "configurationLimitContPower": {
+        "message": "Непрерывная мощность (dW)"
+    },
+    "configurationLimitContPowerHelp": {
+        "message": "Максимальная постоянная мощность в деци-ваттах (dW). Пример: 8000 = 800 Вт. Установите 0 для отключения. Требует измерение напряжения."
+    },
+    "configurationLimitBurstPower": {
+        "message": "Пиковая мощность (dW)"
+    },
+    "configurationLimitBurstPowerHelp": {
+        "message": "Повышенная мощность допускается на короткое время. Пример: 10000 = 1000 Вт. Должна быть >= непрерывной."
+    },
+    "configurationLimitBurstPowerTime": {
+        "message": "Время пиковой мощности (ds)"
+    },
+    "configurationLimitBurstPowerTimeHelp": {
+        "message": "Продолжительность пиковой мощности в деци-секундах (ds). Пример: 50 = 5 секунд."
+    },
+    "configurationLimitBurstPowerFalldownTime": {
+        "message": "Время снижения мощности (ds)"
+    },
+    "configurationLimitBurstPowerFalldownTimeHelp": {
+        "message": "Время плавного снижения от пиковой до непрерывной мощности в деци-секундах (ds). Пример: 10 = 1 секунда."
+    },
     "sensorsTemperature4": {
         "message": "Температура 4, °C"
     },

--- a/locale/uk/messages.json
+++ b/locale/uk/messages.json
@@ -1235,6 +1235,63 @@
     "configurationNoBand": {
         "message": "Відсутній"
     },
+    "configurationPowerLimits": {
+        "message": "Обмеження потужності"
+    },
+    "configurationPowerLimitsHelp": {
+        "message": "Обмежте споживання струму та потужності для захисту акумулятора та регуляторів. Встановіть 0 для вимкнення. Одиниці: dA (деці-ампер) = А×10, dW (деці-ват) = Вт×10, ds (деці-секунда) = с×10."
+    },
+    "configurationPowerLimitsNote": {
+        "message": "Захищає акумулятор від перевантаження по струму, плавно зменшуючи газ. Потребує датчик струму. Задайте безперервні та пікові обмеження відповідно до специфікації акумулятора."
+    },
+    "configurationLimitContCurrent": {
+        "message": "Безперервний струм (dA)"
+    },
+    "configurationLimitContCurrentHelp": {
+        "message": "Максимальний постійний струм у деці-амперах (dA). Приклад: 500 = 50А. Встановіть 0 для вимкнення обмеження струму."
+    },
+    "configurationLimitBurstCurrent": {
+        "message": "Піковий струм (dA)"
+    },
+    "configurationLimitBurstCurrentHelp": {
+        "message": "Підвищений струм допускається на короткий час (різкі маневри, набір висоти). Приклад: 750 = 75А. Має бути >= безперервного."
+    },
+    "configurationLimitBurstCurrentTime": {
+        "message": "Час пікового струму (ds)"
+    },
+    "configurationLimitBurstCurrentTimeHelp": {
+        "message": "Тривалість пікового струму у деці-секундах (ds). Приклад: 100 = 10 секунд. Після закінчення знижується до безперервного."
+    },
+    "configurationLimitBurstCurrentFalldownTime": {
+        "message": "Час зниження струму (ds)"
+    },
+    "configurationLimitBurstCurrentFalldownTimeHelp": {
+        "message": "Час плавного зниження від пікового до безперервного обмеження у деці-секундах (ds). Приклад: 20 = 2 секунди."
+    },
+    "configurationLimitContPower": {
+        "message": "Безперервна потужність (dW)"
+    },
+    "configurationLimitContPowerHelp": {
+        "message": "Максимальна постійна потужність у деці-ватах (dW). Приклад: 8000 = 800 Вт. Встановіть 0 для вимкнення. Потребує вимірювання напруги."
+    },
+    "configurationLimitBurstPower": {
+        "message": "Пікова потужність (dW)"
+    },
+    "configurationLimitBurstPowerHelp": {
+        "message": "Підвищена потужність допускається на короткий час. Приклад: 10000 = 1000 Вт. Має бути >= безперервної."
+    },
+    "configurationLimitBurstPowerTime": {
+        "message": "Час пікової потужності (ds)"
+    },
+    "configurationLimitBurstPowerTimeHelp": {
+        "message": "Тривалість пікової потужності у деці-секундах (ds). Приклад: 50 = 5 секунд."
+    },
+    "configurationLimitBurstPowerFalldownTime": {
+        "message": "Час зниження потужності (ds)"
+    },
+    "configurationLimitBurstPowerFalldownTimeHelp": {
+        "message": "Час плавного зниження від пікової до безперервної потужності у деці-секундах (ds). Приклад: 10 = 1 секунда."
+    },
     "configurationVTXNoBandHelp": {
         "message": "Частота VTX була встановлена вручну. Вибір діапазону перезапише налаштовану частоту."
     },

--- a/locale/zh_CN/messages.json
+++ b/locale/zh_CN/messages.json
@@ -1238,6 +1238,63 @@
     "configurationNoBand": {
         "message": "None"
     },
+    "configurationPowerLimits": {
+        "message": "功率限制"
+    },
+    "configurationPowerLimitsHelp": {
+        "message": "限制电流和功率消耗以保护电池和电调。设为0禁用。单位：dA（分安培）= A×10，dW（分瓦）= W×10，ds（分秒）= s×10。"
+    },
+    "configurationPowerLimitsNote": {
+        "message": "通过平滑降低油门来保护电池免受过流。需要电流传感器。根据电池规格设置连续限制和突发限制。"
+    },
+    "configurationLimitContCurrent": {
+        "message": "持续电流限制 (dA)"
+    },
+    "configurationLimitContCurrentHelp": {
+        "message": "最大持续电流（分安培 dA）。示例：500 = 50A。设为0禁用电流限制。"
+    },
+    "configurationLimitBurstCurrent": {
+        "message": "突发电流限制 (dA)"
+    },
+    "configurationLimitBurstCurrentHelp": {
+        "message": "短时突发（急推油门、爬升）允许的更高电流。示例：750 = 75A。应大于等于持续限制值。"
+    },
+    "configurationLimitBurstCurrentTime": {
+        "message": "突发电流时间 (ds)"
+    },
+    "configurationLimitBurstCurrentTimeHelp": {
+        "message": "允许突发电流的持续时间（分秒 ds）。示例：100 = 10秒。超时后限制降回持续值。"
+    },
+    "configurationLimitBurstCurrentFalldownTime": {
+        "message": "突发电流降落时间 (ds)"
+    },
+    "configurationLimitBurstCurrentFalldownTimeHelp": {
+        "message": "从突发限制平滑过渡到持续限制的时间（分秒 ds）。示例：20 = 2秒。"
+    },
+    "configurationLimitContPower": {
+        "message": "持续功率限制 (dW)"
+    },
+    "configurationLimitContPowerHelp": {
+        "message": "最大持续功率（分瓦 dW）。示例：8000 = 800W。设为0禁用功率限制。需要电压测量。"
+    },
+    "configurationLimitBurstPower": {
+        "message": "突发功率限制 (dW)"
+    },
+    "configurationLimitBurstPowerHelp": {
+        "message": "短时突发允许的更高功率。示例：10000 = 1000W。应大于等于持续限制值。"
+    },
+    "configurationLimitBurstPowerTime": {
+        "message": "突发功率时间 (ds)"
+    },
+    "configurationLimitBurstPowerTimeHelp": {
+        "message": "允许突发功率的持续时间（分秒 ds）。示例：50 = 5秒。"
+    },
+    "configurationLimitBurstPowerFalldownTime": {
+        "message": "突发功率降落时间 (ds)"
+    },
+    "configurationLimitBurstPowerFalldownTimeHelp": {
+        "message": "从突发限制平滑过渡到持续功率限制的时间（分秒 ds）。示例：10 = 1秒。"
+    },
     "configurationVTXNoBandHelp": {
         "message": "已手动设置VTX频率。选择一个频段将覆盖当前配置的频率。"
     },

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -211,28 +211,28 @@
 
                     <!-- Current Limits -->
                     <div class="number">
-                        <input type="number" class="batteryProfileHighlight" id="limit_cont_current" name="limit_cont_current" step="1" min="0" max="2000" data-setting-placeholder="limit_cont_current" />
+                        <input type="number" class="batteryProfileHighlight" id="limit_cont_current" name="limit_cont_current" step="1" min="0" max="2000" data-setting="limit_cont_current" />
                         <label for="limit_cont_current">
                             <span data-i18n="configurationLimitContCurrent"></span>
                         </label>
                         <div for="limit_cont_current" class="helpicon cf_tip" data-i18n_title="configurationLimitContCurrentHelp"></div>
                     </div>
                     <div class="number">
-                        <input type="number" class="batteryProfileHighlight" id="limit_burst_current" name="limit_burst_current" step="1" min="0" max="2000" data-setting-placeholder="limit_burst_current" />
+                        <input type="number" class="batteryProfileHighlight" id="limit_burst_current" name="limit_burst_current" step="1" min="0" max="2000" data-setting="limit_burst_current" />
                         <label for="limit_burst_current">
                             <span data-i18n="configurationLimitBurstCurrent"></span>
                         </label>
                         <div for="limit_burst_current" class="helpicon cf_tip" data-i18n_title="configurationLimitBurstCurrentHelp"></div>
                     </div>
                     <div class="number">
-                        <input type="number" class="batteryProfileHighlight" id="limit_burst_current_time" name="limit_burst_current_time" step="1" min="0" max="600" data-setting-placeholder="limit_burst_current_time" />
+                        <input type="number" class="batteryProfileHighlight" id="limit_burst_current_time" name="limit_burst_current_time" step="1" min="0" max="600" data-setting="limit_burst_current_time" />
                         <label for="limit_burst_current_time">
                             <span data-i18n="configurationLimitBurstCurrentTime"></span>
                         </label>
                         <div for="limit_burst_current_time" class="helpicon cf_tip" data-i18n_title="configurationLimitBurstCurrentTimeHelp"></div>
                     </div>
                     <div class="number">
-                        <input type="number" class="batteryProfileHighlight" id="limit_burst_current_falldown_time" name="limit_burst_current_falldown_time" step="1" min="0" max="600" data-setting-placeholder="limit_burst_current_falldown_time" />
+                        <input type="number" class="batteryProfileHighlight" id="limit_burst_current_falldown_time" name="limit_burst_current_falldown_time" step="1" min="0" max="600" data-setting="limit_burst_current_falldown_time" />
                         <label for="limit_burst_current_falldown_time">
                             <span data-i18n="configurationLimitBurstCurrentFalldownTime"></span>
                         </label>
@@ -241,28 +241,28 @@
 
                     <!-- Power Limits -->
                     <div class="number">
-                        <input type="number" class="batteryProfileHighlight" id="limit_cont_power" name="limit_cont_power" step="1" min="0" max="20000" data-setting-placeholder="limit_cont_power" />
+                        <input type="number" class="batteryProfileHighlight" id="limit_cont_power" name="limit_cont_power" step="1" min="0" max="20000" data-setting="limit_cont_power" />
                         <label for="limit_cont_power">
                             <span data-i18n="configurationLimitContPower"></span>
                         </label>
                         <div for="limit_cont_power" class="helpicon cf_tip" data-i18n_title="configurationLimitContPowerHelp"></div>
                     </div>
                     <div class="number">
-                        <input type="number" class="batteryProfileHighlight" id="limit_burst_power" name="limit_burst_power" step="1" min="0" max="20000" data-setting-placeholder="limit_burst_power" />
+                        <input type="number" class="batteryProfileHighlight" id="limit_burst_power" name="limit_burst_power" step="1" min="0" max="20000" data-setting="limit_burst_power" />
                         <label for="limit_burst_power">
                             <span data-i18n="configurationLimitBurstPower"></span>
                         </label>
                         <div for="limit_burst_power" class="helpicon cf_tip" data-i18n_title="configurationLimitBurstPowerHelp"></div>
                     </div>
                     <div class="number">
-                        <input type="number" class="batteryProfileHighlight" id="limit_burst_power_time" name="limit_burst_power_time" step="1" min="0" max="600" data-setting-placeholder="limit_burst_power_time" />
+                        <input type="number" class="batteryProfileHighlight" id="limit_burst_power_time" name="limit_burst_power_time" step="1" min="0" max="600" data-setting="limit_burst_power_time" />
                         <label for="limit_burst_power_time">
                             <span data-i18n="configurationLimitBurstPowerTime"></span>
                         </label>
                         <div for="limit_burst_power_time" class="helpicon cf_tip" data-i18n_title="configurationLimitBurstPowerTimeHelp"></div>
                     </div>
                     <div class="number">
-                        <input type="number" class="batteryProfileHighlight" id="limit_burst_power_falldown_time" name="limit_burst_power_falldown_time" step="1" min="0" max="600" data-setting-placeholder="limit_burst_power_falldown_time" />
+                        <input type="number" class="batteryProfileHighlight" id="limit_burst_power_falldown_time" name="limit_burst_power_falldown_time" step="1" min="0" max="600" data-setting="limit_burst_power_falldown_time" />
                         <label for="limit_burst_power_falldown_time">
                             <span data-i18n="configurationLimitBurstPowerFalldownTime"></span>
                         </label>

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -197,6 +197,80 @@
                 </div>
             </div>
 
+            <div class="config-section gui_box grey">
+                <div class="gui_box_titlebar">
+                    <div class="spacer_box_title" data-i18n="configurationPowerLimits"></div>
+                    <div class="helpicon cf_tip" data-i18n_title="configurationPowerLimitsHelp"></div>
+                </div>
+                <div class="spacer_box">
+                    <div class="note">
+                        <div class="note_spacer">
+                            <p data-i18n="configurationPowerLimitsNote"></p>
+                        </div>
+                    </div>
+
+                    <!-- Current Limits -->
+                    <div class="number">
+                        <input type="number" class="batteryProfileHighlight" id="limit_cont_current" name="limit_cont_current" step="1" min="0" max="2000" data-setting-placeholder="limit_cont_current" />
+                        <label for="limit_cont_current">
+                            <span data-i18n="configurationLimitContCurrent"></span>
+                        </label>
+                        <div for="limit_cont_current" class="helpicon cf_tip" data-i18n_title="configurationLimitContCurrentHelp"></div>
+                    </div>
+                    <div class="number">
+                        <input type="number" class="batteryProfileHighlight" id="limit_burst_current" name="limit_burst_current" step="1" min="0" max="2000" data-setting-placeholder="limit_burst_current" />
+                        <label for="limit_burst_current">
+                            <span data-i18n="configurationLimitBurstCurrent"></span>
+                        </label>
+                        <div for="limit_burst_current" class="helpicon cf_tip" data-i18n_title="configurationLimitBurstCurrentHelp"></div>
+                    </div>
+                    <div class="number">
+                        <input type="number" class="batteryProfileHighlight" id="limit_burst_current_time" name="limit_burst_current_time" step="1" min="0" max="600" data-setting-placeholder="limit_burst_current_time" />
+                        <label for="limit_burst_current_time">
+                            <span data-i18n="configurationLimitBurstCurrentTime"></span>
+                        </label>
+                        <div for="limit_burst_current_time" class="helpicon cf_tip" data-i18n_title="configurationLimitBurstCurrentTimeHelp"></div>
+                    </div>
+                    <div class="number">
+                        <input type="number" class="batteryProfileHighlight" id="limit_burst_current_falldown_time" name="limit_burst_current_falldown_time" step="1" min="0" max="600" data-setting-placeholder="limit_burst_current_falldown_time" />
+                        <label for="limit_burst_current_falldown_time">
+                            <span data-i18n="configurationLimitBurstCurrentFalldownTime"></span>
+                        </label>
+                        <div for="limit_burst_current_falldown_time" class="helpicon cf_tip" data-i18n_title="configurationLimitBurstCurrentFalldownTimeHelp"></div>
+                    </div>
+
+                    <!-- Power Limits -->
+                    <div class="number">
+                        <input type="number" class="batteryProfileHighlight" id="limit_cont_power" name="limit_cont_power" step="1" min="0" max="20000" data-setting-placeholder="limit_cont_power" />
+                        <label for="limit_cont_power">
+                            <span data-i18n="configurationLimitContPower"></span>
+                        </label>
+                        <div for="limit_cont_power" class="helpicon cf_tip" data-i18n_title="configurationLimitContPowerHelp"></div>
+                    </div>
+                    <div class="number">
+                        <input type="number" class="batteryProfileHighlight" id="limit_burst_power" name="limit_burst_power" step="1" min="0" max="20000" data-setting-placeholder="limit_burst_power" />
+                        <label for="limit_burst_power">
+                            <span data-i18n="configurationLimitBurstPower"></span>
+                        </label>
+                        <div for="limit_burst_power" class="helpicon cf_tip" data-i18n_title="configurationLimitBurstPowerHelp"></div>
+                    </div>
+                    <div class="number">
+                        <input type="number" class="batteryProfileHighlight" id="limit_burst_power_time" name="limit_burst_power_time" step="1" min="0" max="600" data-setting-placeholder="limit_burst_power_time" />
+                        <label for="limit_burst_power_time">
+                            <span data-i18n="configurationLimitBurstPowerTime"></span>
+                        </label>
+                        <div for="limit_burst_power_time" class="helpicon cf_tip" data-i18n_title="configurationLimitBurstPowerTimeHelp"></div>
+                    </div>
+                    <div class="number">
+                        <input type="number" class="batteryProfileHighlight" id="limit_burst_power_falldown_time" name="limit_burst_power_falldown_time" step="1" min="0" max="600" data-setting-placeholder="limit_burst_power_falldown_time" />
+                        <label for="limit_burst_power_falldown_time">
+                            <span data-i18n="configurationLimitBurstPowerFalldownTime"></span>
+                        </label>
+                        <div for="limit_burst_power_falldown_time" class="helpicon cf_tip" data-i18n_title="configurationLimitBurstPowerFalldownTimeHelp"></div>
+                    </div>
+                </div>
+            </div>
+
             <div class="config-section gui_box grey config-vtx">
                 <div class="gui_box_titlebar">
                     <div class="spacer_box_title" data-i18n="configurationVTX"></div>


### PR DESCRIPTION
### **User description**
## Summary

Adds user interface for configuring power and current limiting settings in the Configuration tab. These firmware settings have existed since INAV 3.0.0 but were never exposed in the Configurator GUI, requiring users to use CLI commands.

## Problem

Power limiting is a valuable battery protection feature that:
- Has been in INAV firmware since version 3.0.0 (PR iNavFlight/inav#6929)
- Is fully functional and tested
- Has no GUI configuration interface
- Requires users to know and use CLI commands
- Remains largely unknown despite being very useful

## Changes

### Added to `tabs/configuration.html`:
- New "Power Limiting" section in Configuration tab
- 8 input fields for power limit configuration:
  - **Current Limits**: `limit_cont_current`, `limit_burst_current`, `limit_burst_current_time`, `limit_burst_current_falldown_time`
  - **Power Limits**: `limit_cont_power`, `limit_burst_power`, `limit_burst_power_time`, `limit_burst_power_falldown_time`
- Info note explaining feature requirements
- Help tooltips for each setting

### Added to `locale/en/messages.json`:
- 14 new i18n strings for labels and help text
- Clear explanations of units (dA = deci-amps, dW = deci-watts, ds = deci-seconds)
- Practical examples in tooltips (e.g., "500 = 50A")

## Benefits

- Users can configure battery protection without CLI
- Feature becomes discoverable in the GUI
- Different limits can be set per battery profile
- Reduces support burden (no more CLI confusion)
- Makes existing feature actually usable for most users

## Testing

Tested with INAV Configurator:
- [x] UI elements display correctly in Configuration tab
- [x] Settings load from firmware correctly  
- [x] Settings save to firmware correctly
- [x] Help tooltips display properly
- [x] Battery profile switching updates values
- [x] Units and ranges are correct

## Screenshots

_(Tested live on ORBITF435_SD / INAV 9.0.1 — all 8 fields load, save, and update correctly per battery profile)_

## Related

- INAV firmware PR iNavFlight/inav#11187 (adds documentation for these settings)
- Original implementation: iNavFlight/inav#6929

___

### **Description**
This description is generated by an AI tool. It may have inaccuracies


- Adds Power Limiting UI configuration section to the Configuration tab, exposing firmware settings that have existed since INAV 3.0.0 but were previously only accessible via CLI

- Implements 8 new input fields for configuring current and power limiting parameters:
  - Current limits: `limit_cont_current`, `limit_burst_current`, `limit_burst_current_time`, `limit_burst_current_falldown_time`
  - Power limits: `limit_cont_power`, `limit_burst_power`, `limit_burst_power_time`, `limit_burst_power_falldown_time`

- Adds 14 new internationalization strings to `locale/en/messages.json` with clear unit explanations and practical examples

- Integrates with battery profile system using `batteryProfileHighlight` class for per-profile configuration

- Follows existing configurator patterns with automatic firmware synchronization via `data-setting-placeholder`

- Improves feature discoverability and usability by providing GUI access instead of requiring CLI commands

- Includes help tooltips for each setting to guide users on proper configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Firmware Settings<br/>Power Limiting Parameters"] -->|"Exposed via GUI"| B["Configuration Tab<br/>Power Limiting Section"]
  B -->|"8 Input Fields"| C["Current & Power<br/>Limit Controls"]
  B -->|"i18n Strings"| D["Localized Labels<br/>& Help Text"]
  C -->|"Per Battery Profile"| E["Battery Profile<br/>Configuration"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tbody></table>

</details>

___