### PR TITLE
LED strip: send only configured LED slots when saving

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -2766,20 +2766,25 @@ var mspHelper = (function () {
         }
     };
 
-    self.sendLedStripConfig = function (onCompleteCallback) {
+    self.sendLedStripConfig = function (onCompleteCallback, slotsToSend) {
 
-        var nextFunction = send_next_led_strip_config;
-
-        var ledIndex = 0;
-
-        if (FC.LED_STRIP.length == 0) {
-            onCompleteCallback();
-        } else {
-            send_next_led_strip_config();
+        var indicesToSend = [];
+        for (var i = 0; i < FC.LED_STRIP.length; i++) {
+            if (!slotsToSend || slotsToSend.has(i)) {
+                indicesToSend.push(i);
+            }
         }
 
-        function send_next_led_strip_config() {
+        if (indicesToSend.length === 0) {
+            onCompleteCallback();
+            return;
+        }
 
+        var position = 0;
+        send_next_led_strip_config();
+
+        function send_next_led_strip_config() {
+            var ledIndex = indicesToSend[position];
             var led = FC.LED_STRIP[ledIndex];
             /*
              var led = {
@@ -2849,10 +2854,8 @@ var mspHelper = (function () {
             buffer.push(BitHelper.specificByte(extra, 0));
 
             // prepare for next iteration
-            ledIndex++;
-            if (ledIndex == FC.LED_STRIP.length) {
-                nextFunction = onCompleteCallback;
-            }
+            position++;
+            var nextFunction = (position === indicesToSend.length) ? onCompleteCallback : send_next_led_strip_config;
 
             MSP.send_message(MSPCodes.MSP2_INAV_SET_LED_STRIP_CONFIG_EX, buffer, false, nextFunction);
         }

--- a/tabs/led_strip.js
+++ b/tabs/led_strip.js
@@ -49,6 +49,20 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     load_led_config();
 
 
+    function isLedSlotConfigured(led) {
+        if (!led) return false;
+        // Normalize functions and directions to strings — they are arrays in MSP-received data,
+        // strings in UI/preset data.
+        var fnStr = Array.isArray(led.functions) ? led.functions.join('') : (led.functions || '');
+        var dirStr = Array.isArray(led.directions) ? led.directions.join('') : (led.directions || '');
+        if (led.x === 0 && led.y === 0 && dirStr === '') {
+            if (fnStr === '') return false;                       // UI/preset empty slot
+            if (fnStr === 'c' && led.color == 0) return false;  // MSP empty slot (Color-only, no overlays)
+            // Note: loose == for color because DOM parsing yields a string ("0") while MSP yields a number (0)
+        }
+        return true;
+    }
+
     function buildUsedWireNumbers() {
         var usedWireNumbers = [];
         $('.mainGrid .gPoint .wire').each(function () {
@@ -90,7 +104,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         // Re-populate from FC.LED_STRIP
         for (var ledIndex = 0; ledIndex < FC.LED_STRIP.length; ledIndex++) {
             var led = FC.LED_STRIP[ledIndex];
-            if (!led || (led.functions === '' && led.directions === '' && led.x === 0 && led.y === 0)) continue;
+            if (!isLedSlotConfigured(led)) continue;
 
             var gridIndex = led.y * 16 + led.x;
             var cell = $('.gPoint').eq(gridIndex);
@@ -198,6 +212,11 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     }
 
     function process_html() {
+
+        var initialConfiguredSlots = new Set();
+        for (var i = 0; i < FC.LED_STRIP.length; i++) {
+            if (isLedSlotConfigured(FC.LED_STRIP[i])) initialConfiguredSlots.add(i);
+        }
 
        i18n.localize();;
 
@@ -730,7 +749,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
             var ledIndex = ledResult.index;
             var led = ledResult.led;
 
-            if (led.functions[0] == 'c' && led.functions.length == 1 && led.directions.length == 0 && led.color == 0 && led.x == 0 && led.y == 0) {
+            if (!isLedSlotConfigured(led)) {
                 return;
             }
 
@@ -750,7 +769,13 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
 
         $('a.save').on('click', function () {
 
-            mspHelper.sendLedStripConfig(send_led_strip_colors);
+            var currentConfiguredSlots = new Set();
+            for (var i = 0; i < FC.LED_STRIP.length; i++) {
+                if (isLedSlotConfigured(FC.LED_STRIP[i])) currentConfiguredSlots.add(i);
+            }
+            var slotsToSend = new Set([...initialConfiguredSlots, ...currentConfiguredSlots]);
+
+            mspHelper.sendLedStripConfig(send_led_strip_colors, slotsToSend);
 
             function send_led_strip_colors() {
                 mspHelper.sendLedStripColors(send_led_strip_mode_colors);


### PR DESCRIPTION
## Summary

When saving LED strip configuration, the configurator was sending `MSP2_INAV_SET_LED_STRIP_CONFIG_EX` for every possible LED slot unconditionally — up to 128 messages even when only a few LEDs were configured. This unnecessarily stressed the serial link and increased the window during which a disconnect could leave the FC in an inconsistent state.

## Changes

- Added `isLedSlotConfigured()` helper in `tabs/led_strip.js` that correctly detects empty slots in both MSP array format (`functions: ['c']`) and UI string format (`functions: ''`)
- The save handler now computes the union of slots configured before and after the editing session, and passes that `Set` to `sendLedStripConfig()`
- `sendLedStripConfig()` in `MSPHelper.js` accepts an optional `slotsToSend` Set parameter; when provided, only those slots are transmitted (backwards compatible — omitting the parameter sends all slots as before)
- Unified the duplicate empty-slot detection logic in `redrawGridFromFC()` and the initial grid drawing to use the new helper

## Testing

- Tested on RP2350 PICO hardware running INAV 9.0.0
- With 20 LEDs configured: Save now sends exactly 20 `MSP2_INAV_SET_LED_STRIP_CONFIG_EX` messages (previously sent 102)
- Verified LED configuration persists correctly after save and reconnect
- Verified no regressions in LED grid display or preset application