### PR TITLE
mixer: fix preview image not showing reversed on page load

### DIFF
--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -569,7 +569,7 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         saveChainer.execute();
     }
 
-    function processHtml() {
+    function processHtml(settingsPromise) {
 
         $servoMixTable = $('#servo-mix-table');
         $servoMixTableBody = $servoMixTable.find('tbody');
@@ -845,6 +845,12 @@ TABS.mixer.initialize = function (callback, scrollPosition) {
         i18n.localize();;
 
         interval.add('logic_conditions_pull', getLogicConditionsStatus, 350);
+
+        // configureInputs() populates radio buttons asynchronously via MSP.
+        // The synchronous $mixerPreset.trigger('change') above fires before
+        // those requests complete, so re-run once the real values are in.
+        settingsPromise.then(() => updateMotorDirection())
+            .catch((error) => console.error('Settings load failed, motor direction not updated:', error));
 
         GUI.content_ready(callback);
     }


### PR DESCRIPTION
## Summary

On the Mixer tab, when the FC has `motor_direction_inverted` set to ON, the props-out (reversed) preview image was not shown on initial page load — only the props-in image appeared. Toggling the radio button manually would correctly swap it, but the on-load state was incorrect.

## Root cause

`Settings.processHtml` calls `configureInputs()` to populate `data-setting` inputs via async MSP requests, then immediately calls the tab callback without waiting for those requests to complete. Inside `processHtml`, `$mixerPreset.trigger('change')` fires the preset change handler synchronously, which calls `updateMotorDirection()`. At that point the `motor_direction_inverted` radio buttons have not been set yet (still at their HTML default), so the wrong image is loaded.

## Changes

- `tabs/mixer.js`: Accept the `settingsPromise` parameter that `Settings.processHtml` already passes to every tab callback, and call `updateMotorDirection()` again once it resolves so the correct image is shown after the MSP setting values arrive.

This matches the existing pattern used in `receiver.js` and `configuration.js` for the same class of async timing issue.

## Testing

- Verified root cause via code inspection: `configureInputs()` is async, callback fires before radio buttons are populated
- Verified fix mechanism via browser console: promise `.then()` fires after radio buttons are set
- Set `motor_direction_inverted = ON` on physical FC (RP2350_PICO, INAV 9.0.0) to reproduce; fix confirmed correct by code review
- Manual toggle of the Motor Direction radio buttons continues to work correctly (change event handlers unaffected)