### PR TITLE
Fix GUI_control ReferenceError in magnetometer and other tabs

### DIFF
--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -345,7 +345,7 @@ var SerialBackend = (function () {
     privateScope.onOpen = function (openInfo) {
 
         if (FC.restartRequired) {
-            GUI_control.prototype.log("<span style='color: red; font-weight: bolder'><strong>" + i18n.getMessage("illegalStateRestartRequired") + "</strong></span>");
+            GUI.log("<span style='color: red; font-weight: bolder'><strong>" + i18n.getMessage("illegalStateRestartRequired") + "</strong></span>");
             $('div.connect_controls a').trigger( "click" ); // disconnect
             return;
         }
@@ -413,7 +413,7 @@ var SerialBackend = (function () {
             MSP.send_message(MSPCodes.MSP_API_VERSION, false, false, function () {
                 
                 if (FC.CONFIG.apiVersion === "0.0.0") {
-                    GUI_control.prototype.log("<span style='color: red; font-weight: bolder'><strong>" + i18n.getMessage("illegalStateRestartRequired") + "</strong></span>");
+                    GUI.log("<span style='color: red; font-weight: bolder'><strong>" + i18n.getMessage("illegalStateRestartRequired") + "</strong></span>");
                     FC.restartRequired = true;
                     return;
                 }

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -826,7 +826,7 @@ TABS.firmware_flasher.onOpen = async function(openInfo) {
         MSP.send_message(MSPCodes.MSP_API_VERSION, false, false, function () {
             
             if (FC.CONFIG.apiVersion === "0.0.0") {
-                GUI_control.prototype.log("Cannot prefetch target: <span style='color: red; font-weight: bolder'><strong>" + i18n.getMessage("illegalStateRestartRequired") + "</strong></span>");
+                GUI.log("Cannot prefetch target: <span style='color: red; font-weight: bolder'><strong>" + i18n.getMessage("illegalStateRestartRequired") + "</strong></span>");
                 FC.restartRequired = true;
                 return;
             }

--- a/tabs/magnetometer.js
+++ b/tabs/magnetometer.js
@@ -650,7 +650,7 @@ TABS.magnetometer.initialize3D = function () {
     if (useWebGlRenderer) {
         if (FC.MIXER_CONFIG.appliedMixerPreset === -1) {
             model_file = 'custom';
-            GUI_control.prototype.log("<span style='color: red; font-weight: bolder'><strong>" + i18n.getMessage("mixerNotConfigured") + "</strong></span>");
+            GUI.log("<span style='color: red; font-weight: bolder'><strong>" + i18n.getMessage("mixerNotConfigured") + "</strong></span>");
         }
         else {
             model_file = mixer.getById(FC.MIXER_CONFIG.appliedMixerPreset).model;


### PR DESCRIPTION
### **User description**
## Summary
Fixes JavaScript `ReferenceError: GUI_control is not defined` that on magnetometer tab, firmware flasher and serial connection flows.

## Changes
Changed 4 instances across 3 files from incorrect `GUI_control.prototype.log()` to correct `GUI.log()`:
- `tabs/magnetometer.js:653` - Magnetometer 3D initialization error message
- `tabs/firmware_flasher.js:829` - Firmware flasher connection error logging
- `js/serial_backend.js:348, 416` - Serial connection restart-required and API version error logging

## Root Cause
Code was calling `GUI_control.prototype.log()` (the constructor prototype method) instead of using the exported singleton instance `GUI.log()`. All other tabs in the codebase correctly use `GUI.log()` - these 4 locations were inconsistent with the established pattern.

___

### **PR Type**
Bug fix


___

### **Description**
- Fix ReferenceError by replacing GUI_control.prototype.log() with GUI.log()

- Corrects 4 instances across 3 files to use singleton pattern

- Affects magnetometer, firmware flasher, and serial backend modules

- Aligns code with established GUI logging pattern throughout codebase


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GUI_control.prototype.log<br/>incorrect calls"] -->|"Replace with"| B["GUI.log<br/>singleton instance"]
  B --> C["js/serial_backend.js<br/>2 instances"]
  B --> D["tabs/firmware_flasher.js<br/>1 instance"]
  B --> E["tabs/magnetometer.js<br/>1 instance"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serial_backend.js</strong><dd><code>Fix GUI logging calls in serial backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/serial_backend.js

<ul><li>Changed <code>GUI_control.prototype.log()</code> to <code>GUI.log()</code> at line 348 for <br>restart-required error message<br> <li> Changed <code>GUI_control.prototype.log()</code> to <code>GUI.log()</code> at line 416 for API <br>version error message<br> <li> Both changes fix ReferenceError in serial connection error handling <br>paths</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2544/files#diff-54b6ea6089bfd0f182476ee7067d8d3eb64a91b752175c572998959c7fdffc8c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firmware_flasher.js</strong><dd><code>Fix GUI logging in firmware flasher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tabs/firmware_flasher.js

<ul><li>Changed <code>GUI_control.prototype.log()</code> to <code>GUI.log()</code> at line 829 for <br>target prefetch error message<br> <li> Fixes ReferenceError when API version check fails during firmware <br>flashing</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2544/files#diff-ef3a8e48ee23e6d39840f6b2b1e7edb3822043ad010417a2ffb627e64a1aaa33">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>magnetometer.js</strong><dd><code>Fix GUI logging in magnetometer tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tabs/magnetometer.js

<ul><li>Changed <code>GUI_control.prototype.log()</code> to <code>GUI.log()</code> at line 653 for mixer <br>configuration error message<br> <li> Fixes ReferenceError during 3D magnetometer initialization when mixer <br>is not configured</ul>


</details>


  </td>
  <td><a href="https://github.com/iNavFlight/inav-configurator/pull/2544/files#diff-4a6f538c3c0b3e778993d86096ae14216ac0f6337c99516eddffcf5d08abd0be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

