### PR TITLE
Fix SITL binary path resolution for dev and packaged modes

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -9,6 +9,39 @@ export default {
     executableName: "inav-configurator",
     asar: false,
     icon: 'images/inav',
+    extraResource: [
+      'resources/public/sitl'
+    ],
+    afterCopy: [
+      (buildPath, electronVersion, platform, arch, callback) => {
+        // Remove SITL binaries for other platforms/architectures to reduce package size
+        const sitlPath = path.join(buildPath, 'resources', 'sitl');
+        if (platform === 'win32') {
+          fs.rmSync(path.join(sitlPath, 'linux'), { recursive: true, force: true });
+          fs.rmSync(path.join(sitlPath, 'macos'), { recursive: true, force: true });
+        } else if (platform === 'darwin') {
+          fs.rmSync(path.join(sitlPath, 'linux'), { recursive: true, force: true });
+          fs.rmSync(path.join(sitlPath, 'windows'), { recursive: true, force: true });
+        } else if (platform === 'linux') {
+          fs.rmSync(path.join(sitlPath, 'macos'), { recursive: true, force: true });
+          fs.rmSync(path.join(sitlPath, 'windows'), { recursive: true, force: true });
+          // Remove wrong architecture
+          if (arch === 'x64') {
+            fs.rmSync(path.join(sitlPath, 'linux', 'arm64'), { recursive: true, force: true });
+          } else if (arch === 'arm64') {
+            // Move arm64 binary to linux root and remove x64
+            const arm64Binary = path.join(sitlPath, 'linux', 'arm64', 'inav_SITL');
+            const destBinary = path.join(sitlPath, 'linux', 'inav_SITL');
+            if (fs.existsSync(arm64Binary)) {
+              fs.rmSync(destBinary, { force: true });
+              fs.renameSync(arm64Binary, destBinary);
+              fs.rmSync(path.join(sitlPath, 'linux', 'arm64'), { recursive: true, force: true });
+            }
+          }
+        }
+        callback();
+      }
+    ],
   },
   rebuildConfig: {},
   plugins: [

--- a/js/main/main.js
+++ b/js/main/main.js
@@ -14,6 +14,19 @@ import child_process from './child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Returns the base path for SITL binaries.
+ * - In packaged mode: uses Electron's resourcesPath (where extraResource files are placed)
+ * - In dev mode: uses the source location in resources/public/sitl
+ */
+function getSitlBasePath() {
+  if (app.isPackaged) {
+    return path.join(process.resourcesPath, 'sitl');
+  } else {
+    return path.join(app.getAppPath(), 'resources', 'public', 'sitl');
+  }
+}
+
 const usbBootloaderIds =  [
   { vendorId: 1155, productId: 57105}, 
   { vendorId: 11836, productId: 57105}
@@ -350,7 +363,7 @@ app.whenReady().then(() => {
 
   ipcMain.handle('chmod', (_event, pathName, mode) => {
     return new Promise(resolve => {
-      chmod(path.join(__dirname, 'sitl', pathName), mode, error => {
+      chmod(path.join(getSitlBasePath(), pathName), mode, error => {
         if (error) {
           resolve(error.message)
         } else {
@@ -373,7 +386,7 @@ app.whenReady().then(() => {
   });
 
   ipcMain.on('startChildProcess', (_event, command, args, opts) => {
-    child_process.start(path.join(__dirname, 'sitl', command), args, opts, mainWindow);
+    child_process.start(path.join(getSitlBasePath(), command), args, opts, mainWindow);
   });
 
   ipcMain.on('killChildProcess', (_event) => {


### PR DESCRIPTION
### **User description**
## Summary
Fixes SITL feature which was broken because the code looked for binaries in the wrong location.

## Problem
The SITL path used `__dirname` which points to the Vite build output (`.vite/build/`), but SITL binaries are located in `resources/public/sitl/`. This meant SITL couldn't find its executables in either dev mode or packaged builds.

## Changes
- Add `getSitlBasePath()` function that returns the correct path based on whether the app is packaged (`process.resourcesPath`) or in dev mode (`app.getAppPath()/resources/public/sitl`)
- Add `extraResource` in forge.config.js to include SITL binaries in packaged builds
- Add `afterCopy` hook to remove binaries for other platforms/architectures, reducing package size

## Testing
- Verified path resolution logic for both packaged and dev scenarios
- The `afterCopy` hook correctly handles all platform/arch combinations including Linux arm64

## Related
Alternative implementation to #2492


___

### **PR Type**
Bug fix


___

### **Description**
- Fix SITL binary path resolution for dev and packaged modes

- Add getSitlBasePath() function for correct path detection

- Include SITL binaries in packaged builds via extraResource

- Remove platform-specific binaries in afterCopy hook to reduce package size


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SITL Binary Location"] --> B{"App Packaged?"}
  B -->|Yes| C["process.resourcesPath/sitl"]
  B -->|No| D["app.getAppPath/resources/public/sitl"]
  C --> E["getSitlBasePath Function"]
  D --> E
  E --> F["chmod & startChildProcess"]
  G["forge.config.js"] --> H["extraResource adds SITL to package"]
  H --> I["afterCopy removes unused platform binaries"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>forge.config.js</strong><dd><code>Configure SITL binary inclusion and platform filtering</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forge.config.js

<ul><li>Add <code>extraResource</code> configuration to include <code>resources/public/sitl</code> in <br>packaged builds<br> <li> Add <code>afterCopy</code> hook that removes SITL binaries for non-target platforms <br>and architectures<br> <li> Handle Linux arm64 architecture by moving binary to correct location <br>and removing x64 variant</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2496/files#diff-0afe94b5ad1971b035d2d538a77509ebe4f7ecd7a16313e3ac63025dfd865f8b">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.js</strong><dd><code>Implement dynamic SITL path resolution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/main/main.js

<ul><li>Add <code>getSitlBasePath()</code> function that returns correct path based on <br>packaged vs dev mode<br> <li> Replace hardcoded <code>__dirname/sitl</code> paths with <code>getSitlBasePath()</code> calls in <br>chmod and startChildProcess handlers<br> <li> Function uses <code>process.resourcesPath</code> for packaged builds and <br><code>app.getAppPath()/resources/public/sitl</code> for dev mode</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2496/files#diff-34ac9400ad8aa4c5573db2b1e27555eb25fce827f5ed8a86907ff1a492f76636">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

