### PR TITLE
led tab: separate presets, keep grid in easy reach

### DIFF
--- a/src/css/tabs/led_strip.css
+++ b/src/css/tabs/led_strip.css
@@ -23,6 +23,7 @@
     border-radius: 3px;
     background-color: #dcdcdc;
     border: silver;
+    margin-top: 4em;
 }
 
 .tab-led-strip .mainGrid .gPoint {
@@ -432,6 +433,10 @@
 /* Quick Layouts */
 .tab-led-strip .quick-layouts {
     margin: 8px 0;
+    width: 50%;
+    margin-bottom: 2em;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .tab-led-strip .quick-layouts .color_section {

--- a/tabs/led_strip.html
+++ b/tabs/led_strip.html
@@ -6,6 +6,15 @@
                 <p i18n="ledStripHelp"></p>
             </div>
         </div>
+
+
+        <div class="quick-layouts">
+            <div class="section step-header">Quick Presets:</div>
+            <button class="quickLayout" data-layout="xframe">X-Frame Quad</button>
+            <button class="quickLayout" data-layout="crossframe">Cross-Frame Quad</button>
+            <button class="quickLayout" data-layout="wing">Wing</button>
+        </div>
+
         <div class="gridColumn">
             <div class="mainGrid"></div>
             <div class="gridSections">
@@ -50,12 +59,6 @@
             </div>
         </div>
         <div class="controls">
-            <div class="quick-layouts">
-                <div class="section step-header">Quick Presets:</div>
-                <button class="quickLayout" data-layout="xframe">X-Frame Quad</button>
-                <button class="quickLayout" data-layout="crossframe">Cross-Frame Quad</button>
-                <button class="quickLayout" data-layout="wing">Wing</button>
-            </div>
 
             <div class="step-section" data-step-section="1">
                 <div class="section step-header"><span class="circle-number">① </span>Wire Ordering


### PR DESCRIPTION
Moves quick presets for clearer separation.
Moves the grid down slightly so it is within easy reach while setting colors.

<img width="1215" height="818" alt="image" src="https://github.com/user-attachments/assets/f7637e36-f159-41f5-987c-c078cb3cf09f" />
