### PR TITLE
fix: sync JS programming framework constants with firmware

### DIFF
--- a/js/logicConditionOperantTypes.js
+++ b/js/logicConditionOperantTypes.js
@@ -93,6 +93,7 @@ const OPERAND_TYPES = {
             13: "USER 4",
             14: "Acro",
             15: "Waypoint Mission",
+            16: "Angle Hold",
         }
     },
     4: {

--- a/js/transpiler/transpiler/inav_constants.js
+++ b/js/transpiler/transpiler/inav_constants.js
@@ -272,6 +272,7 @@ const OPERATION_NAMES = {
   [53]: 'Disable Gps Fix',
   [54]: 'Reset Mag Calibration',
   [55]: 'Set Gimbal Sensitivity',
+  [56]: 'Override Min Ground Speed',
 };
 
 /**


### PR DESCRIPTION
## Summary

Fills two missing entries in the JavaScript programming framework lookup tables to match firmware definitions:

- **Angle Hold flight mode** missing from the classic Programming tab. Firmware defines `LOGIC_CONDITION_OPERAND_FLIGHT_MODE_ANGLEHOLD = 16` but it was absent from `logicConditionOperantTypes.js`, so users could not select it as a flight mode operand in the Logic Conditions UI.
- **Override Min Ground Speed name** missing from `OPERATION_NAMES` in `inav_constants.js`. `OPERATION.OVERRIDE_MIN_GROUND_SPEED = 56` was present but the human-readable name entry `[56]` was absent, causing `'unknown_operation_56'` in transpiler warning messages.

## Changes

- `js/logicConditionOperantTypes.js` — Add `16: "Angle Hold"` to flight mode operand dictionary
- `js/transpiler/transpiler/inav_constants.js` — Add `[56]: 'Override Min Ground Speed'` to `OPERATION_NAMES`

## Testing

- All 28 transpiler unit tests pass (`run_all_tests.cjs`)
- Full configurator build succeeds (Vite + Electron Forge, linux/x64)
- Angle Hold now appears in the flight mode selector in the Logic Conditions tab
- `inav.override.minGroundSpeed` decompiles correctly in the JS Programming tab (confirmed via screenshot)

## Code Review

Reviewed with inav-code-review agent — no critical or important issues found. Both numeric keys verified against firmware `logic_condition.h`.

## Documentation

No documentation changes needed (bug fixes — missing UI entries).