### PR TITLE
Fix SITL binary path resolution for dev and packaged modes

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -9,6 +9,9 @@ export default {
     executableName: "inav-configurator",
     asar: false,
     icon: 'images/inav',
+    extraResource: [
+      'resources/public/sitl'
+    ],
   },
   rebuildConfig: {},
   plugins: [
@@ -43,6 +46,37 @@ export default {
     },
   ],
   hooks: {
+    // Remove SITL binaries for other platforms/architectures to reduce package size
+    postPackage: async (forgeConfig, options) => {
+      for (const outputPath of options.outputPaths) {
+        const sitlPath = path.join(outputPath, 'resources', 'sitl');
+        if (!fs.existsSync(sitlPath)) continue;
+
+        if (options.platform === 'win32') {
+          fs.rmSync(path.join(sitlPath, 'linux'), { recursive: true, force: true });
+          fs.rmSync(path.join(sitlPath, 'macos'), { recursive: true, force: true });
+        } else if (options.platform === 'darwin') {
+          fs.rmSync(path.join(sitlPath, 'linux'), { recursive: true, force: true });
+          fs.rmSync(path.join(sitlPath, 'windows'), { recursive: true, force: true });
+        } else if (options.platform === 'linux') {
+          fs.rmSync(path.join(sitlPath, 'macos'), { recursive: true, force: true });
+          fs.rmSync(path.join(sitlPath, 'windows'), { recursive: true, force: true });
+          // Remove wrong architecture
+          if (options.arch === 'x64') {
+            fs.rmSync(path.join(sitlPath, 'linux', 'arm64'), { recursive: true, force: true });
+          } else if (options.arch === 'arm64') {
+            // Move arm64 binary to linux root and remove x64
+            const arm64Binary = path.join(sitlPath, 'linux', 'arm64', 'inav_SITL');
+            const destBinary = path.join(sitlPath, 'linux', 'inav_SITL');
+            if (fs.existsSync(arm64Binary)) {
+              fs.rmSync(destBinary, { force: true });
+              fs.renameSync(arm64Binary, destBinary);
+              fs.rmSync(path.join(sitlPath, 'linux', 'arm64'), { recursive: true, force: true });
+            }
+          }
+        }
+      }
+    },
     // Uniform artifact file names
     postMake: async (config, makeResults) => {
       makeResults.forEach(result => {

--- a/js/main/main.js
+++ b/js/main/main.js
@@ -14,6 +14,19 @@ import child_process from './child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Returns the base path for SITL binaries.
+ * - In packaged mode: uses Electron's resourcesPath (where extraResource files are placed)
+ * - In dev mode: uses the source location in resources/public/sitl
+ */
+function getSitlBasePath() {
+  if (app.isPackaged) {
+    return path.join(process.resourcesPath, 'sitl');
+  } else {
+    return path.join(app.getAppPath(), 'resources', 'public', 'sitl');
+  }
+}
+
 const usbBootloaderIds =  [
   { vendorId: 1155, productId: 57105}, 
   { vendorId: 11836, productId: 57105}
@@ -350,7 +363,7 @@ app.whenReady().then(() => {
 
   ipcMain.handle('chmod', (_event, pathName, mode) => {
     return new Promise(resolve => {
-      chmod(path.join(__dirname, 'sitl', pathName), mode, error => {
+      chmod(path.join(getSitlBasePath(), pathName), mode, error => {
         if (error) {
           resolve(error.message)
         } else {
@@ -373,7 +386,7 @@ app.whenReady().then(() => {
   });
 
   ipcMain.on('startChildProcess', (_event, command, args, opts) => {
-    child_process.start(path.join(__dirname, 'sitl', command), args, opts, mainWindow);
+    child_process.start(path.join(getSitlBasePath(), command), args, opts, mainWindow);
   });
 
   ipcMain.on('killChildProcess', (_event) => {


### PR DESCRIPTION
Fixes SITL feature which was broken because the code looked for binaries in the wrong location.

Problem
The SITL path used __dirname which points to the Vite build output (.vite/build/), but SITL binaries are located in resources/public/sitl/. This meant SITL couldn't find its executables in either dev mode or packaged builds.

Changes
Add getSitlBasePath() function that returns the correct path based on whether the app is packaged (process.resourcesPath) or in dev mode (app.getAppPath()/resources/public/sitl)
Add extraResource in forge.config.js to include SITL binaries in packaged builds