### PR TITLE
Remember last save directory across file operations

### DIFF
--- a/js/dialog.js
+++ b/js/dialog.js
@@ -1,35 +1,9 @@
-const LAST_SAVE_DIRECTORY_KEY = 'lastSaveDirectory';
-
 const dialog =  {
     showOpenDialog: async function (options) {
         return window.electronAPI.showOpenDialog(options);
     },
     showSaveDialog: async function (options) {
-        const opts = options || {};
-
-        // Get the last save directory from storage
-        const lastDirectory = window.electronAPI.storeGet(LAST_SAVE_DIRECTORY_KEY, null);
-
-        // If we have a last directory and no defaultPath is specified, use it
-        if (lastDirectory && !opts.defaultPath) {
-            opts.defaultPath = lastDirectory;
-        }
-
-        // Show the save dialog
-        const result = await window.electronAPI.showSaveDialog(opts);
-
-        // If user selected a file (didn't cancel), save the directory for next time
-        if (result && result.filePath) {
-            // Extract directory from the full file path
-            // Get parent directory by removing the filename
-            const lastSlash = Math.max(result.filePath.lastIndexOf('/'), result.filePath.lastIndexOf('\\'));
-            if (lastSlash !== -1) {
-                const directory = result.filePath.substring(0, lastSlash);
-                window.electronAPI.storeSet(LAST_SAVE_DIRECTORY_KEY, directory);
-            }
-        }
-
-        return result;
+        return window.electronAPI.showSaveDialog(options);
     },
     alert: function (message) {
         return window.electronAPI.alertDialog(message);

--- a/js/dialog.js
+++ b/js/dialog.js
@@ -1,9 +1,35 @@
+const LAST_SAVE_DIRECTORY_KEY = 'lastSaveDirectory';
+
 const dialog =  {
     showOpenDialog: async function (options) {
         return window.electronAPI.showOpenDialog(options);
     },
     showSaveDialog: async function (options) {
-        return window.electronAPI.showSaveDialog(options);
+        const opts = options || {};
+
+        // Get the last save directory from storage
+        const lastDirectory = window.electronAPI.storeGet(LAST_SAVE_DIRECTORY_KEY, null);
+
+        // If we have a last directory and no defaultPath is specified, use it
+        if (lastDirectory && !opts.defaultPath) {
+            opts.defaultPath = lastDirectory;
+        }
+
+        // Show the save dialog
+        const result = await window.electronAPI.showSaveDialog(opts);
+
+        // If user selected a file (didn't cancel), save the directory for next time
+        if (result && result.filePath) {
+            // Extract directory from the full file path
+            // Get parent directory by removing the filename
+            const lastSlash = Math.max(result.filePath.lastIndexOf('/'), result.filePath.lastIndexOf('\\'));
+            if (lastSlash !== -1) {
+                const directory = result.filePath.substring(0, lastSlash);
+                window.electronAPI.storeSet(LAST_SAVE_DIRECTORY_KEY, directory);
+            }
+        }
+
+        return result;
     },
     alert: function (message) {
         return window.electronAPI.alertDialog(message);


### PR DESCRIPTION
## Summary

Implement persistent "last save directory" feature that remembers the directory used in file save dialogs and automatically defaults to it in future save operations.

## Problem

Currently, save dialogs always default to some system directory (Documents, Downloads, etc.). Users must navigate to their preferred location every single time they save a file - whether it's blackbox logs, diffs, configurations, or other exports. This is particularly frustrating when saving multiple files in a session.

## Solution

Modified `showSaveDialog()` wrapper to:
1. Retrieve the last saved directory from electron-store
2. Set it as `defaultPath` for the save dialog (if no path was explicitly provided)
3. After successful save, extract the directory from the returned filepath
4. Store it for next time

## Changes

**File Modified:** `js/dialog.js`

- Added `LAST_SAVE_DIRECTORY_KEY` constant for storage key
- Enhanced `showSaveDialog()` to get/set last directory
- Cross-platform path handling (supports both `/` and `\` separators)
- Uses existing `electronAPI.storeGet/storeSet` infrastructure

## Benefits

- **Reduces friction:** Users don't have to navigate to the same directory repeatedly
- **Persists across sessions:** Works even after app restart
- **Universal:** Applies to ALL save operations automatically (blackbox, diffs, configs, etc.)
- **Transparent:** No UI changes - just works
- **Backwards compatible:** Gracefully handles first use (no saved directory yet)
- **Non-intrusive:** Doesn't override explicitly provided defaultPath

## Testing

- Tested save dialog flow
- Verified directory extraction logic
- Checked storage persistence
- Windows path handling should be tested

## Use Cases

This improves UX for common workflows:
- Saving multiple blackbox logs to analysis directory
- Exporting configuration diffs to backup location
- Saving CLI dumps to troubleshooting folder