### PR TITLE
Add smart rounding for unit-converted display values

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -23,6 +23,49 @@ function padZeros(val, length) {
     return str;
 }
 
+/**
+ * Round a converted value to fewer decimal places when doing so
+ * changes the value by less than 1%. For example, 328.08 ft (from 100m)
+ * becomes "328" and 9842.52 ft becomes "9843". Also rounds to the
+ * nearest 10/100/etc when within 1 of a boundary (e.g. 999 → "1000").
+ * Returns a string like toFixed().
+ */
+function smartRound(value, decimalPlaces) {
+    if (decimalPlaces < 2 || value === 0) {
+        return value.toFixed(decimalPlaces);
+    }
+    // Try removing decimal places (most aggressive first)
+    let best = null;
+    for (let dp = 0; dp <= decimalPlaces - 2; dp++) {
+        let rounded = parseFloat(value.toFixed(dp));
+        if (Math.abs(rounded - value) / Math.abs(value) < 0.01) {
+            best = rounded.toFixed(dp);
+            break;
+        }
+    }
+    // Try rounding to nearest 10, 100, etc. but only when the integer
+    // value is within 1 of a boundary (e.g. 999->1000, 1001->1000).
+    // Use absolute values for boundary detection to handle negatives.
+    if (best !== null) {
+        let intVal = Math.round(Math.abs(value));
+        for (let mag = 1; mag <= 3; mag++) {
+            let factor = Math.pow(10, mag);
+            let remainder = intVal % factor;
+            if (remainder <= 1 || remainder >= factor - 1) {
+                let rounded = Math.sign(value) * Math.round(Math.abs(value) / factor) * factor;
+                if (Math.abs(rounded - value) / Math.abs(value) < 0.01) {
+                    best = rounded.toFixed(0);
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+    }
+    return best !== null ? best : value.toFixed(decimalPlaces);
+}
+
 var Settings = (function () {
     let self = {};
 
@@ -534,7 +577,7 @@ var Settings = (function () {
             let mins = oldValue - (hours*60);
             newValue = ((hours < 0) ? padZeros(hours, 3) : padZeros(hours, 2)) + ':' + padZeros(mins, 2);
         } else {
-            newValue = Number((oldValue / multiplier)).toFixed(decimalPlaces);
+            newValue = smartRound(Number(oldValue / multiplier), decimalPlaces);
         }
 
         element.val(newValue);
@@ -688,3 +731,4 @@ var Settings = (function () {
 })();
 
 export default  Settings;
+export { smartRound };

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -11,7 +11,7 @@ import { GUI, TABS } from './../js/gui';
 import MSP from './../js/msp';
 import MSPCodes from './../js/msp/MSPCodes';
 import mspHelper from './../js/msp/MSPHelper';
-import Settings from './../js/settings';
+import Settings, { smartRound } from './../js/settings';
 import { globalSettings } from './../js/globalSettings';
 import { PortHandler } from './../js/port_handler';
 import i18n from './../js/localization';
@@ -769,10 +769,10 @@ OSD.constants = {
                     case 0: // Imperial
                     case 3: // UK
                         // meters to miles
-                        return (value / 1609.344).toFixed(2);
+                        return smartRound(value / 1609.344, 2);
                     case 4: // GA
                         // metres to nautical miles
-                        return (value / 1852.001).toFixed(2);
+                        return smartRound(value / 1852.001, 2);
                     default: // Metric
                         return value;
                 }


### PR DESCRIPTION
## Summary

The displayed unit-converted values showed excessive decimal precision from conversion that no user would intentionally set. For example, Setting 1000 feet displays 1000.66 feet.  An altitude alarm of 100m displayed as "328.08 ft" and an ADSB distance alert of 3000m displayed as "9842.52 ft".  


This adds a `smartRound()` function that:
1. Removes unnecessary decimal places when rounding changes the value by less than 1%
2. Snaps to nearby round numbers (e.g. 999.02 -> 1000) when the integer is within 1 of a 10/100/1000 boundary, if doing so is within 1% margin

## Before / After

| Field | Before | After |
|-------|--------|-------|
| Altitude alarm (100m) | 328.08 ft | **328 ft** |
| ADSB distance alert (3000m) | 9842.52 ft | **9843 ft** |
| ADSB distance warning (20000m) | 65616.80 ft | **65617 ft** |
| Negative altitude (5m) | 16.40 ft | 16.40 ft (unchanged - precision matters) |
| Distance alarm (1km) | 0.62 mi | 0.62 mi (unchanged - precision matters) |

## Changes

- `js/settings.js`: Add `smartRound()` function and apply it to unit-converted input values
- `tabs/osd.js`: Apply `smartRound()` to OSD distance alarm display (miles/NM conversion)

## Testing

- Built configurator successfully
- Connected to SITL in Imperial unit mode
- Verified OSD alarm fields display clean rounded values
- Verified small values retain necessary precision (16.40 ft, 0.62 mi)
- Verified negative values round correctly
- No functional change to stored values
