### PR TITLE
Fix mixer tab motor direction arrow not reflecting Props Out on load

### DIFF
--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -569,7 +569,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         saveChainer.execute();
     }
 
-    function processHtml() {
+    function processHtml(settingsPromise) {
 
         $servoMixTable = $('#servo-mix-table');
         $servoMixTableBody = $servoMixTable.find('tbody');
@@ -747,6 +747,9 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         } else {
             $mixerPreset.trigger('change');
         }
+
+        // Re-run after settings load, since configureInputs() is async.
+        settingsPromise.then(() => updateMotorDirection());
 
         modal = new jBox('Modal', {
             width: 480,


### PR DESCRIPTION
## Summary

When a flight controller has **Props Out** (reversed motor direction) configured, the motor spin direction arrows on the Mixer tab showed the wrong direction on page load. The Outputs tab was unaffected and showed the correct arrows.

## Root Cause

`Settings.configureInputs()` populates `data-setting` form elements (including the `motor_direction_inverted` radio buttons) via async MSP requests. `Settings.processHtml()` calls the tab's init callback immediately — before those requests complete:

```js
// settings.js
self.processHtml = function(callback) {
    return function() {
        const settingsPromise = self.configureInputs(); // async
        callback(settingsPromise);                      // called immediately
    };
};
```

The mixer preset `change` event fires synchronously during init and calls `updateMotorDirection()`, which reads the radio button value — but the button hasn't been set yet. It defaults to the normal (non-reversed) image regardless of the FC setting.

## Fix

Accept `settingsPromise` in `processHtml()` and re-run `updateMotorDirection()` after it resolves, so the arrow reflects the actual FC setting once it arrives.

## Changes

- `tabs/mixer.js` — accept `settingsPromise` parameter in `processHtml()`; re-call `updateMotorDirection()` after promise resolves

## Related

Fixes https://github.com/iNavFlight/inav/issues/11316