### PR TITLE
Add GPS preset UI with auto-detection and M9 Precision/Sport modes

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -198,6 +198,12 @@ var mspHelper = (function () {
                 FC.GPS_DATA.hdop = data.getUint16(14, true);
                 FC.GPS_DATA.eph = data.getUint16(16, true);
                 FC.GPS_DATA.epv = data.getUint16(18, true);
+                // Check if hwVersion field exists (firmware with extended MSP_GPSSTATISTICS)
+                if (data.byteLength >= 24) {
+                    FC.GPS_DATA.hwVersion = data.getUint32(20, true);
+                } else {
+                    FC.GPS_DATA.hwVersion = 0; // Unknown for older firmware
+                }
                 break;
             case MSPCodes.MSP2_ADSB_VEHICLE_LIST:
                 var byteOffsetCounter = 0;

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1209,6 +1209,24 @@
     "configurationGPSUseGlonass": {
         "message": "Gps use Glonass Satellites (RU)"
     },
+    "gpsPresetMode": {
+        "message": "GPS Configuration Preset"
+    },
+    "gpsPresetModeHelp": {
+        "message": "Choose a preset optimized for your GPS module, or use Manual for custom configuration. Auto-detect will identify your GPS module if connected."
+    },
+    "gpsUpdateRate": {
+        "message": "GPS Update Rate (Hz)"
+    },
+    "gpsUpdateRateHelp": {
+        "message": "How often the GPS module sends position updates. Higher rates provide lower latency but may reduce accuracy with multiple constellations on M10 modules."
+    },
+    "gpsAutoDetectFailed": {
+        "message": "Could not auto-detect GPS module. Please connect flight controller or select manual preset."
+    },
+    "gpsAutoDetectSuccess": {
+        "message": "GPS module detected:"
+    },
     "tzOffset": {
         "message": "Timezone Offset"
     },

--- a/tabs/gps.html
+++ b/tabs/gps.html
@@ -44,7 +44,8 @@
                                 <option value="auto">Auto-detect GPS Type</option>
                                 <option value="manual" selected>Manual Settings</option>
                                 <option value="m8">u-blox M8</option>
-                                <option value="m9">u-blox M9</option>
+                                <option value="m9-precision">u-blox M9 (Precision Mode)</option>
+                                <option value="m9-sport">u-blox M9 (Sport Mode)</option>
                                 <option value="m10">u-blox M10</option>
                                 <option value="m10-highperf">u-blox M10 (High-Performance)</option>
                             </select>

--- a/tabs/gps.html
+++ b/tabs/gps.html
@@ -38,16 +38,44 @@
                             <input type="number" id="mag_declination" name="mag_declination" step="0.1" min="-180" max="180" />
                             <label for="mag_declination"><span data-i18n="configurationMagDeclination"></span></label>
                         </div>
+                        <!-- GPS Optimization Preset -->
+                        <div class="select">
+                            <select id="gps_preset_mode">
+                                <option value="auto">Auto-detect GPS Type</option>
+                                <option value="manual" selected>Manual Settings</option>
+                                <option value="m8">u-blox M8</option>
+                                <option value="m9">u-blox M9</option>
+                                <option value="m10">u-blox M10</option>
+                                <option value="m10-highperf">u-blox M10 (High-Performance)</option>
+                            </select>
+                            <label for="gps_preset_mode">
+                                <span data-i18n="gpsPresetMode">GPS Configuration Preset</span>
+                            </label>
+                            <div for="gps_preset_mode" class="helpicon cf_tip" data-i18n_title="gpsPresetModeHelp"></div>
+                        </div>
+                        <!-- GPS Preset Info (shown when preset selected) -->
+                        <div class="preset-info" id="preset_info" style="display: none; padding: 5px; margin: 5px 0; background: #f0f0f0; border-radius: 3px;">
+                            <strong><span id="preset_name"></span></strong>
+                            <ul id="preset_details" style="margin: 5px 0; padding-left: 20px;"></ul>
+                        </div>
+                        <!-- GPS Update Rate -->
+                        <div class="number">
+                            <input type="number" id="gps_ublox_nav_hz" data-setting="gps_ublox_nav_hz" step="1" min="5" max="20" />
+                            <label for="gps_ublox_nav_hz">
+                                <span data-i18n="gpsUpdateRate">GPS Update Rate (Hz)</span>
+                            </label>
+                            <div for="gps_ublox_nav_hz" class="helpicon cf_tip" data-i18n_title="gpsUpdateRateHelp"></div>
+                        </div>
                         <div class="checkbox">
-                            <input type="checkbox" class="toggle update_preview" data-setting="gps_ublox_use_galileo" data-live="true">
+                            <input type="checkbox" id="gps_use_galileo" class="toggle update_preview preset-controlled" data-setting="gps_ublox_use_galileo" data-live="true">
                             <label for="gps_use_galileo"><span data-i18n="configurationGPSUseGalileo"></span></label>
                         </div>
                         <div class="checkbox">
-                            <input type="checkbox" class="toggle update_preview" data-setting="gps_ublox_use_beidou" data-live="true">
+                            <input type="checkbox" id="gps_use_beidou" class="toggle update_preview preset-controlled" data-setting="gps_ublox_use_beidou" data-live="true">
                             <label for="gps_use_beidou"><span data-i18n="configurationGPSUseBeidou"></span></label>
                         </div>
                         <div class="checkbox">
-                            <input type="checkbox" class="toggle update_preview" data-setting="gps_ublox_use_glonass" data-live="true">
+                            <input type="checkbox" id="gps_use_glonass" class="toggle update_preview preset-controlled" data-setting="gps_ublox_use_glonass" data-live="true">
                             <label for="gps_use_glonass"><span data-i18n="configurationGPSUseGlonass"></span></label>
                         </div>
                         <div class="number">

--- a/tabs/gps.html
+++ b/tabs/gps.html
@@ -54,6 +54,12 @@
                             </label>
                             <div for="gps_preset_mode" class="helpicon cf_tip" data-i18n_title="gpsPresetModeHelp"></div>
                         </div>
+                        <!-- Hardware detection status -->
+                        <div id="gps_hardware_status" style="display: none; padding: 5px; margin: 5px 0; font-size: 12px; color: #28a745;">
+                            <span style="margin-right: 5px;">✓</span>
+                            <span id="gps_hardware_name"></span>
+                            <a href="#" id="gps_apply_optimal" style="margin-left: 10px; color: #007bff; text-decoration: none;">[Use optimal settings]</a>
+                        </div>
                         <!-- GPS Preset Info (shown when preset selected) -->
                         <div class="preset-info" id="preset_info" style="display: none; padding: 5px; margin: 5px 0; background: #f0f0f0; border-radius: 3px;">
                             <strong><span id="preset_name"></span></strong>
@@ -68,15 +74,15 @@
                             <div for="gps_ublox_nav_hz" class="helpicon cf_tip" data-i18n_title="gpsUpdateRateHelp"></div>
                         </div>
                         <div class="checkbox">
-                            <input type="checkbox" id="gps_use_galileo" class="toggle update_preview preset-controlled" data-setting="gps_ublox_use_galileo" data-live="true">
+                            <input type="checkbox" id="gps_use_galileo" class="toggle update_preview preset-controlled" data-setting="gps_ublox_use_galileo">
                             <label for="gps_use_galileo"><span data-i18n="configurationGPSUseGalileo"></span></label>
                         </div>
                         <div class="checkbox">
-                            <input type="checkbox" id="gps_use_beidou" class="toggle update_preview preset-controlled" data-setting="gps_ublox_use_beidou" data-live="true">
+                            <input type="checkbox" id="gps_use_beidou" class="toggle update_preview preset-controlled" data-setting="gps_ublox_use_beidou">
                             <label for="gps_use_beidou"><span data-i18n="configurationGPSUseBeidou"></span></label>
                         </div>
                         <div class="checkbox">
-                            <input type="checkbox" id="gps_use_glonass" class="toggle update_preview preset-controlled" data-setting="gps_ublox_use_glonass" data-live="true">
+                            <input type="checkbox" id="gps_use_glonass" class="toggle update_preview preset-controlled" data-setting="gps_ublox_use_glonass">
                             <label for="gps_use_glonass"><span data-i18n="configurationGPSUseGlonass"></span></label>
                         </div>
                         <div class="number">

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -218,10 +218,10 @@ TABS.gps.initialize = function (callback) {
                 name: "u-blox M9",
                 galileo: true,
                 glonass: true,
-                beidou: true,
+                beidou: false,
                 rate: 10,
                 description: [
-                    "4 GNSS constellations (16 satellites at 10Hz due to hardware limit)",
+                    "3 GNSS constellations (GPS+Galileo+Glonass)",
                     "10Hz update rate",
                     "Best for: General use, balanced accuracy and responsiveness"
                 ]
@@ -230,10 +230,10 @@ TABS.gps.initialize = function (callback) {
                 name: "u-blox M10",
                 galileo: true,
                 glonass: true,
-                beidou: true,
+                beidou: false,
                 rate: 6,
                 description: [
-                    "4 GNSS constellations for maximum satellites",
+                    "3 GNSS constellations (GPS+Galileo+Glonass)",
                     "6Hz update rate (safe for M10 default CPU clock)",
                     "Best for: Long-range, cruise, slower aircraft"
                 ]
@@ -242,10 +242,10 @@ TABS.gps.initialize = function (callback) {
                 name: "u-blox M10 (High-Performance)",
                 galileo: true,
                 glonass: true,
-                beidou: true,
+                beidou: false,
                 rate: 10,
                 description: [
-                    "4 GNSS constellations at full speed",
+                    "3 GNSS constellations (GPS+Galileo+Glonass)",
                     "10Hz update rate (requires high-performance CPU clock)",
                     "Only use if you KNOW your M10 has high-performance clock enabled"
                 ]

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -328,8 +328,8 @@ TABS.gps.initialize = function (callback) {
             $('#preset_info').show();
         }
 
-        // Set up preset mode handler
-        $('#gps_preset_mode').on('change', function() {
+        // Set up preset mode handler (namespaced to prevent memory leaks)
+        $('#gps_preset_mode').on('change.gpsTab', function() {
             applyGPSPreset($(this).val());
         });
 
@@ -344,8 +344,8 @@ TABS.gps.initialize = function (callback) {
             }
         }
 
-        // Handler for "Use optimal settings" link
-        $('#gps_apply_optimal').on('click', function(e) {
+        // Handler for "Use optimal settings" link (namespaced)
+        $('#gps_apply_optimal').on('click.gpsTab', function(e) {
             e.preventDefault();
             if (FC.GPS_DATA && FC.GPS_DATA.hwVersion) {
                 const detectedPreset = detectGPSPreset(FC.GPS_DATA.hwVersion);
@@ -403,7 +403,7 @@ TABS.gps.initialize = function (callback) {
             }));
         }
 
-        $("#center_button").on('click', function () {
+        $("#center_button").on('click.gpsTab', function () {
             let lat = FC.GPS_DATA.lat / 10000000;
             let lon = FC.GPS_DATA.lon / 10000000;
             let center = fromLonLat([lon, lat]);
@@ -629,7 +629,7 @@ TABS.gps.initialize = function (callback) {
             });
         }
 
-        $('a.save').on('click', function () {
+        $('a.save').on('click.gpsTab', function () {
             serialPortHelper.set($port.val(), 'GPS', $baud.val());
             features.reset();
             features.fromUI($('.tab-gps'));
@@ -680,7 +680,7 @@ TABS.gps.initialize = function (callback) {
             }
         }
 
-        $('a.loadAssistnowOnline').on('click', function () {
+        $('a.loadAssistnowOnline').on('click.gpsTab', function () {
             if(globalSettings.assistnowApiKey != null && globalSettings.assistnowApiKey != '') {
                 ublox.loadAssistnowOnline(processUbloxData);
            } else {
@@ -688,7 +688,7 @@ TABS.gps.initialize = function (callback) {
             }
         });
 
-        $('a.loadAssistnowOffline').on('click', function () {
+        $('a.loadAssistnowOffline').on('click.gpsTab', function () {
             if(globalSettings.assistnowApiKey != null && globalSettings.assistnowApiKey != '') {
                 ublox.loadAssistnowOffline(processUbloxData);
             } else {
@@ -702,6 +702,14 @@ TABS.gps.initialize = function (callback) {
 };
 
 TABS.gps.cleanup = function (callback) {
+    // Remove all namespaced event handlers to prevent memory leaks
+    $('#gps_preset_mode').off('.gpsTab');
+    $('#gps_apply_optimal').off('.gpsTab');
+    $('#center_button').off('.gpsTab');
+    $('a.save').off('.gpsTab');
+    $('a.loadAssistnowOnline').off('.gpsTab');
+    $('a.loadAssistnowOffline').off('.gpsTab');
+
     if (callback) callback();
     if (TABS.gps.toolboxAdsbVehicle){
         TABS.gps.toolboxAdsbVehicle.close();

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -214,38 +214,50 @@ TABS.gps.initialize = function (callback) {
                     "Best for: Navigation, position hold, slower aircraft"
                 ]
             },
-            m9: {
-                name: "u-blox M9",
+            'm9-precision': {
+                name: "u-blox M9 (Precision Mode)",
                 galileo: true,
-                glonass: true,
-                beidou: false,
+                glonass: false,
+                beidou: true,
+                rate: 5,
+                description: [
+                    "3 GNSS constellations (GPS+Galileo+Beidou) → 32 satellites",
+                    "5Hz update rate, HDOP ~1.0-1.3",
+                    "Best for: Long-range cruise, position hold, navigation missions"
+                ]
+            },
+            'm9-sport': {
+                name: "u-blox M9 (Sport Mode)",
+                galileo: true,
+                glonass: false,
+                beidou: true,
                 rate: 10,
                 description: [
-                    "3 GNSS constellations (GPS+Galileo+Glonass)",
-                    "10Hz update rate",
-                    "Best for: General use, balanced accuracy and responsiveness"
+                    "3 GNSS constellations (GPS+Galileo+Beidou) → 16 satellites",
+                    "10Hz update rate (hardware limit), HDOP ~2.0-2.5",
+                    "Best for: Fast flying, racing, acrobatics, quick response"
                 ]
             },
             m10: {
                 name: "u-blox M10",
                 galileo: true,
-                glonass: true,
-                beidou: false,
-                rate: 6,
+                glonass: false,
+                beidou: true,
+                rate: 8,
                 description: [
-                    "3 GNSS constellations (GPS+Galileo+Glonass)",
-                    "6Hz update rate (safe for M10 default CPU clock)",
-                    "Best for: Long-range, cruise, slower aircraft"
+                    "3 GNSS constellations (GPS+Galileo+Beidou)",
+                    "8Hz update rate (safe for M10 default CPU clock)",
+                    "Best for: General use, balanced performance"
                 ]
             },
             'm10-highperf': {
                 name: "u-blox M10 (High-Performance)",
                 galileo: true,
                 glonass: true,
-                beidou: false,
+                beidou: true,
                 rate: 10,
                 description: [
-                    "3 GNSS constellations (GPS+Galileo+Glonass)",
+                    "4 GNSS constellations for maximum satellites",
                     "10Hz update rate (requires high-performance CPU clock)",
                     "Only use if you KNOW your M10 has high-performance clock enabled"
                 ]
@@ -262,7 +274,7 @@ TABS.gps.initialize = function (callback) {
         function detectGPSPreset(hwVersion) {
             switch(hwVersion) {
                 case 800:  return 'm8';
-                case 900:  return 'm9';
+                case 900:  return 'm9-precision';  // Default to precision mode for better accuracy
                 case 1000: return 'm10';
                 default:   return 'manual';
             }

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -310,11 +310,11 @@ TABS.gps.initialize = function (callback) {
             const preset = GPS_PRESETS[presetId];
             if (!preset) return;
 
-            // Apply preset values
-            $('#gps_use_galileo').prop('checked', preset.galileo);
-            $('#gps_use_glonass').prop('checked', preset.glonass);
-            $('#gps_use_beidou').prop('checked', preset.beidou);
-            $('#gps_ublox_nav_hz').val(preset.rate);
+            // Apply preset values (trigger change for state consistency)
+            $('#gps_use_galileo').prop('checked', preset.galileo).trigger('change');
+            $('#gps_use_glonass').prop('checked', preset.glonass).trigger('change');
+            $('#gps_use_beidou').prop('checked', preset.beidou).trigger('change');
+            $('#gps_ublox_nav_hz').val(preset.rate).trigger('change');
 
             // Disable controls (user can see but not edit)
             $('.preset-controlled').prop('disabled', true);


### PR DESCRIPTION
### **User description**
## Summary

Adds GPS configuration preset system with auto-detection of GPS module type (M8/M9/M10) and optimized presets for each module. Includes educational two-preset approach for M9 modules to help users understand the accuracy vs latency trade-off.

**Screenshot:**
<img width="459" height="303" alt="image" src="https://github.com/user-attachments/assets/a6a02aef-ac9d-4762-bc78-7d07da12b928" />

## Changes

### New Features
- **GPS presets** including auto-detection and manual settings
- **Auto-detection** uses hwVersion from MSP_GPSSTATISTICS (firmware PR #11262)
- **M9 Precision Mode** (5Hz, 32 sats, HDOP ~1.0-1.3) - default for M9
- **M9 Sport Mode** (10Hz, 16 sats, HDOP ~2.0-2.5) - for racing/sport
- **Preset info boxes** display configuration details and use cases


### Files Modified
- **tabs/gps.js**: Added GPS_PRESETS, detectGPSPreset(), applyGPSPreset() functions
- **tabs/gps.html**: Added preset dropdown with 7 options
- **js/msp/MSPHelper.js**: Parse hwVersion from MSP_GPSSTATISTICS (backward compatible)

### Preset Configurations

| Preset | Rate | Constellations | Use Case |
|--------|------|----------------|----------|
| **M8** | 8Hz | GPS+Galileo+Beidou+Glonass | Navigation, position hold |
| **M9 Precision** | 5Hz | GPS+Galileo+Beidou | Long-range cruise, accuracy ✨ Default |
| **M9 Sport** | 10Hz | GPS+Galileo+Beidou | Racing, acrobatics, responsiveness |
| **M10** | 8Hz | GPS+Galileo+Beidou | General use, balanced |
| **M10 High-Perf** | 10Hz | GPS+Galileo+Beidou+Glonass | High-performance clock only |

## Research & Citations

This work is based on extensive research and community contributions:

### u-blox Forum Research
- **M9 16-satellite limitation** discovered by u-blox community expert **Clive Turvey (cturvey)**
- u-blox forum posts documenting 10Hz threshold:
  - https://portal.u-blox.com/s/question/0D52p00008HKEbOCAX/can-neom9n-only-use-16-satellites-with-nav-update-rate-5hz
  - https://portal.u-blox.com/s/question/0D52p00009IsVqkCAF/is-the-neom9n-limited-to-16-svs-for-the-navigation-solution
  - https://portal.u-blox.com/s/question/0D52p0000990yQ1CAI/neom9n-reduced-satellites-at-increased-rates-is-there-a-way-around-it

### Clive Turvey's Code Analysis
- Documented undocumented configuration key **CFG-NAVSPG-CONSTR_GNSS**
- Code: https://github.com/cturvey/RandomNinjaChef/blob/main/M9_channels.c
- Shows M9 hardware enforces 16-sat limit at ≥10Hz, 32-sat below 10Hz

### PX4 GPS Driver Decision
- PX4 GPS drivers chose **5Hz for M9** for better accuracy (32 satellites)
- PR discussion: https://github.com/PX4/PX4-GPSDrivers/pull/57
- Industry consensus: prioritize accuracy over latency for navigation

### Field Testing
- **Jetrell's INAV testing** contributed to understanding real-world M9 behavior
- Community-reported HDOP improvements: ~1.0-1.3 at 5Hz vs ~2.0-2.5 at 10Hz

## Implementation Details

### Auto-Detection Logic
1. User selects "Auto-detect GPS Type" from dropdown
2. Reads `FC.GPS_DATA.hwVersion` from MSP_GPSSTATISTICS
3. Maps hwVersion to preset:
   - 800 (UBLOX8) → M8 preset
   - 900 (UBLOX9) → M9 Precision Mode (default)
   - 1000 (UBLOX10) → M10 preset
   - 0 (Unknown) → Falls back to Manual Settings
4. Applies preset (constellations, rate) and disables controls
5. Displays preset info box with description



### Backward Compatibility
- Works with older firmware (hwVersion field check before use)
- Gracefully falls back to Manual Settings if hwVersion unavailable
- Manual preset selection always available

## Testing

### Tested ✅
- **All presets selectable**: 7 dropdown options work correctly
- **M8 auto-detection**: Successfully detected M8 (hwVersion=800) and applied M8 preset
- **Manual presets**: All 7 presets apply correct constellation/rate values
- **Preset info boxes**: Display correctly with descriptions
- **Control disable/enable**: Works correctly for presets vs manual
- **Tab switching**: Preserves auto-detected preset when navigating between tabs
- **Backward compatibility**: Older firmware without hwVersion falls back to manual

### Testing Needed ⚠️
- **M9 modules**: Community testing needed to verify:
  - Auto-detection selects M9 Precision Mode
- **M10 modules**: Community testing needed to verify:
  - Auto-detection selects M10 preset


## Related PR
- Firmware PR: https://github.com/iNavFlight/inav/pull/11262
- Firmware extends MSP_GPSSTATISTICS to include hwVersion field

## Educational Value

The two M9 presets help users understand:
- **Hardware limitation**: M9 can only track 16 satellites at ≥10Hz
- **Accuracy vs latency trade-off**: 5Hz/32 sats vs 10Hz/16 sats
- **HDOP impact**: ~2x better accuracy at lower rate
- **Flight profile matching**: Choose based on aircraft type and mission

Defaults to Precision Mode (matches PX4/ArduPilot) but gives users informed choice.

---

**Testing help appreciated!** If you have M9 or M10 modules, please test auto-detection and verify satellite counts at various rates.


___

### **PR Type**
Enhancement, New Feature


___

### **Description**
- Add GPS preset system with auto-detection for M8/M9/M10 modules

- Implement M9 Precision (5Hz) and Sport (10Hz) modes for accuracy/latency trade-off

- Expose GPS update rate control in UI with preset-based configuration

- Parse hwVersion from MSP_GPSSTATISTICS for automatic GPS module detection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MSP_GPSSTATISTICS<br/>hwVersion field"] -->|"Parse in<br/>MSPHelper.js"| B["FC.GPS_DATA.hwVersion"]
  B -->|"Detect GPS<br/>module type"| C["detectGPSPreset()"]
  C -->|"Map to preset<br/>M8/M9/M10"| D["GPS_PRESETS<br/>object"]
  D -->|"Apply constellation<br/>& rate settings"| E["applyGPSPreset()"]
  E -->|"Update UI<br/>& disable controls"| F["GPS Tab<br/>Configuration"]
  G["User selects<br/>preset dropdown"] -->|"Trigger change<br/>event"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MSPHelper.js</strong><dd><code>Parse hwVersion from MSP_GPSSTATISTICS for auto-detection</code></dd></summary>
<hr>

js/msp/MSPHelper.js

<ul><li>Add backward-compatible parsing of <code>hwVersion</code> field from <br>MSP_GPSSTATISTICS response<br> <li> Check data buffer length (>= 24 bytes) before reading hwVersion at <br>offset 20<br> <li> Set hwVersion to 0 (Unknown) for older firmware without extended <br>MSP_GPSSTATISTICS</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2526/files#diff-d006b63aa45117eed77ad8b4f1bb6c267d50798748974998302028eacd01673c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gps.js</strong><dd><code>Implement GPS preset detection and application logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tabs/gps.js

<ul><li>Define <code>GPS_PRESETS</code> object with 7 preset configurations (M8, M9 <br>Precision/Sport, M10, M10 High-Perf, Manual, Auto)<br> <li> Implement <code>detectGPSPreset()</code> function to map hwVersion (800/900/1000) <br>to appropriate preset<br> <li> Implement <code>applyGPSPreset()</code> function to apply constellation/rate <br>settings and disable/enable controls<br> <li> Add preset change event handler and initialization logic that <br>auto-detects or defaults to manual mode<br> <li> Display preset info box with description when preset is selected</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2526/files#diff-c7018a953b99b712c3499d71e39610b65f48d01b9f6b636b1c577fdb876052b5">+142/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gps.html</strong><dd><code>Add GPS preset dropdown and update rate UI controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tabs/gps.html

<ul><li>Add GPS preset mode dropdown with 7 options (Auto-detect, Manual, M8, <br>M9 Precision/Sport, M10, M10 High-Perf)<br> <li> Add preset info display box showing preset name and configuration <br>details<br> <li> Add GPS update rate number input field (previously not exposed in UI)<br> <li> Add IDs and <code>preset-controlled</code> class to constellation checkboxes for <br>preset control<br> <li> Add help icons and labels for new preset and update rate controls</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2526/files#diff-9b70d7ea064b83562f44907248cdbd90f5b05c5ddba4bcee1e39760458087e65">+32/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>messages.json</strong><dd><code>Add i18n strings for GPS preset UI elements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

locale/en/messages.json

<ul><li>Add translation strings for GPS preset mode label and help text<br> <li> Add translation strings for GPS update rate label and help text<br> <li> Add translation strings for auto-detect success and failure messages</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2526/files#diff-d2cf5f055286abdef37960eb38ee80194d6a662fe27b548603584642fcf2295f">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

