### PR TITLE
Add error reporting for SITL child process failures

### DIFF
--- a/js/main/child_process.js
+++ b/js/main/child_process.js
@@ -3,17 +3,20 @@ import { spawn } from 'node:child_process'
 const child_process = {
     _processes: [],
 
-    start: function (command, args, opts, window) {        
+    start: function (command, args, opts, window) {
         var process;
         try {
             process = spawn(command, args, opts);
         } catch (err) {
-            console.log(err);
+            console.log(`[child_process] Spawn error: ${err.message}`);
+            if (!window.isDestroyed()) {
+                window.webContents.send('onChildProcessError', { message: `Spawn error: ${err.message}` });
+            }
             return -1;
         }
-        
+
         this._processes.push(process);
-        
+
         process.stdout.on('data', (data) => {
             if (!window.isDestroyed()) {
                 window.webContents.send('onChildProcessStdout', data.toString());
@@ -27,8 +30,15 @@ const child_process = {
         });
 
         process.on('error', (error) => {
+            console.log(`[child_process] Error: ${error.message}`);
             if (!window.isDestroyed()) {
-                window.webContents.send('onChildProcessError', error);
+                window.webContents.send('onChildProcessError', { message: error.message });
+            }
+        });
+
+        process.on('exit', (code, signal) => {
+            if (!window.isDestroyed()) {
+                window.webContents.send('onChildProcessExit', { code, signal });
             }
         });
     },

--- a/js/main/preload.js
+++ b/js/main/preload.js
@@ -95,4 +95,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return handler;
   },
   offChildProcessError: (handler) => ipcRenderer.removeListener('onChildProcessError', handler),
+  onChildProcessExit: (callback) => {
+    const handler = (_event, data) => callback(data);
+    ipcRenderer.on('onChildProcessExit', handler);
+    return handler;
+  },
+  offChildProcessExit: (handler) => ipcRenderer.removeListener('onChildProcessExit', handler),
 });

--- a/js/sitl.js
+++ b/js/sitl.js
@@ -183,17 +183,19 @@ var SITLProcess = {
 
     spawn: function(path, args) {
 
-        var opts = undefined;
-        if (GUI.operating_system == 'Linux')
-            opts = { useShell: true };
-
-        window.electronAPI.startChildProcess(path, args, opts);
-
-        if (this.processHandle == -1) {
+        window.electronAPI.onChildProcessError((error) => {
+            console.log(`SITL error: ${error.message || JSON.stringify(error)}`);
+            GUI.log(`SITL error: ${error.message || JSON.stringify(error)}`);
+        });
+        window.electronAPI.onChildProcessExit((data) => {
+            if (data.code !== 0 && data.code !== null) {
+                console.log(`SITL process exited with code ${data.code}`);
+                GUI.log(`SITL process exited with code ${data.code}`);
+            }
             this.isRunning = false;
-            return;
-        }
+        });
 
+        window.electronAPI.startChildProcess(path, args);
         this.isRunning = true;
     },
 

--- a/js/sitl.js
+++ b/js/sitl.js
@@ -93,8 +93,9 @@ var SitlSerialPortUtils = {
 
 var SITLProcess = {
 
-    spawn : null,
     isRunning: false,
+    _errorHandler: null,
+    _exitHandler: null,
 
     deleteEepromFile(filename) {
         window.electronAPI.rm(`${window.electronAPI.appGetPath('userData')}/${filename}`).then(error => {
@@ -183,11 +184,18 @@ var SITLProcess = {
 
     spawn: function(path, args) {
 
-        window.electronAPI.onChildProcessError((error) => {
+        if (this._errorHandler) {
+            window.electronAPI.offChildProcessError(this._errorHandler);
+        }
+        if (this._exitHandler) {
+            window.electronAPI.offChildProcessExit(this._exitHandler);
+        }
+
+        this._errorHandler = window.electronAPI.onChildProcessError((error) => {
             console.log(`SITL error: ${error.message || JSON.stringify(error)}`);
             GUI.log(`SITL error: ${error.message || JSON.stringify(error)}`);
         });
-        window.electronAPI.onChildProcessExit((data) => {
+        this._exitHandler = window.electronAPI.onChildProcessExit((data) => {
             if (data.code !== 0 && data.code !== null) {
                 console.log(`SITL process exited with code ${data.code}`);
                 GUI.log(`SITL process exited with code ${data.code}`);


### PR DESCRIPTION
### **User description**
SITL spawn errors and unexpected exits were silently swallowed — the renderer never subscribed to child process error/exit events. Users saw only "ECONNREFUSED" with no indication of the actual cause.

- Forward spawn errors and process error events to renderer via IPC
- Add exit event handler to detect abnormal termination
- Log errors to both console and GUI log
- Remove ineffective `useShell` option (not a valid Node.js spawn property)


