### PR TITLE
Trigger CI build for 9.0.2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "inav-configurator",
   "productName": "INAV Configurator",
-  "description": "Configurator for the open source flight controller software INAV.",
+  "description": "Configurator for the open source flight controller firmware INAV.",
   "version": "9.0.2",
   "main": ".vite/build/main.js",
   "type": "module",


### PR DESCRIPTION
CI build trigger for 9.0.2 release artifacts. Includes:
- #2522 Firmware flasher target matching fix
- #2559 OSD LC configured mask fix
- Version bump to 9.0.2