### PR TITLE
Remove 'set' prefix from nav_fw keys

### DIFF
--- a/js/defaults_dialog_entries.js
+++ b/js/defaults_dialog_entries.js
@@ -519,19 +519,19 @@ var defaultsDialogData = [
                 value: 255
             },
             {
-                key: "set nav_fw_pos_z_p",
+                key: "nav_fw_pos_z_p",
                 value: 22
             },
             {
-                key: "set nav_fw_pos_z_i",
+                key: "nav_fw_pos_z_i",
                 value: 6
             },
             {
-                key: "set nav_fw_pos_z_d",
+                key: "nav_fw_pos_z_d",
                 value: 2
             },
             {
-                key: "set nav_fw_pos_z_FF",
+                key: "nav_fw_pos_z_FF",
                 value: 25
             },
             {
@@ -733,19 +733,19 @@ var defaultsDialogData = [
                 value: 100
             },
             {
-                key: "set nav_fw_pos_z_p",
+                key: "nav_fw_pos_z_p",
                 value: 25
             },
             {
-                key: "set nav_fw_pos_z_i",
+                key: "nav_fw_pos_z_i",
                 value: 6
             },
             {
-                key: "set nav_fw_pos_z_d",
+                key: "nav_fw_pos_z_d",
                 value: 5
             },
             {
-                key: "set nav_fw_pos_z_FF",
+                key: "nav_fw_pos_z_FF",
                 value: 25
             },
             {


### PR DESCRIPTION
### **User description**
oopsie


___

### **PR Type**
Enhancement


___

### **Description**
- Remove 'set' prefix from nav_fw_pos_z PID parameter keys

- Standardize key naming convention across firmware defaults

- Update 8 parameter entries in two profile configurations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["nav_fw_pos_z parameters<br/>with 'set' prefix"] -- "Remove prefix" --> B["Standardized parameter<br/>key names"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>defaults_dialog_entries.js</strong><dd><code>Remove 'set' prefix from nav_fw_pos_z keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/defaults_dialog_entries.js

<ul><li>Removed 'set ' prefix from 4 nav_fw_pos_z PID parameter keys: <br>nav_fw_pos_z_p, nav_fw_pos_z_i, nav_fw_pos_z_d, nav_fw_pos_z_FF<br> <li> Changes applied in two separate profile sections (lines 517-530 and <br>731-744)<br> <li> Total of 8 key entries updated across both profiles</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2537/files#diff-b0e26cb052abb02f3648889a384b938910716c1b5b3bb01247ad411169dc187c">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

