### PR TITLE
Fix mission file save error caused by fs module usage

### DIFF
--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -4057,15 +4057,15 @@ function iconKey(filename) {
         var builder = new xml2js.Builder({ 'rootName': 'mission', 'renderOpts': { 'pretty': true, 'indent': '\t', 'newline': '\n' } });
         var xml = builder.buildObject(data);
         xml = xml.replace(/missionitem mission/g, 'meta mission');
-        fs.writeFile(filename, xml, (err) => {
+        window.electronAPI.writeFile(filename, xml).then(err => {
             if (err) {
                 GUI.log(i18n.getMessage('ErrorWritingFile'));
                 return console.error(err);
             }
+            let sFilename = String(filename.split('\\').pop().split('/').pop());
+            GUI.log(sFilename + i18n.getMessage('savedSuccessfully'));
+            updateFilename(sFilename);
         });
-        let sFilename = String(filename.split('\\').pop().split('/').pop());
-        GUI.log(sFilename + i18n.getMessage('savedSuccessfully'));
-        updateFilename(sFilename);
     }
 
     /////////////////////////////////////////////


### PR DESCRIPTION
## Summary
Fixes the "fs is not defined" ReferenceError that occurs when trying to save mission files from the Mission Control tab.

## Problem
Users encountered a JavaScript error when attempting to save mission files:
```
mission_control.js:4050 Uncaught (in promise) ReferenceError: fs is not defined
```

The legacy code was using Node.js `fs.writeFile()` directly from the renderer process, but the `fs` module is not accessible in Electron's renderer process due to context isolation.

## Changes
- Replaced `fs.writeFile()` with `window.electronAPI.writeFile()` 
- Updated from callback pattern to Promise-based API (`.then()`)
- Moved success messages inside `.then()` block to ensure they execute after file write completes

## Testing
- [x] Mission file save dialog opens correctly  
- [x] Files save successfully to selected location
- [x] No console errors during save operation
- [x] Tested with live configurator (yarn start)

This follows the same pattern already used in `cli.js` and other tabs that were previously updated.