### PR TITLE
Add TPA rate defaults to fixed-wing presets

### DIFF
--- a/js/defaults_dialog_entries.js
+++ b/js/defaults_dialog_entries.js
@@ -574,6 +574,13 @@ var defaultsDialogData = [
                 key: "nav_fw_launch_climb_angle",
                 value: 25
             },
+            /*
+             * TPA
+             */
+            {
+                key: "tpa_rate",
+                value: 80
+            },
         ],
     },
     {
@@ -779,6 +786,13 @@ var defaultsDialogData = [
             {
                 key: "nav_fw_launch_climb_angle",
                 value: 25
+            },
+            /*
+             * TPA
+             */
+            {
+                key: "tpa_rate",
+                value: 80
             },
         ],
     },


### PR DESCRIPTION
### **User description**
## Summary

Adds `tpa_rate = 80` to the fixed-wing presets in the configurator defaults dialog, addressing feedback that airplanes benefit from higher TPA values than the firmware default.

## Changes

- Added `tpa_rate: 80` to "Airplane with a Tail" preset
- Added `tpa_rate: 80` to "Airplane without a Tail (Wing, Delta, etc)" preset
- Multicopter presets retain their existing `tpa_rate = 20` setting

## Context

This addresses feedback from PR iNavFlight/inav#11222 which noted that fixed-wing aircraft work better with higher TPA values. The firmware default is 0, which is suboptimal for airplanes.

The value of 80 (out of 0-200 range for FW) provides a sensible default that users can fine-tune if needed.

## Testing

- Tested with SITL by applying "Airplane with a Tail" preset - verified `tpa_rate = 80` via CLI
- Tested with SITL by applying "Mini Quad with 5" propellers" preset - verified `tpa_rate = 20` (multicopter preset unchanged)


___

### **PR Type**
Enhancement


___

### **Description**
- Add TPA rate defaults to fixed-wing aircraft presets

- Set `tpa_rate = 80` for both airplane preset configurations

- Improves default tuning for fixed-wing aircraft performance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fixed-wing Presets"] -->|Add tpa_rate: 80| B["Airplane with Tail"]
  A -->|Add tpa_rate: 80| C["Airplane without Tail"]
  D["Multicopter Presets"] -->|Retain tpa_rate: 20| E["Unchanged"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>defaults_dialog_entries.js</strong><dd><code>Add TPA rate defaults to airplane presets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/defaults_dialog_entries.js

<ul><li>Added <code>tpa_rate: 80</code> configuration to "Airplane with a Tail" preset<br> <li> Added <code>tpa_rate: 80</code> configuration to "Airplane without a Tail (Wing, <br>Delta, etc)" preset<br> <li> Included TPA section comments for clarity in both presets<br> <li> Multicopter presets remain unchanged with existing <code>tpa_rate = 20</code></ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2515/files#diff-b0e26cb052abb02f3648889a384b938910716c1b5b3bb01247ad411169dc187c">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

