### PR TITLE
correcting vspeed defaults in presets

### DIFF
--- a/js/defaults_dialog_entries.js
+++ b/js/defaults_dialog_entries.js
@@ -454,18 +454,6 @@ var defaultsDialogData = [
                 key: "yaw_rate",
                 value: 3
             },
-                        {
-                key: "nav_fw_pos_z_p",
-                value: 35
-            },
-            {
-                key: "nav_fw_pos_z_i",
-                value: 5
-            },
-            {
-                key: "nav_fw_pos_z_d",
-                value: 10
-            },
             {
                 key: "nav_fw_pos_xy_p",
                 value: 55


### PR DESCRIPTION
### **User description**
With 9.0 the default presets have been missed updating for the vspeed controller values. Since the firmware defaults also have not been updated, a fresh plane setup or a setup with unchanged vspeed PIDFF controller values (not in diff) will have a 5x higher d value than recommended. This still results in dolphining on some platforms. 

Updating the presets for the maintenance release that is planned.


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected VSpeed PIDFF controller default parameters for firmware 9.0

- Removed outdated pre-9.0 vertical speed control values

- Added proper altitude control response and feedforward settings

- Updated parameters for FW-WT and other fixed-wing platforms


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old VSpeed Parameters<br/>nav_fw_pos_z_p/i/d"] -->|Remove| B["Outdated Pre-9.0 Values"]
  C["New VSpeed Parameters<br/>set nav_fw_pos_z_p/i/d/FF<br/>set nav_fw_alt_control_response"] -->|Add| D["Firmware 9.0 Compliant"]
  B --> E["Prevent Dolphining<br/>on Fixed-Wing Platforms"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>defaults_dialog_entries.js</strong><dd><code>Update VSpeed PIDFF defaults to firmware 9.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/defaults_dialog_entries.js

<ul><li>Removed outdated <code>nav_fw_pos_z_p</code>, <code>nav_fw_pos_z_i</code>, and <code>nav_fw_pos_z_d</code> <br>parameters from FW-WT and other presets<br> <li> Added corrected VSpeed PIDFF parameters with <code>set</code> prefix: <br><code>nav_fw_pos_z_p</code>, <code>nav_fw_pos_z_i</code>, <code>nav_fw_pos_z_d</code>, and <code>nav_fw_pos_z_FF</code><br> <li> Added <code>nav_fw_alt_control_response</code> parameter set to 45 for altitude <br>control<br> <li> Updated parameter values to firmware 9.0 recommended settings for <br>multiple fixed-wing presets</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2533/files#diff-b0e26cb052abb02f3648889a384b938910716c1b5b3bb01247ad411169dc187c">+40/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

