### PR TITLE
Fix decompiler to output whenChanged() instead of delta()

### DIFF
--- a/js/transpiler/transpiler/condition_decompiler.js
+++ b/js/transpiler/transpiler/condition_decompiler.js
@@ -11,6 +11,7 @@
 
 import {
   OPERATION,
+  OPERAND_TYPE,
   getOperationName
 } from './inav_constants.js';
 
@@ -57,9 +58,6 @@ class ConditionDecompiler {
   constructor(context) {
     this.decompileOperand = context.decompileOperand;
     this.addWarning = context.addWarning;
-
-    // Operation constants for structural pattern matching
-    this.OPERAND_TYPE_LC = 4;  // OPERAND_TYPE.LC
   }
 
   /**
@@ -150,7 +148,7 @@ class ConditionDecompiler {
    */
   handleNot(lc, allConditions, visited) {
     // If operandA is an LC reference, we can inspect the referenced LC directly
-    if (lc.operandAType === this.OPERAND_TYPE_LC && allConditions) {
+    if (lc.operandAType === OPERAND_TYPE.LC && allConditions) {
       const innerLcIndex = lc.operandAValue;
       const innerLC = allConditions.find(c => c.index === innerLcIndex);
 

--- a/js/transpiler/transpiler/decompiler.js
+++ b/js/transpiler/transpiler/decompiler.js
@@ -854,7 +854,7 @@ class Decompiler {
         lines.push(indentStr + '});');
       },
       'whenChanged': () => {
-        lines.push(indentStr + `delta(${pattern.value}, ${pattern.threshold}, () => {`);
+        lines.push(indentStr + `whenChanged(${pattern.value}, ${pattern.threshold}, () => {`);
         if (body) lines.push(body);
         lines.push(indentStr + '});');
       }


### PR DESCRIPTION
## Summary

Fixes the JavaScript programming decompiler to output `whenChanged()` instead of `delta()`.

## Changes

- **decompiler.js**: The `whenChanged` pattern now renders as `whenChanged()` to match the API
- **condition_decompiler.js**: Import `OPERAND_TYPE` from constants instead of hardcoding the value

## Why

The API defines `whenChanged(value, threshold, callback)` as the user-facing function, but the decompiler was outputting `delta()`. This caused round-trip inconsistency - code compiled with `whenChanged()` would decompile to `delta()`.