### PR TITLE
Fix ADSB vechiles on map in GPS TAB

### DIFF
--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -417,7 +417,7 @@ TABS.gps.initialize = function (callback) {
                             textBaseline: "bottom",
                             offsetY: +40,
                             padding: [2, 2, 2, 2],
-                            backgroundFill: '#444444',
+                            backgroundFill: new Fill({ color: '#444444' }),
                             fill: new Fill({color: '#ffffff'}),
                         })),
                     });


### PR DESCRIPTION
There was JS error

```
ol_layer_Vector__js.js?v=c9f9de37:628 Uncaught TypeError: fillStyle.getColor is not a function
    at CanvasTextBuilder.fillStyleToState (ol_layer_Vector__js.js?v=c9f9de37:628:40)
    at CanvasTextBuilder.drawText (ol_layer_Vector__js.…?v=c9f9de37:1661:78)
    at renderPointGeometry (ol_layer_Vector__js.…?v=c9f9de37:4731:16)
    at renderFeatureInternal (ol_layer_Vector__js.js?v=c9f9de37:4620:5)
    at renderFeature (ol_layer_Vector__js.js?v=c9f9de37:4595:3)
    at CanvasVectorLayerRenderer.renderFeature (ol_layer_Vector__js.…?v=c9f9de37:5294:19)
    at render (ol_layer_Vector__js.…?v=c9f9de37:5230:30)
    at CanvasVectorLayerRenderer.prepareFrame (ol_layer_Vector__js.js?v=c9f9de37:5249:7)
    at VectorLayer.render (chunk-BJC6XOTJ.js?v=44f6a0de:587:23)
    at CompositeMapRenderer.renderFrame (chunk-7B5DBLNC.js?v=44f6a0de:1830:29)
    ```
    
    after fix
    
    
<img width="1337" height="658" alt="image" src="https://github.com/user-attachments/assets/a5977133-df18-40c9-8a7f-d41548dd525d" />
