### PR TITLE
Fix firmware flasher board matching for multi-underscore targets

### DIFF
--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -23,8 +23,7 @@ import dialog from '../js/dialog.js';
 
 TABS.firmware_flasher = {};
 
-// Normalize target names by converting hyphens to underscores for consistent matching
-// This allows both TBS_LUCID_H7_WING and TBS-LUCID-H7-WING to match
+// Allow hyphens due to 9.0.0 patch
 function normalizeTargetName(name) {
     return name.replace(/-/g, '_');
 }
@@ -89,7 +88,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             var rawMatch = match[3];  // e.g., "TBS-LUCID-H7-WING" or "TBS_LUCID_H7_WING"
             return {
-                target_id: normalizeTargetName(rawMatch),  // Normalized: "TBS_LUCID_H7_WING"
+                target_id: normalizeTargetName(rawMatch),
                 target: rawMatch.replace(/_/g, " ").replace(/-/g, " "),  // Display: "TBS LUCID H7 WING"
                 format: match[9],
                 version: match[1]+match[2],
@@ -110,7 +109,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             var rawMatch = match[2];  // e.g., "MATEKF405" or "MATEK-F405"
             return {
-                target_id: normalizeTargetName(rawMatch),  // Normalized: "MATEKF405"
+                target_id: normalizeTargetName(rawMatch),
                 target: rawMatch.replace(/_/g, " ").replace(/-/g, " "),  // Display: "MATEKF405"
                 format: match[3],
             };

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -87,9 +87,10 @@ TABS.firmware_flasher.initialize = function (callback) {
                 return null;
             }
 
+            var rawMatch = match[3];  // e.g., "TBS-LUCID-H7-WING" or "TBS_LUCID_H7_WING"
             return {
-                raw_target: match[3],
-                target: match[3].replace(/_/g, " ").replace(/-/g, " "), // "/g" to replace all
+                target_id: normalizeTargetName(rawMatch),  // Normalized: "TBS_LUCID_H7_WING"
+                target: rawMatch.replace(/_/g, " ").replace(/-/g, " "),  // Display: "TBS LUCID H7 WING"
                 format: match[9],
                 version: match[1]+match[2],
                 major: match[1]
@@ -107,9 +108,10 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             //GUI.log("non dev: match[2]: " + match[2] + " match[3]: " + match[3]);
 
+            var rawMatch = match[2];  // e.g., "MATEKF405" or "MATEK-F405"
             return {
-                raw_target: match[2],
-                target: match[2].replace(/_/g, " ").replace(/-/g, " "), // "/g" to replace all
+                target_id: normalizeTargetName(rawMatch),  // Normalized: "MATEKF405"
+                target: rawMatch.replace(/_/g, " ").replace(/-/g, " "),  // Display: "MATEKF405"
                 format: match[3],
             };
         }
@@ -165,9 +167,8 @@ TABS.firmware_flasher.initialize = function (callback) {
                     if ((!showDevReleases && release.prerelease) || !result) {
                         return;
                     }
-                    var normalizedTarget = normalizeTargetName(result.raw_target);
-                    if($.inArray(normalizedTarget, unsortedTargets) == -1) {
-                        unsortedTargets.push(normalizedTarget);
+                    if($.inArray(result.target_id, unsortedTargets) == -1) {
+                        unsortedTargets.push(result.target_id);
                     }
                 });
             });
@@ -179,9 +180,8 @@ TABS.firmware_flasher.initialize = function (callback) {
                         var result = parseDevFilename(asset.name);
 
                         if (result) {
-                            var normalizedTarget = normalizeTargetName(result.raw_target);
-                            if ($.inArray(normalizedTarget, unsortedTargets) == -1) {
-                                unsortedTargets.push(normalizedTarget);
+                            if ($.inArray(result.target_id, unsortedTargets) == -1) {
+                                unsortedTargets.push(result.target_id);
                             }
                         }
                     });
@@ -225,14 +225,13 @@ TABS.firmware_flasher.initialize = function (callback) {
                         "version"   : release.tag_name,
                         "url"       : asset.browser_download_url,
                         "file"      : asset.name,
-                        "raw_target": result.raw_target,
+                        "target_id" : result.target_id,
                         "target"    : result.target,
                         "date"      : formattedDate,
                         "notes"     : release.body,
                         "status"    : release.prerelease ? "release-candidate" : "stable"
                     };
-                    var normalizedTarget = normalizeTargetName(result.raw_target);
-                    releases[normalizedTarget].push(descriptor);
+                    releases[result.target_id].push(descriptor);
                 });
             });
 
@@ -280,14 +279,13 @@ TABS.firmware_flasher.initialize = function (callback) {
                             "version"   : release.tag_name,
                             "url"       : asset.browser_download_url,
                             "file"      : asset.name,
-                            "raw_target": result.raw_target,
+                            "target_id" : result.target_id,
                             "target"    : result.target,
                             "date"      : formattedDate,
                             "notes"     : release.body,
                             "status"    : release.prerelease ? "nightly" : "stable"
                         };
-                        var normalizedTarget = normalizeTargetName(result.raw_target);
-                        releases[normalizedTarget].push(descriptor);
+                        releases[result.target_id].push(descriptor);
                     });
                 });
             }
@@ -300,10 +298,9 @@ TABS.firmware_flasher.initialize = function (callback) {
                     descriptors.forEach(function(descriptor){
                         if($.inArray(target, selectTargets) == -1) {
                             selectTargets.push(target);
-                            var normalizedTarget = normalizeTargetName(descriptor.raw_target);
                             var select_e =
                                     $("<option value='{0}'>{1}</option>".format(
-                                            normalizedTarget,
+                                            descriptor.target_id,
                                             descriptor.target
                                     )).data('summary', descriptor);
                             boards_e.append(select_e);
@@ -353,9 +350,8 @@ TABS.firmware_flasher.initialize = function (callback) {
                         versions_e.append($("<option value='0'>{0} {1}</option>".format(i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersionFor'), target)));
                     }
 
-                    var normalizedTarget = normalizeTargetName(target);
-                    if (typeof TABS.firmware_flasher.releases[normalizedTarget]?.forEach === 'function') {
-                        TABS.firmware_flasher.releases[normalizedTarget].forEach(function(descriptor) {
+                    if (typeof TABS.firmware_flasher.releases[target]?.forEach === 'function') {
+                        TABS.firmware_flasher.releases[target].forEach(function(descriptor) {
                             var select_e =
                                     $("<option value='{0}'>{0} - {1} - {2} ({3})</option>".format(
                                             descriptor.version,


### PR DESCRIPTION
### **User description**
## Summary

Fixes firmware flasher board selection for targets with multiple underscores in their names (e.g., `TBS_LUCID_H7_WING`).

## Problem

The original code only replaced the **first** underscore with a space when creating display names, which caused a mismatch:
- Dictionary was keyed by: `"TBS LUCID_H7_WING"` (first underscore → space)
- Lookup used: `"TBS_LUCID_H7_WING"` (all underscores)
- **Result**: Board not found in releases dictionary

## Solution

1. Added `normalizeTargetName()` function to convert hyphens to underscores for consistent matching
2. Fixed `parseFilename()` and `parseDevFilename()` to replace **ALL** underscores/hyphens with spaces for display (using `/g` flag)
3. Changed releases dictionary to be keyed by normalized `raw_target` instead of modified `target`
4. Normalized all dictionary lookups to use consistent underscore format
5. Added support for hyphen-based filenames as a workaround (e.g., `TBS-LUCID-H7-WING`)

## Changes

- **tabs/firmware_flasher.js**:
  - Add `normalizeTargetName()` function
  - Update `parseFilename()` to replace all underscores/hyphens
  - Update `parseDevFilename()` to replace all underscores/hyphens and accept hyphens in regex
  - Key releases dictionary by normalized targets
  - Normalize all lookups in board selection and FC auto-detect

## Test Plan

- [x] Manual testing with INAV Configurator dev build
- [x] Verified board dropdown populates correctly
- [x] Verified no console errors
- [x] Confirmed fix handles both underscore and hyphen variants

## Compatibility

- **Backwards compatible**: Works with existing underscore-based filenames
- **Forward compatible**: Also supports hyphen-based filenames as workaround


___

### **PR Type**
Bug fix


___

### **Description**
- Add `normalizeTargetName()` function to convert hyphens to underscores

- Fix board matching for multi-underscore target names like `TBS_LUCID_H7_WING`

- Replace all underscores/hyphens with spaces in display names using `/g` flag

- Normalize all dictionary lookups and board selection logic consistently


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Target Name<br/>TBS_LUCID_H7_WING"] --> B["normalizeTargetName()"]
  B --> C["Normalized<br/>TBS_LUCID_H7_WING"]
  C --> D["Dictionary Key<br/>Lookup"]
  D --> E["Board Found<br/>& Selected"]
  F["parseFilename()"] --> G["Replace All<br/>Underscores/Hyphens"]
  G --> H["Display Name<br/>TBS LUCID H7 WING"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>firmware_flasher.js</strong><dd><code>Normalize target names for consistent board matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tabs/firmware_flasher.js

<ul><li>Added <code>normalizeTargetName()</code> function to convert hyphens to underscores <br>for consistent matching<br> <li> Updated <code>parseFilename()</code> and <code>parseDevFilename()</code> to replace all <br>underscores/hyphens with spaces using <code>/g</code> flag<br> <li> Modified regex in <code>parseDevFilename()</code> to accept hyphens in target names <br>(<code>[A-Za-z0-9_-]+</code>)<br> <li> Changed all releases dictionary keys and lookups to use normalized <br><code>raw_target</code> instead of modified <code>target</code><br> <li> Normalized board selection and FC auto-detect logic to use consistent <br>underscore format</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2522/files#diff-ef3a8e48ee23e6d39840f6b2b1e7edb3822043ad010417a2ffb627e64a1aaa33">+30/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

