### PR TITLE
Fix async settings loading race condition in Configuration and Receiver tabs

### DIFF
--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -266,6 +266,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         // Wait for settings to load before triggering change event
         settingsPromise.then(function() {
             $i2cSpeed.trigger('change');
+        }).catch(function(error) {
+            console.error('Settings load failed, I2C speed change not triggered:', error);
         });
 
         $('a.save').on('click', function () {

--- a/tabs/receiver.js
+++ b/tabs/receiver.js
@@ -92,8 +92,8 @@ TABS.receiver.initialize = function (callback) {
         });
 
         // Wait for settings to load before triggering change events
+        // Trigger receiverMode which will trigger serialRxProvider when mode is SERIAL
         settingsPromise.then(function() {
-            $serialRxProvider.trigger("change");
             $receiverMode.trigger("change");
         });
 


### PR DESCRIPTION
### **User description**
## Summary

Fixes a bug where change event handlers were triggered before settings had finished loading asynchronously, causing incorrect UI state in Configuration and Receiver tabs.

## Root Cause

A recent PR changed `Settings.processHtml()` to load settings asynchronously via `configureInputs()`. While the function calls the callback immediately (to avoid blocking UI rendering), it now passes a `settingsPromise` parameter. Tabs must wait for this promise to resolve before triggering change events that depend on `data-setting` values being populated.

Without awaiting the promise, trigger calls execute before the async `configureInputs()` populates the select element values, causing handlers to read stale/default values instead of the saved settings.

## Bug Symptoms

**Configuration Tab (I2C Speed):**
- Warning "This I2C speed is too low!" appeared even when I2C speed was already set to maximum (800KHZ)
- Warning disappeared if user manually changed the value
- Only affected initial page load

**Receiver Tab (Serial RX):**
- FrSky options visibility based on receiver type could be incorrect on initial load
- Worked correctly after user changed receiver settings

## Changes

### tabs/configuration.js
- Added `settingsPromise` parameter to `process_html()` function
- Wrapped `$i2cSpeed.trigger('change')` in `settingsPromise.then()` callback
- Ensures I2C speed validation only runs after settings are loaded

### tabs/receiver.js  
- Added `settingsPromise` parameter to `process_html()` function
- Wrapped `$serialRxProvider.trigger("change")` and `$receiverMode.trigger("change")` in `settingsPromise.then()` callback
- Ensures FrSky options visibility updates correctly based on loaded settings

## Testing

**Configuration Tab - I2C Speed:**
- ✅ 800KHZ: No warning displayed (correct)
- ✅ 400KHZ: Blue info message suggesting 800KHZ (correct)
- ✅ 100KHZ/200KHZ: Red warning about speed too low (correct)
- ✅ No console errors

**Receiver Tab:**
- ✅ SERIAL/CRSF: Loads correctly
- ✅ Changed to SBUS: FrSky Options section appears dynamically (correct)
- ✅ No console errors

**Other Tabs Verified:**
Checked all tabs using `Settings.processHtml()` for similar issues:
- failsafe.js, gps.js, mixer.js, outputs.js, pid_tuning.js: No issues found
- Their trigger calls operate on elements loaded via MSP/FC objects, not Settings.configureInputs()

## Files Changed

- `tabs/configuration.js` - Added async handling for I2C speed validation
- `tabs/receiver.js` - Added async handling for receiver mode and serial RX provider

## Related

This fix adapts to the async settings loading pattern introduced in the recent settings.js refactor.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes race condition where change handlers triggered before async settings loaded

- Wraps I2C speed validation trigger in settingsPromise callback

- Wraps receiver mode and serial RX provider triggers in settingsPromise callback

- Ensures UI state reflects loaded settings instead of stale defaults


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Settings.processHtml called"] --> B["settingsPromise returned"]
  B --> C["configureInputs loads async"]
  C --> D["settingsPromise resolves"]
  D --> E["Change event handlers triggered"]
  E --> F["UI reflects loaded settings"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.js</strong><dd><code>Add async settings handling for I2C speed validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tabs/configuration.js

<ul><li>Added <code>settingsPromise</code> parameter to <code>process_html()</code> function<br> <li> Wrapped <code>$i2cSpeed.trigger('change')</code> in <code>settingsPromise.then()</code> callback<br> <li> Ensures I2C speed validation runs only after settings are fully loaded<br> <li> Fixes incorrect warning display when I2C speed is already at maximum</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2485/files#diff-4813c1d4def74e3981369f51a598b3d492e7658f1f86c709393697a097441c9b">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>receiver.js</strong><dd><code>Add async settings handling for receiver mode triggers</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tabs/receiver.js

<ul><li>Added <code>settingsPromise</code> parameter to <code>process_html()</code> function<br> <li> Wrapped <code>$serialRxProvider.trigger("change")</code> and <br><code>$receiverMode.trigger("change")</code> in <code>settingsPromise.then()</code> callback<br> <li> Ensures FrSky options visibility updates correctly based on loaded <br>receiver settings<br> <li> Fixes incorrect UI state on initial page load for receiver <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2485/files#diff-8fe836f5d8dae3b813ec8e912d4c101899ba3b5da77b25bd274ef8b762984eb6">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

