### PR TITLE
OSD: use LC configured mask

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -2435,10 +2435,12 @@ OSD.reload = function(callback) {
                     OSD.data.supported = true;
                     OSD.msp.decodePreferences(resp);
                     
-                    MSP.promise(MSPCodes.MSP2_INAV_CUSTOM_OSD_ELEMENTS).then(() => { 
+                    MSP.promise(MSPCodes.MSP2_INAV_CUSTOM_OSD_ELEMENTS).then(() => {
                         mspHelper.loadOsdCustomElements(() => {
-                            createCustomElements();
-                            done();
+                            MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_CONFIGURED, false, false, function() {
+                                createCustomElements();
+                                done();
+                            });
                         });
                     });
                 });
@@ -3558,10 +3560,6 @@ TABS.osd = {};
 TABS.osd.initialize = function (callback) {
 
     mspHelper.loadServoMixRules();
-    mspHelper.loadLogicConditions(function() {
-        // Refresh LC dropdowns now that conditions are loaded
-        $('select.lc, select.ico_lc').html(getLCoptions());
-    });
 
     if (GUI.active_tab != 'osd') {
         GUI.active_tab = 'osd';
@@ -4177,13 +4175,16 @@ function getGVoptions(){
 
 function getLCoptions(){
     var result = '';
-    // Return empty if conditions aren't fully loaded yet - callback will refresh
-    if (FC.LOGIC_CONDITIONS.getCount() < FC.LOGIC_CONDITIONS.getMaxLogicConditionCount()) {
+    var mask = FC.LOGIC_CONDITIONS_CONFIGURED_MASK;
+    if (!mask) {
         return result;
     }
-    for(var i = 0; i < FC.LOGIC_CONDITIONS.getMaxLogicConditionCount(); i++) {
-        if (FC.LOGIC_CONDITIONS.isEnabled(i)) {
-            result += `<option value="` + i + `">LC ` + i + `</option>`;
+    for (var i = 0; i < 64; i++) {
+        var isConfigured = (i < 32) ?
+            (mask.lower & (1 << i)) !== 0 :
+            (mask.upper & (1 << (i - 32))) !== 0;
+        if (isConfigured) {
+            result += '<option value="' + i + '">LC ' + i + '</option>';
         }
     }
     return result;

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -2437,7 +2437,10 @@ OSD.reload = function(callback) {
                     
                     MSP.promise(MSPCodes.MSP2_INAV_CUSTOM_OSD_ELEMENTS).then(() => {
                         mspHelper.loadOsdCustomElements(() => {
-                            MSP.send_message(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_CONFIGURED, false, false, function() {
+                            MSP.promise(MSPCodes.MSP2_INAV_LOGIC_CONDITIONS_CONFIGURED).then(() => {
+                                createCustomElements();
+                                done();
+                            }).catch(() => {
                                 createCustomElements();
                                 done();
                             });
@@ -4181,8 +4184,8 @@ function getLCoptions(){
     }
     for (var i = 0; i < 64; i++) {
         var isConfigured = (i < 32) ?
-            (mask.lower & (1 << i)) !== 0 :
-            (mask.upper & (1 << (i - 32))) !== 0;
+            ((mask.lower >>> i) & 1) === 1 :
+            ((mask.upper >>> (i - 32)) & 1) === 1;
         if (isConfigured) {
             result += '<option value="' + i + '">LC ' + i + '</option>';
         }


### PR DESCRIPTION
## Summary
- The OSD tab only needs to know *which* Logic Conditions are enabled (for dropdown selectors) — it never inspects LC content
- Replaces the heavyweight `loadLogicConditions()` call (which fetches up to 64 individual LCs via MSP) with a single `MSP2_INAV_LOGIC_CONDITIONS_CONFIGURED` request that returns an 8-byte bitmask
- Moves the fetch into the `OSD.reload` callback chain so the mask is available before `createCustomElements()` builds the UI

This is an alternative fix for #2552 — same root cause (LC data not loaded when custom element dropdowns are built), but instead of loading all 64 LCs, we only fetch the configured mask since that's all the OSD tab needs.

## Testing
Tested on real hardware (AOCODARCF4V3_SD running INAV 9.0.0):
1. Enabled LC 4 and LC 6 in Programming tab, saved to EEPROM
2. Navigated to OSD tab — LC dropdowns correctly show only LC 4 and LC 6
3. Set custom element 0 visibility to "Logic Condition" -> LC 6, saved
4. Left OSD tab (Status), returned to OSD tab
5. Verified: dropdown shows LC 6 (not LC 0) — bug #2552 is fixed
6. Verified FC data model: {type: 2, value: 6} matches UI
7. Zero console errors throughout

Also tested with no LCs configured — dropdowns are correctly empty.

## Code Review
Reviewed with inav-code-review agent — no critical or important issues found.

Fixes #2552