### PR TITLE
Grid Survey Pattern Generator, Quickly See Heading and RTH Icons along with new Keyboard Navigation

### DIFF
--- a/images/icons/cf_icon_MP_grid_grey.svg
+++ b/images/icons/cf_icon_MP_grid_grey.svg
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 141.7 141.7" version="1.1">
-  <!-- Grid pattern icon: polygon outline with parallel survey lines inside -->
+  <!-- Grid pattern icon: polygon outline with lawnmower survey lines inside -->
   <g fill="none" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
-    <!-- Outer polygon (survey area boundary) -->
-    <polygon points="25,115 20,40 70,15 125,35 120,120" />
-    <!-- Parallel survey lines (lawnmower pattern) -->
-    <polyline points="35,100 40,45 60,38 60,108" />
-    <polyline points="60,108 80,32 80,105" />
-    <polyline points="80,105 100,38 105,100" />
+    <!-- Outer rectangle (survey area boundary) -->
+    <rect x="20" y="20" width="102" height="102" />
+    <!-- Lawnmower pattern: horizontal lines with U-turns -->
+    <polyline points="30,40 112,40 112,60 30,60 30,80 112,80 112,100 30,100" />
   </g>
 </svg>

--- a/images/icons/cf_icon_MP_grid_grey.svg
+++ b/images/icons/cf_icon_MP_grid_grey.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 141.7 141.7" version="1.1">
+  <!-- Grid pattern icon: polygon outline with parallel survey lines inside -->
+  <g fill="none" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Outer polygon (survey area boundary) -->
+    <polygon points="25,115 20,40 70,15 125,35 120,120" />
+    <!-- Parallel survey lines (lawnmower pattern) -->
+    <polyline points="35,100 40,45 60,38 60,108" />
+    <polyline points="60,108 80,32 80,105" />
+    <polyline points="80,105 100,38 105,100" />
+  </g>
+</svg>

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6306,6 +6306,49 @@
   },
   "javascriptCompleteExample": {
     "message": "Complete Example"
+  },
+
+  "missionGridPatternTitle": {
+    "message": "Generate grid survey pattern (Ctrl+G)"
+  },
+  "missionGridDrawPrompt": {
+    "message": "Click on the map to draw a survey area polygon. Double-click to finish. Press Escape to cancel."
+  },
+  "missionGridSettingsTitle": {
+    "message": "Grid Survey Settings"
+  },
+  "missionGridSpacing": {
+    "message": "Line Spacing"
+  },
+  "missionGridAltitude": {
+    "message": "Altitude"
+  },
+  "missionGridSpeed": {
+    "message": "Speed"
+  },
+  "missionGridAngle": {
+    "message": "Sweep Angle"
+  },
+  "missionGridOvershoot": {
+    "message": "Overshoot"
+  },
+  "missionGridEndRTH": {
+    "message": "End with RTH"
+  },
+  "missionGridPreview": {
+    "message": "Preview"
+  },
+  "missionGridGenerate": {
+    "message": "Generate"
+  },
+  "missionGridNoWaypoints": {
+    "message": "No waypoints generated. Try adjusting spacing or area."
+  },
+  "missionGridWaypointCount": {
+    "message": "Waypoints: $1 (remaining capacity: $2)"
+  },
+  "missionGridTooManyWaypoints": {
+    "message": "Grid needs $1 waypoints but only $2 slots remaining. Reduce area or increase spacing."
   }
 
 }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -4967,6 +4967,9 @@
     "confirm_delete_all_points": {
         "message": "Do you really want to delete all points?"
     },
+    "confirm_delete_selected_point": {
+        "message": "Delete this waypoint?"
+    },
     "confirm_delete_point_with_options": {
         "message": "Do you really want to delete this Waypoint with non-Geo JUMP/SET_HEAD/RTH options? \nIf yes, Non-Geo options attached will be removed also!"
     },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6338,9 +6338,6 @@
   "missionGridEndRTH": {
     "message": "End with RTH"
   },
-  "missionGridPreview": {
-    "message": "Preview"
-  },
   "missionGridGenerate": {
     "message": "Generate"
   },

--- a/src/css/tabs/mission_planer.css
+++ b/src/css/tabs/mission_planer.css
@@ -101,6 +101,10 @@
     background-image: url(./../../../images/icons/search-white.svg);
 }
 
+.tab-mission-control .ic_grid {
+    background-image: url(./../../../images/icons/cf_icon_MP_grid_grey.svg);
+}
+
 .tab-mission-control .ic_setup {
     background-image: url(./../../../images/icons/cf_icon_setup_white.svg);
 }

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -49,6 +49,52 @@
                             href="#"
                             title="Center map on latest GPS fix (Ctrl+C)"></a>
                         </div>
+
+                        <div id="gridPattern" class="btn btn-default" style="padding-top: 1px; display: inline-block; cursor: pointer; float: left;">
+                            <a id="gridPatternButton"
+                            class="btnicon ic_grid"
+                            href="#"
+                            i18n_title="missionGridPatternTitle"></a>
+                        </div>
+                    </div>
+                </div>
+
+                <div id="missionPlannerGridSettings" class="gui_box grey" style="display: none;">
+                    <div class="gui_box_titlebar">
+                        <div class="spacer_box_title" data-i18n="missionGridSettingsTitle"></div>
+                        <div class="btnMenu btnMenuIcon save_btn">
+                            <a id="gridCancel" class="ic_cancel" href="#" i18n_title="missionSettingsCancel"></a>
+                        </div>
+                    </div>
+                    <div class="spacer" id="gridSettingsContent">
+                        <div class="point">
+                            <label class="point-label" for="gridSpacing" data-i18n="missionGridSpacing"></label>
+                            <input id="gridSpacing" type="number" value="25" min="5" max="1000" step="5"> m
+                        </div>
+                        <div class="point">
+                            <label class="point-label" for="gridAltitude" data-i18n="missionGridAltitude"></label>
+                            <input id="gridAltitude" type="number" value="50" min="5" max="5000" step="5"> m
+                        </div>
+                        <div class="point">
+                            <label class="point-label" for="gridSpeed" data-i18n="missionGridSpeed"></label>
+                            <input id="gridSpeed" type="number" value="0" min="0" max="100" step="1"> m/s
+                        </div>
+                        <div class="point">
+                            <label class="point-label" for="gridAngle" data-i18n="missionGridAngle"></label>
+                            <input id="gridAngle" type="number" value="0" min="0" max="359" step="1"> &deg;
+                        </div>
+                        <div class="point">
+                            <label class="point-label" for="gridOvershoot" data-i18n="missionGridOvershoot"></label>
+                            <input id="gridOvershoot" type="number" value="0" min="0" max="200" step="5"> m
+                        </div>
+                        <div class="point">
+                            <label class="point-label" for="gridEndRTH" data-i18n="missionGridEndRTH"></label>
+                            <input id="gridEndRTH" type="checkbox" checked>
+                        </div>
+                        <div id="gridWaypointCount" style="margin-top:4px;margin-left:5px;font-size:0.9em;color:#666;"></div>
+                        <div style="margin-top:8px;text-align:right;padding-right:5px;">
+                            <button id="gridGenerate" class="default_btn" data-i18n="missionGridGenerate" style="background:#007cba;color:#fff;border:none;padding:4px 14px;cursor:pointer;"></button>
+                        </div>
                     </div>
                 </div>
 

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -72,7 +72,7 @@
                     <div class="spacer" id="gridSettingsContent">
                         <div class="point">
                             <label class="point-label" for="gridSpacing" data-i18n="missionGridSpacing">Grid spacing</label>
-                            <input id="gridSpacing" type="number" value="25" min="5" max="1000" step="5"> m
+                            <input id="gridSpacing" type="number" value="100" min="5" max="1000" step="5"> m
                         </div>
                         <div class="point">
                             <label class="point-label" for="gridAltitude" data-i18n="missionGridAltitude">Grid altitude</label>

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -40,21 +40,24 @@
                             <a id="searchAddressButton"
                             class="btnicon ic_search"
                             href="#"
-                            title="Search for address (Ctrl+A)"></a>
+                            title="Search for address (Ctrl+A)"
+                            aria-label="Search for address (Ctrl+A)"><span class="sr-only">Search for address</span></a>
                         </div>
 
                         <div id="centerOnDrone" class="btn btn-default" style="padding-top: 1px; display: inline-block; cursor: pointer; float: left; opacity: 0.45; pointer-events: none;">
                             <a id="centerOnDroneButton"
                             class="btnicon ic_center"
                             href="#"
-                            title="Center map on latest GPS fix (Ctrl+C)"></a>
+                            title="Center map on latest GPS fix (Ctrl+C)"
+                            aria-label="Center map on latest GPS fix (Ctrl+C)"><span class="sr-only">Center map on latest GPS fix</span></a>
                         </div>
 
                         <div id="gridPattern" class="btn btn-default" style="padding-top: 1px; display: inline-block; cursor: pointer; float: left;">
                             <a id="gridPatternButton"
                             class="btnicon ic_grid"
                             href="#"
-                            i18n_title="missionGridPatternTitle"></a>
+                            i18n_title="missionGridPatternTitle"
+                            aria-label="Grid survey pattern"><span class="sr-only" data-i18n="missionGridPatternTitle">Grid survey pattern</span></a>
                         </div>
                     </div>
                 </div>
@@ -63,32 +66,32 @@
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title" data-i18n="missionGridSettingsTitle"></div>
                         <div class="btnMenu btnMenuIcon save_btn">
-                            <a id="gridCancel" class="ic_cancel" href="#" i18n_title="missionSettingsCancel"></a>
+                            <a id="gridCancel" class="ic_cancel" href="#" i18n_title="missionSettingsCancel" aria-label="Cancel grid settings"><span class="sr-only" data-i18n="missionSettingsCancel">Cancel</span></a>
                         </div>
                     </div>
                     <div class="spacer" id="gridSettingsContent">
                         <div class="point">
-                            <label class="point-label" for="gridSpacing" data-i18n="missionGridSpacing"></label>
+                            <label class="point-label" for="gridSpacing" data-i18n="missionGridSpacing">Grid spacing</label>
                             <input id="gridSpacing" type="number" value="25" min="5" max="1000" step="5"> m
                         </div>
                         <div class="point">
-                            <label class="point-label" for="gridAltitude" data-i18n="missionGridAltitude"></label>
+                            <label class="point-label" for="gridAltitude" data-i18n="missionGridAltitude">Grid altitude</label>
                             <input id="gridAltitude" type="number" value="50" min="5" max="5000" step="5"> m
                         </div>
                         <div class="point">
-                            <label class="point-label" for="gridSpeed" data-i18n="missionGridSpeed"></label>
+                            <label class="point-label" for="gridSpeed" data-i18n="missionGridSpeed">Grid speed</label>
                             <input id="gridSpeed" type="number" value="0" min="0" max="100" step="1"> m/s
                         </div>
                         <div class="point">
-                            <label class="point-label" for="gridAngle" data-i18n="missionGridAngle"></label>
+                            <label class="point-label" for="gridAngle" data-i18n="missionGridAngle">Grid angle</label>
                             <input id="gridAngle" type="number" value="0" min="0" max="359" step="1"> &deg;
                         </div>
                         <div class="point">
-                            <label class="point-label" for="gridOvershoot" data-i18n="missionGridOvershoot"></label>
+                            <label class="point-label" for="gridOvershoot" data-i18n="missionGridOvershoot">Grid overshoot</label>
                             <input id="gridOvershoot" type="number" value="0" min="0" max="200" step="5"> m
                         </div>
                         <div class="point">
-                            <label class="point-label" for="gridEndRTH" data-i18n="missionGridEndRTH"></label>
+                            <label class="point-label" for="gridEndRTH" data-i18n="missionGridEndRTH">End with return to home</label>
                             <input id="gridEndRTH" type="checkbox" checked>
                         </div>
                         <div id="gridWaypointCount" style="margin-top:4px;margin-left:5px;font-size:0.9em;color:#666;"></div>

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -30,6 +30,7 @@ import RegularShape from 'ol/style/RegularShape';
 import Circle from 'ol/geom/Circle';
 import PointerInteraction from 'ol/interaction/Pointer.js';
 import Draw from 'ol/interaction/Draw.js';
+import Overlay from 'ol/Overlay.js';
 import {defaults as defaultInteractions} from 'ol/interaction/defaults';
 import {Control, defaults as defaultControls} from 'ol/control.js';
 
@@ -1657,7 +1658,30 @@ function iconKey(filename) {
                 }
             }
             else if (element.isAttached()) {
-                if (element.getAction() == MWNP.WPTYPE.JUMP) {
+                if (element.getAction() == MWNP.WPTYPE.RTH && typeof oldPos !== 'undefined') {
+                    // Green RTH marker at the last waypoint position
+                    var rthMarker = new Feature({ geometry: new Point(oldPos) });
+                    rthMarker.setStyle(new Style({
+                        image: new RegularShape({
+                            fill: new Fill({ color: '#00c850' }),
+                            stroke: new Stroke({ color: '#fff', width: 2 }),
+                            points: 32,
+                            radius: 10,
+                        }),
+                        text: new Text({
+                            text: 'RTH',
+                            font: 'bold 9px sans-serif',
+                            fill: new Fill({ color: '#fff' }),
+                        }),
+                    }));
+                    var rthSource = new VectorSource({ features: [rthMarker] });
+                    var rthLayer = new VectorLayer({ source: rthSource });
+                    rthLayer.kind = "rth";
+                    rthLayer.selection = false;
+                    lines.push(rthLayer);
+                    map.addLayer(rthLayer);
+                }
+                else if (element.getAction() == MWNP.WPTYPE.JUMP) {
                     let jumpWPIndex = multiMissionWPNum + element.getP1();
                     let coord = fromLonLat([mission.getWaypoint(jumpWPIndex).getLonMap(), mission.getWaypoint(jumpWPIndex).getLatMap()]);
                     paintLine(oldPos, coord, element.getNumber(), '#e935d6', 5, "Repeat x"+(element.getP2() == -1 ? " infinite" : String(element.getP2())), false, true);
@@ -2273,6 +2297,7 @@ function iconKey(filename) {
          */
         app.handleDownEvent = function (evt) {
             if (disableMarkerEdit) return false;
+            addWpTooltipEl.style.display = 'none';
 
             var map = evt.map;
 
@@ -2373,22 +2398,30 @@ function iconKey(filename) {
          * @param {ol.MapBrowserEvent} evt Event.
          */
         app.handleMoveEvent = function (evt) {
-            if (this.cursor_) {
-                var map = evt.map;
-                var feature = map.forEachFeatureAtPixel(evt.pixel,
-                    function (feature, layer) {
-                        return feature;
-                    });
-                var element = evt.map.getTargetElement();
-                if (feature && feature.name != "circleFeature" && feature.name != "circleSafeFeature") {
-                    if (element.style.cursor != this.cursor_) {
-                        this.previousCursor_ = element.style.cursor;
-                        element.style.cursor = this.cursor_;
-                    }
-                } else if (this.previousCursor_ !== undefined) {
-                    element.style.cursor = this.previousCursor_;
-                    this.previousCursor_ = undefined;
+            var map = evt.map;
+            var feature = map.forEachFeatureAtPixel(evt.pixel,
+                function (feature, layer) {
+                    return feature;
+                });
+            var hoverLayer = map.forEachFeatureAtPixel(evt.pixel,
+                function (feature, layer) {
+                    return layer;
+                });
+            var element = evt.map.getTargetElement();
+            var isLine = hoverLayer && hoverLayer.kind === 'line' && hoverLayer.selection;
+
+            if (feature && feature.name != "circleFeature" && feature.name != "circleSafeFeature") {
+                if (isLine) {
+                    element.style.cursor = 'crosshair';
+                    addWpTooltipEl.style.display = '';
+                    addWpOverlay.setPosition(evt.coordinate);
+                } else {
+                    element.style.cursor = 'pointer';
+                    addWpTooltipEl.style.display = 'none';
                 }
+            } else {
+                element.style.cursor = '';
+                addWpTooltipEl.style.display = 'none';
             }
         };
 
@@ -2542,6 +2575,30 @@ function iconKey(filename) {
         setTimeout(function() {
             $('.ol-attribution a').attr('target', '_blank');
         }, 100);
+        // "Add WP" tooltip overlay shown when hovering on a flight path line
+        var addWpTooltipEl = document.createElement('div');
+        addWpTooltipEl.className = 'add-wp-tooltip';
+        addWpTooltipEl.innerHTML = '<span style="font-size:1.1em;font-weight:bold;">＋</span> Add WP';
+        Object.assign(addWpTooltipEl.style, {
+            background: 'rgba(20,151,241,0.9)',
+            color: '#fff',
+            padding: '3px 8px',
+            borderRadius: '4px',
+            fontSize: '0.85em',
+            fontFamily: 'sans-serif',
+            whiteSpace: 'nowrap',
+            pointerEvents: 'none',
+            boxShadow: '0 1px 4px rgba(0,0,0,0.3)',
+            display: 'none',
+        });
+        var addWpOverlay = new Overlay({
+            element: addWpTooltipEl,
+            offset: [12, -12],
+            positioning: 'bottom-left',
+            stopEvent: false,
+        });
+        map.addOverlay(addWpOverlay);
+
         //////////////////////////////////////////////////////////////////////////
         // save map view settings when user moves it
         //////////////////////////////////////////////////////////////////////////
@@ -4092,6 +4149,9 @@ function iconKey(filename) {
 
             hideGridCard();
             cancelGridDraw();
+
+            // Auto-select first waypoint
+            selectWaypointByLayerNumber(0);
         });
 
         /**
@@ -4259,10 +4319,123 @@ function iconKey(filename) {
                 e.preventDefault();
                 startGridPolygonDraw();
             }
+
+            // Delete key: delete selected waypoint with confirmation
+            if (key === 'delete' && selectedMarker && !$(e.target).is('input, select, textarea')) {
+                e.preventDefault();
+                if (dialog.confirm(i18n.getMessage('confirm_delete_selected_point'))) {
+                    $('#removePoint').trigger('click');
+                }
+            }
+
+            // Left/Right arrow keys: navigate between waypoints
+            if ((key === 'arrowleft' || key === 'arrowright') && !$(e.target).is('input, select, textarea')) {
+                e.preventDefault();
+                var wpList = mission.get().filter(function (wp) { return !wp.isAttached(); });
+                if (wpList.length === 0) return;
+
+                var currentLayerNum = selectedMarker ? selectedMarker.getLayerNumber() : -1;
+                var targetLayerNum;
+                if (key === 'arrowleft') {
+                    targetLayerNum = currentLayerNum > 0 ? currentLayerNum - 1 : wpList.length - 1;
+                } else {
+                    targetLayerNum = currentLayerNum < wpList.length - 1 ? currentLayerNum + 1 : 0;
+                }
+                selectWaypointByLayerNumber(targetLayerNum);
+            }
         });
+
+        // Programmatically select a waypoint by its layer number (0-based display index)
+        function selectWaypointByLayerNumber(layerNum) {
+            // Deselect current
+            if (selectedFeature && selectedMarker) {
+                try { selectedFeature.setStyle(getWaypointIcon(selectedMarker, false)); } catch (e) {}
+            }
+            selectedMarker = null;
+            selectedFeature = null;
+            tempMarker = null;
+
+            // Find the marker layer with this layerNumber
+            var markerLayer = markers.find(function (m) { return m.layerNumber === layerNum; });
+            if (!markerLayer) {
+                clearEditForm();
+                return;
+            }
+
+            tempMarker = markerLayer;
+            selectedMarker = mission.getWaypoint(markerLayer.number);
+            selectedFeature = markerLayer.getSource().getFeatures()[0];
+
+            if (!selectedMarker || !selectedFeature) {
+                clearEditForm();
+                return;
+            }
+
+            selectedFwApproachWp = FC.FW_APPROACH.get()[FC.SAFEHOMES.getMaxSafehomeCount() + selectedMarker.getMultiMissionIdx()];
+
+            selectedFeature.setStyle(getWaypointIcon(selectedMarker, true));
+
+            var coord = toLonLat(selectedFeature.getGeometry().getCoordinates());
+            let P3Value = selectedMarker.getP3();
+
+            changeSwitch($('#pointP3Alt'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.ALT_TYPE));
+            changeSwitch($('#pointP3UserAction1'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_1));
+            changeSwitch($('#pointP3UserAction2'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_2));
+            changeSwitch($('#pointP3UserAction3'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_3));
+            changeSwitch($('#pointP3UserAction4'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_4));
+
+            var altitudeMeters = selectedMarker.getAlt() / 100;
+
+            if (selectedMarker.getAction() == MWNP.WPTYPE.LAND) {
+                $('#wpFwLanding').fadeIn(300);
+            } else {
+                $('#wpFwLanding').fadeOut(300);
+            }
+
+            (async () => {
+                const elevationAtWP = await selectedMarker.getElevation(globalSettings);
+                $('#elevationValueAtWP').text(elevationAtWP);
+                const returnAltitude = checkAltElevSanity(false, selectedMarker.getAlt(), elevationAtWP, P3Value);
+                selectedMarker.setAlt(returnAltitude);
+                plotElevation();
+            })();
+
+            $('#elevationAtWP').fadeIn();
+            $('#groundClearanceAtWP').fadeIn();
+
+            $('#altitudeInMeters').text(` ${altitudeMeters}m`);
+            $('#pointLon').val(Math.round(coord[0] * 10000000) / 10000000);
+            $('#pointLat').val(Math.round(coord[1] * 10000000) / 10000000);
+            $('#pointAlt').val(selectedMarker.getAlt());
+            $('#pointType').val(selectedMarker.getAction());
+            $('#pointP1').val(selectedMarker.getP1());
+            $('#pointP2').val(selectedMarker.getP2());
+
+            for (var j in dictOfLabelParameterPoint[selectedMarker.getAction()]) {
+                if (dictOfLabelParameterPoint[selectedMarker.getAction()][j] != '') {
+                    $('#pointP'+String(j).slice(-1)+'class').fadeIn(300);
+                    $('label[for=pointP'+String(j).slice(-1)+']').html(dictOfLabelParameterPoint[selectedMarker.getAction()][j]);
+                }
+                else {$('#pointP'+String(j).slice(-1)+'class').fadeOut(300);}
+            }
+            selectedMarker = renderWaypointOptionsTable(selectedMarker);
+            $('#EditPointNumber').text("Edit point "+String(selectedMarker.getLayerNumber()+1));
+
+            // Quick flash transition so user sees the card update
+            var $card = $('#MPeditPoint');
+            if ($card.is(':visible')) {
+                $card.css('opacity', 0.3).animate({ opacity: 1 }, 200);
+            } else {
+                $card.fadeIn(300);
+            }
+            $('#pointP3UserActionClass').fadeIn();
+            redrawLayer();
+        }
 
         $('#removePoint').on('click', function () {
             if (selectedMarker) {
+                var prevLayerNum = selectedMarker.getLayerNumber() - 1;
+
                 if (mission.isJumpTargetAttached(selectedMarker)) {
                     dialog.alert(i18n.getMessage('MissionPlannerJumpTargetRemoval'));
                 }
@@ -4284,6 +4457,10 @@ function iconKey(filename) {
                         refreshLayers();
                         plotElevation();
                         updateLocationButtonsVisibility();
+
+                        if (prevLayerNum >= 0 && !mission.isEmpty()) {
+                            selectWaypointByLayerNumber(Math.min(prevLayerNum, mission.get().filter(function (wp) { return !wp.isAttached(); }).length - 1));
+                        }
                     }
                 }
                 else {
@@ -4296,6 +4473,10 @@ function iconKey(filename) {
                     clearEditForm();
                     refreshLayers();
                     plotElevation();
+
+                    if (prevLayerNum >= 0 && !mission.isEmpty()) {
+                        selectWaypointByLayerNumber(Math.min(prevLayerNum, mission.get().filter(function (wp) { return !wp.isAttached(); }).length - 1));
+                    }
                 }
                 updateMultimissionState();
                 updateLocationButtonsVisibility();

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1710,9 +1710,10 @@ function iconKey(filename) {
                             var headingDeg = element.getP1();
                             // SVG: circle stays fixed, arrow rotates around center via SVG transform
                             var arrowSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">'
-                                + '<circle cx="12" cy="12" r="10" fill="#222" stroke="#fff" stroke-width="2"/>'
-                                + '<path d="M12 4 L15 10 L12 8 L9 10 Z" fill="#fff" transform="rotate(' + headingDeg + ' 12 12)"/>'
-                                + '</svg>';
+  + '<circle cx="12" cy="12" r="10" fill="#222" stroke="#fff" stroke-width="2"/>'
+  + '<line x1="12" y1="2.71" x2="12" y2="12" stroke="#fff" stroke-width="1" transform="rotate(' + headingDeg + ' 12 12)"/>'
+  + '<path d="M12 2.5 L15 8.5 L12 6.5 L9 8.5 Z" fill="#fff" transform="rotate(' + headingDeg + ' 12 12)"/>'
+  + '</svg>';
                             var headMarker = new Feature({ geometry: new Point(oldPos) });
                             headMarker.setStyle([
                                 new Style({

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1610,7 +1610,7 @@ function iconKey(filename) {
     }
 
     // Vertical pixel offset to push RTH/heading markers below the WP pin (increase to move further down)
-    var MARKER_ICON_OFFSET_Y = 10;
+    var MARKER_ICON_OFFSET_Y = 11;
     var MARKER_ICON_OFFSET_X = -2;  // Match WP pin text offsetX
 
     function repaintLine4Waypoints(mission) {
@@ -1663,19 +1663,20 @@ function iconKey(filename) {
             }
             else if (element.isAttached()) {
                 if (element.getAction() == MWNP.WPTYPE.RTH && typeof oldPos !== 'undefined') {
-                    // Green RTH marker at the last waypoint position
+                    // RTH marker
+                    var markerOpacity = 0.60;
                     var rthMarker = new Feature({ geometry: new Point(oldPos) });
                     rthMarker.setStyle(new Style({
                         image: new RegularShape({
-                            fill: new Fill({ color: '#00c850' }),
-                            stroke: new Stroke({ color: '#fff', width: 2 }),
+                            fill: new Fill({ color: 'rgba(0, 200, 80, ' + markerOpacity + ')' }),
+                            stroke: new Stroke({ color: 'rgba(255, 255, 255, ' + markerOpacity + ')', width: 2 }),
                             points: 32,
                             radius: 10,
                             displacement: [MARKER_ICON_OFFSET_X, -MARKER_ICON_OFFSET_Y],
                         }),
                         text: new Text({
                             text: 'RTH',
-                            font: 'bold 9px sans-serif',
+                            font: 'bold 8px sans-serif',
                             offsetX: MARKER_ICON_OFFSET_X,
                             offsetY: MARKER_ICON_OFFSET_Y,
                             fill: new Fill({ color: '#fff' }),
@@ -1709,11 +1710,14 @@ function iconKey(filename) {
                         if (typeof oldPos !== 'undefined') {
                             var headingDeg = element.getP1();
                             // SVG: circle stays fixed, arrow rotates around center via SVG transform
-                            var arrowSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">'
-  + '<circle cx="12" cy="12" r="10" fill="#222" stroke="#fff" stroke-width="2"/>'
-  + '<line x1="12" y1="2.71" x2="12" y2="12" stroke="#fff" stroke-width="1" transform="rotate(' + headingDeg + ' 12 12)"/>'
-  + '<path d="M12 2.5 L15 8.5 L12 6.5 L9 8.5 Z" fill="#fff" transform="rotate(' + headingDeg + ' 12 12)"/>'
-  + '</svg>';
+                            var markerOpacity = 0.60;
+
+                            var arrowSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" opacity="' + markerOpacity + '">'
+                            + '<circle cx="12" cy="12" r="10" fill="#222" stroke="#fff" stroke-width="2"/>'
+                            + '<line x1="12" y1="2.71" x2="12" y2="12" stroke="#fff" stroke-width="1" transform="rotate(' + headingDeg + ' 12 12)"/>'
+                            + '<path d="M12 2.5 L15 8.5 L12 6.5 L9 8.5 Z" fill="#fff" transform="rotate(' + headingDeg + ' 12 12)"/>'
+                            + '<circle cx="12" cy="12" r="0.9" fill="#fff"/>'
+                            + '</svg>';
                             var headMarker = new Feature({ geometry: new Point(oldPos) });
                             headMarker.setStyle([
                                 new Style({

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1618,6 +1618,7 @@ function iconKey(filename) {
             oldAction,
             poiList = [],
             oldHeading,
+            lastWaypointLayerNumber = -1,
             multiMissionWPNum = 0;
         let activatePoi = false;
         let activateHead = false;
@@ -1658,6 +1659,7 @@ function iconKey(filename) {
                         multiMissionWPNum = element.getNumber() + 1;
                     } else {
                         oldPos = coord;
+                        lastWaypointLayerNumber = element.getLayerNumber();
                     }
                 }
             }
@@ -1682,6 +1684,7 @@ function iconKey(filename) {
                     var rthLayer = new VectorLayer({ source: rthSource, zIndex: 99 });
                     rthLayer.kind = "rth";
                     rthLayer.selection = false;
+                    rthLayer.parentLayerNumber = lastWaypointLayerNumber;
                     lines.push(rthLayer);
                     map.addLayer(rthLayer);
                 }
@@ -1738,6 +1741,7 @@ function iconKey(filename) {
                             var headLayer = new VectorLayer({ source: headSource, zIndex: 99 });
                             headLayer.kind = "heading";
                             headLayer.selection = false;
+                            headLayer.parentLayerNumber = lastWaypointLayerNumber;
                             lines.push(headLayer);
                             map.addLayer(headLayer);
                         }
@@ -2691,6 +2695,11 @@ function iconKey(filename) {
             if (selectedFeature && tempMarker && !tempMarker.kind) {
                 selectedFeature = null;
                 tempMarker = null;
+            }
+            // Clicking RTH/heading marker selects the parent waypoint
+            if (tempMarker && (tempMarker.kind === 'rth' || tempMarker.kind === 'heading') && tempMarker.parentLayerNumber >= 0) {
+                selectWaypointByLayerNumber(tempMarker.parentLayerNumber);
+                return;
             }
             if (selectedFeature && tempMarker && tempMarker.kind == "waypoint") {
                 $("#editMission").hide();
@@ -4465,8 +4474,9 @@ function iconKey(filename) {
             selectedMarker = renderWaypointOptionsTable(selectedMarker);
             $('#EditPointNumber').text("Edit point "+String(selectedMarker.getLayerNumber()+1));
 
-            // Quick flash transition so user sees the card update
+            // Stop any in-progress fadeOut from clearEditForm, then show card
             var $card = $('#MPeditPoint');
+            $card.stop(true, true);
             if ($card.is(':visible')) {
                 $card.css('opacity', 0.3).animate({ opacity: 1 }, 200);
             } else {

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -24,11 +24,12 @@ import Point from 'ol/geom/Point.js';
 import Feature from 'ol/Feature';
 import VectorSource from 'ol/source/Vector.js';
 import VectorLayer from 'ol/layer/Vector.js';
-import { LineString } from 'ol/geom';
+import { LineString, Polygon } from 'ol/geom';
 import Stroke from 'ol/style/Stroke';
 import RegularShape from 'ol/style/RegularShape';
 import Circle from 'ol/geom/Circle';
 import PointerInteraction from 'ol/interaction/Pointer.js';
+import Draw from 'ol/interaction/Draw.js';
 import {defaults as defaultInteractions} from 'ol/interaction/defaults';
 import {Control, defaults as defaultControls} from 'ol/control.js';
 
@@ -284,6 +285,7 @@ function iconKey(filename) {
         addShortcutHint('#saveFileMissionButton', '(Ctrl+S)');
         addShortcutHint('#removeAllPoints a', '(Ctrl+D)');
         addShortcutHint('#searchAddressButton', '(Ctrl+A)');
+        addShortcutHint('#gridPatternButton', '(Ctrl+G)');
 
         function get_raw_gps_data() {
             MSP.send_message(MSPCodes.MSP_RAW_GPS, false, false, get_comp_gps_data);
@@ -550,6 +552,8 @@ function iconKey(filename) {
     var selectedFwApproachWp = null;
     var selectedFwApproachSh = null;
     var lockShExclHeading = false;
+    var gridDrawInteraction = null;
+    var gridPreviewLayer = null;
 
 
     //////////////////////////////////////////////////////////////////////////////////////////////
@@ -2283,6 +2287,8 @@ function iconKey(filename) {
                 });
 
             if (feature) {
+                // Ignore features from layers without a 'kind' (e.g. grid preview)
+                if (!tempMarker || !tempMarker.kind) return false;
                 this.coordinate_ = evt.coordinate;
                 this.feature_ = feature;
                 this.layer_ = tempMarker;
@@ -2295,6 +2301,7 @@ function iconKey(filename) {
          * @param {ol.MapBrowserEvent} evt Map browser event.
          */
         app.handleDragEvent = function (evt) {
+            if (!tempMarker || !tempMarker.kind) return;
             
             if (tempMarker.kind == "safehomecircle" || tempMarker.kind == "geozonecircle") {
                 return;
@@ -2390,6 +2397,7 @@ function iconKey(filename) {
          * @return {boolean} `false` to stop the drag sequence.
          */
         app.handleUpEvent = function (evt) {
+            if (!tempMarker || !tempMarker.kind) return false;
             if (tempMarker.kind == "waypoint") {
                 if (selectedMarker != null && tempMarker.number == selectedMarker.getLayerNumber()) {
                     (async () => {
@@ -2578,7 +2586,12 @@ function iconKey(filename) {
                 function (feature, layer) {
                     return layer;
                 });
-            if (selectedFeature && tempMarker.kind == "waypoint") {
+            // Ignore features from layers without a kind (e.g. grid preview overlay)
+            if (selectedFeature && tempMarker && !tempMarker.kind) {
+                selectedFeature = null;
+                tempMarker = null;
+            }
+            if (selectedFeature && tempMarker && tempMarker.kind == "waypoint") {
                 $("#editMission").hide();
                 selectedMarker = mission.getWaypoint(tempMarker.number);
 
@@ -3836,6 +3849,363 @@ function iconKey(filename) {
             }
         });
 
+        /////////////////////////////////////////////
+        // Grid Pattern survey mission generator
+        /////////////////////////////////////////////
+        $(document).on('click', '#gridPatternButton, #gridPattern', function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+            startGridPolygonDraw();
+        });
+
+        function startGridPolygonDraw() {
+            // Cancel any existing grid draw
+            cancelGridDraw();
+
+            // Show instruction banner
+            showGridBanner(i18n.getMessage('missionGridDrawPrompt'));
+
+            const drawSource = new VectorSource();
+            gridPreviewLayer = new VectorLayer({
+                source: drawSource,
+                style: new Style({
+                    stroke: new Stroke({ color: 'rgba(255, 140, 0, 0.8)', width: 2 }),
+                    fill: new Fill({ color: 'rgba(255, 140, 0, 0.15)' }),
+                }),
+            });
+            map.addLayer(gridPreviewLayer);
+
+            gridDrawInteraction = new Draw({
+                source: drawSource,
+                type: 'Polygon',
+            });
+
+            gridDrawInteraction.on('drawend', function (evt) {
+                const polygon = evt.feature.getGeometry();
+                map.removeInteraction(gridDrawInteraction);
+                gridDrawInteraction = null;
+                hideGridBanner();
+                showGridSettingsDialog(polygon);
+            });
+
+            map.addInteraction(gridDrawInteraction);
+
+            // Allow Escape to cancel
+            $(document).off('keydown.gridDraw').on('keydown.gridDraw', function (evt) {
+                if (evt.key === 'Escape') {
+                    cancelGridDraw();
+                }
+            });
+        }
+
+        function cancelGridDraw() {
+            $(document).off('keydown.gridDraw');
+            hideGridBanner();
+            if (gridDrawInteraction) {
+                map.removeInteraction(gridDrawInteraction);
+                gridDrawInteraction = null;
+            }
+            if (gridPreviewLayer) {
+                map.removeLayer(gridPreviewLayer);
+                gridPreviewLayer = null;
+            }
+        }
+
+        function showGridBanner(msg) {
+            hideGridBanner();
+            const banner = $('<div id="gridBanner" style="position:absolute;top:10px;left:50%;transform:translateX(-50%);' +
+                'background:rgba(255,140,0,0.9);color:#fff;padding:8px 20px;border-radius:6px;z-index:9999;' +
+                'font-weight:bold;pointer-events:none;white-space:nowrap;"></div>').text(msg);
+            $('#missionMap').css('position', 'relative').append(banner);
+        }
+
+        function hideGridBanner() {
+            $('#gridBanner').remove();
+        }
+
+        function showGridSettingsDialog(polygon) {
+            const coordsLonLat = polygon.getCoordinates()[0].map(c => toLonLat(c));
+
+            // Store polygon reference for the sidebar card
+            gridPolygonCoords = coordsLonLat;
+            gridPolygonGeom = polygon;
+
+            // Populate card fields
+            $('#gridAltitude').val(settings.alt / 100);
+            $('#gridSpeed').val(settings.speed ? settings.speed / 100 : 0);
+
+            // Show the sidebar card
+            $('#missionPlannerGridSettings').fadeIn(200);
+
+            // Run initial preview
+            updateGridPreview();
+        }
+
+        var gridPolygonCoords = null;
+        var gridPolygonGeom = null;
+
+        function getGridParams() {
+            return {
+                spacing: parseFloat($('#gridSpacing').val()) || 25,
+                altitude: (parseFloat($('#gridAltitude').val()) || 50) * 100,
+                speed: (parseFloat($('#gridSpeed').val()) || 0) * 100,
+                angle: parseFloat($('#gridAngle').val()) || 0,
+                overshoot: parseFloat($('#gridOvershoot').val()) || 0,
+            };
+        }
+
+        function updateGridPreview() {
+            if (!gridPolygonCoords || !gridPreviewLayer) return;
+
+            const params = getGridParams();
+            const waypoints = generateGridWaypoints(gridPolygonCoords, params);
+
+            gridPreviewLayer.getSource().clear();
+
+            if (waypoints.length < 2) {
+                $('#gridWaypointCount').text(i18n.getMessage('missionGridNoWaypoints')).css('color', '#c00');
+                return;
+            }
+
+            const maxWp = mission.getMaxWaypoints();
+            const totalCount = waypoints.length + ($('#gridEndRTH').is(':checked') ? 1 : 0);
+            const countText = i18n.getMessage('missionGridWaypointCount', [totalCount, maxWp]);
+            $('#gridWaypointCount').text(countText).css('color', totalCount > maxWp ? 'red' : '#666');
+
+            // Polygon outline
+            const polyFeature = new Feature({ geometry: gridPolygonGeom });
+            polyFeature.setStyle(new Style({
+                stroke: new Stroke({ color: 'rgba(255, 140, 0, 0.8)', width: 2 }),
+                fill: new Fill({ color: 'rgba(255, 140, 0, 0.1)' }),
+            }));
+            gridPreviewLayer.getSource().addFeature(polyFeature);
+
+            // Survey path line
+            const previewCoords = waypoints.map(wp => fromLonLat([wp.lon, wp.lat]));
+            const lineFeature = new Feature({ geometry: new LineString(previewCoords) });
+            lineFeature.setStyle(new Style({
+                stroke: new Stroke({ color: 'rgba(255, 140, 0, 0.8)', width: 2, lineDash: [8, 4] }),
+            }));
+            gridPreviewLayer.getSource().addFeature(lineFeature);
+
+            // Numbered dots
+            waypoints.forEach((wp, idx) => {
+                const dotFeature = new Feature({ geometry: new Point(fromLonLat([wp.lon, wp.lat])) });
+                dotFeature.setStyle(new Style({
+                    image: new RegularShape({
+                        fill: new Fill({ color: '#ff8c00' }),
+                        stroke: new Stroke({ color: '#fff', width: 1 }),
+                        points: 16,
+                        radius: 5,
+                    }),
+                    text: new Text({
+                        text: String(idx + 1),
+                        offsetY: -12,
+                        fill: new Fill({ color: '#ff8c00' }),
+                        font: 'bold 11px sans-serif',
+                    }),
+                }));
+                gridPreviewLayer.getSource().addFeature(dotFeature);
+            });
+        }
+
+        function hideGridCard() {
+            $('#missionPlannerGridSettings').fadeOut(200);
+            gridPolygonCoords = null;
+            gridPolygonGeom = null;
+        }
+
+        // Live preview when any grid input changes
+        $(document).on('change input', '#missionPlannerGridSettings input', function () {
+            updateGridPreview();
+        });
+
+        // Cancel button (X icon in titlebar)
+        $(document).on('click', '#gridCancel', function (e) {
+            e.preventDefault();
+            hideGridCard();
+            cancelGridDraw();
+        });
+
+        // Generate button
+        $(document).on('click', '#gridGenerate', function () {
+            if (!gridPolygonCoords) return;
+
+            const params = getGridParams();
+            const waypoints = generateGridWaypoints(gridPolygonCoords, params);
+
+            if (waypoints.length === 0) {
+                dialog.alert(i18n.getMessage('missionGridNoWaypoints'));
+                return;
+            }
+
+            const totalCount = waypoints.length + ($('#gridEndRTH').is(':checked') ? 1 : 0);
+
+            if (totalCount > mission.getMaxWaypoints()) {
+                dialog.alert(i18n.getMessage('missionGridTooManyWaypoints', [totalCount, mission.getMaxWaypoints()]));
+                return;
+            }
+
+            // Clear existing waypoints before generating grid
+            removeAllWaypoints();
+
+            waypoints.forEach(function (wp) {
+                const tempWp = new Waypoint(
+                    mission.get().length,
+                    MWNP.WPTYPE.WAYPOINT,
+                    Math.round(wp.lat * 1e7),
+                    Math.round(wp.lon * 1e7),
+                    Number(params.altitude),
+                    Number(params.speed)
+                );
+
+                if (mission.get().length === 0) {
+                    tempWp.setMultiMissionIdx(multimissionCount === 0 ? 0 : multimissionCount - 1);
+                    FC.FW_APPROACH.clean(FC.SAFEHOMES.getMaxSafehomeCount() + tempWp.getMultiMissionIdx());
+                } else {
+                    tempWp.setMultiMissionIdx(mission.getWaypoint(mission.get().length - 1).getMultiMissionIdx());
+                }
+
+                mission.put(tempWp);
+            });
+
+            // Append RTH waypoint if checkbox is checked
+            if ($('#gridEndRTH').is(':checked')) {
+                const lastWp = waypoints[waypoints.length - 1];
+                const rthWp = new Waypoint(
+                    mission.get().length,
+                    MWNP.WPTYPE.RTH,
+                    Math.round(lastWp.lat * 1e7),
+                    Math.round(lastWp.lon * 1e7),
+                    0,
+                    0
+                );
+                rthWp.setMultiMissionIdx(mission.getWaypoint(mission.get().length - 1).getMultiMissionIdx());
+                mission.put(rthWp);
+            }
+
+            mission.update(singleMissionActive());
+            refreshLayers();
+            plotElevation();
+            updateMultimissionState();
+            updateLocationButtonsVisibility();
+
+            hideGridCard();
+            cancelGridDraw();
+        });
+
+        /**
+         * Compute the optimal angle for survey lines by finding the longest edge
+         * of the polygon and using its bearing as the line direction.
+         */
+        function computeOptimalAngle(coordsLonLat) {
+            let maxDist = 0;
+            let bestAngle = 0;
+            for (let i = 0; i < coordsLonLat.length - 1; i++) {
+                const dx = coordsLonLat[i + 1][0] - coordsLonLat[i][0];
+                const dy = coordsLonLat[i + 1][1] - coordsLonLat[i][1];
+                const dist = dx * dx + dy * dy;
+                if (dist > maxDist) {
+                    maxDist = dist;
+                    bestAngle = Math.atan2(dx, dy) * 180 / Math.PI;
+                }
+            }
+            return ((bestAngle % 360) + 360) % 360;
+        }
+
+        /**
+         * Generate lawnmower/zigzag waypoints inside a polygon.
+         * @param {Array} coordsLonLat - Polygon vertices as [lon, lat] pairs (last == first)
+         * @param {Object} params - { spacing (m), angle (deg), overshoot (m) }
+         * @returns {Array} Array of { lat, lon } objects
+         */
+        function generateGridWaypoints(coordsLonLat, params) {
+            const verts = coordsLonLat.slice(0, -1); // Remove closing duplicate
+            if (verts.length < 3) return [];
+
+            // Convert to local meters using centroid as origin
+            const centroid = verts.reduce((acc, v) => [acc[0] + v[0] / verts.length, acc[1] + v[1] / verts.length], [0, 0]);
+            const cosLat = Math.cos(centroid[1] * Math.PI / 180);
+            const metersPerDegLon = 111320 * cosLat;
+            const metersPerDegLat = 110540;
+
+            function toLocal(lonlat) {
+                return [(lonlat[0] - centroid[0]) * metersPerDegLon, (lonlat[1] - centroid[1]) * metersPerDegLat];
+            }
+            function toGeo(xy) {
+                return [centroid[0] + xy[0] / metersPerDegLon, centroid[1] + xy[1] / metersPerDegLat];
+            }
+
+            const localVerts = verts.map(toLocal);
+
+            // Rotate polygon so sweep lines are horizontal
+            const angleRad = params.angle * Math.PI / 180;
+            function rotate(p, a) {
+                const c = Math.cos(a), s = Math.sin(a);
+                return [p[0] * c - p[1] * s, p[0] * s + p[1] * c];
+            }
+            function unrotate(p, a) { return rotate(p, -a); }
+
+            const rotVerts = localVerts.map(v => rotate(v, -angleRad));
+
+            // Find Y extent
+            let minY = Infinity, maxY = -Infinity;
+            rotVerts.forEach(v => { minY = Math.min(minY, v[1]); maxY = Math.max(maxY, v[1]); });
+
+            const spacing = params.spacing;
+            if (spacing <= 0) return [];
+
+            // Generate horizontal sweep lines
+            const waypoints = [];
+            let direction = 1; // 1 = left-to-right, -1 = right-to-left
+
+            // Start first line half-spacing inside the boundary
+            const startY = minY + spacing * 0.25;
+            const endY = maxY - spacing * 0.25;
+
+            for (let y = startY; y <= endY; y += spacing) {
+                // Find intersections of line y=const with polygon edges
+                const intersections = [];
+                for (let i = 0; i < rotVerts.length; i++) {
+                    const j = (i + 1) % rotVerts.length;
+                    const y1 = rotVerts[i][1], y2 = rotVerts[j][1];
+                    if ((y1 <= y && y2 > y) || (y2 <= y && y1 > y)) {
+                        const t = (y - y1) / (y2 - y1);
+                        const x = rotVerts[i][0] + t * (rotVerts[j][0] - rotVerts[i][0]);
+                        intersections.push(x);
+                    }
+                }
+
+                intersections.sort((a, b) => a - b);
+
+                // Process pairs of intersections (entry/exit)
+                for (let k = 0; k + 1 < intersections.length; k += 2) {
+                    let x1 = intersections[k];
+                    let x2 = intersections[k + 1];
+
+                    // Apply overshoot extension
+                    if (params.overshoot > 0) {
+                        x1 -= params.overshoot;
+                        x2 += params.overshoot;
+                    }
+
+                    // Order points based on sweep direction
+                    const ptA = direction > 0 ? [x1, y] : [x2, y];
+                    const ptB = direction > 0 ? [x2, y] : [x1, y];
+
+                    const geoA = toGeo(unrotate(ptA, angleRad));
+                    const geoB = toGeo(unrotate(ptB, angleRad));
+
+                    waypoints.push({ lon: geoA[0], lat: geoA[1] });
+                    waypoints.push({ lon: geoB[0], lat: geoB[1] });
+                }
+
+                direction *= -1; // Alternate sweep direction for lawnmower
+            }
+
+            return waypoints;
+        }
+
         // Keyboard shortcuts (ignored when typing in inputs):
         //  C -> center on latest GPS fix
         //  Ctrl+L -> load mission from file
@@ -3882,6 +4252,12 @@ function iconKey(filename) {
             if (!e.repeat && e.ctrlKey && key === 'a') {
                 e.preventDefault();
                 $('#searchAddressButton').trigger('click');
+            }
+
+            // Ctrl+G: grid pattern
+            if (!e.repeat && e.ctrlKey && key === 'g') {
+                e.preventDefault();
+                startGridPolygonDraw();
             }
         });
 

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1705,31 +1705,21 @@ function iconKey(filename) {
                         activateHead = true;
                         oldHeading = String(element.getP1());
 
-                        // Black circle with white direction dot pointing in the heading direction
+                        // Black circle with white arrow pointing in the heading direction
                         if (typeof oldPos !== 'undefined') {
                             var headingDeg = element.getP1();
-                            var headingRad = headingDeg * Math.PI / 180;
-                            // Dot displacement: sin for X (east), cos for Y (north/up) from circle center
-                            var dotRadius = 9;
-                            var dotDx = Math.sin(headingRad) * dotRadius;
-                            var dotDy = Math.cos(headingRad) * dotRadius;
+                            // SVG: circle stays fixed, arrow rotates around center via SVG transform
+                            var arrowSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">'
+                                + '<circle cx="12" cy="12" r="10" fill="#222" stroke="#fff" stroke-width="2"/>'
+                                + '<path d="M12 4 L15 10 L12 8 L9 10 Z" fill="#fff" transform="rotate(' + headingDeg + ' 12 12)"/>'
+                                + '</svg>';
                             var headMarker = new Feature({ geometry: new Point(oldPos) });
                             headMarker.setStyle([
                                 new Style({
-                                    image: new RegularShape({
-                                        fill: new Fill({ color: '#222' }),
-                                        stroke: new Stroke({ color: '#fff', width: 2 }),
-                                        points: 32,
-                                        radius: 10,
+                                    image: new Icon({
+                                        src: 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(arrowSvg),
+                                        scale: 1,
                                         displacement: [MARKER_ICON_OFFSET_X, -MARKER_ICON_OFFSET_Y],
-                                    }),
-                                }),
-                                new Style({
-                                    image: new RegularShape({
-                                        fill: new Fill({ color: '#fff' }),
-                                        points: 32,
-                                        radius: 4,
-                                        displacement: [MARKER_ICON_OFFSET_X + dotDx, -MARKER_ICON_OFFSET_Y + dotDy],
                                     }),
                                 }),
                                 new Style({

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1664,22 +1664,18 @@ function iconKey(filename) {
             else if (element.isAttached()) {
                 if (element.getAction() == MWNP.WPTYPE.RTH && typeof oldPos !== 'undefined') {
                     // RTH marker
-                    var markerOpacity = 0.60;
+                    // RTH marker as SVG
+                    var markerOpacity = 0.85;
+                    var rthSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" opacity="' + markerOpacity + '">' +
+                        '<circle cx="12" cy="12" r="10" fill="#00c850" stroke="#fff" stroke-width="2"/>' +
+                        '<text x="12" y="15" text-anchor="middle" font-size="7" font-family="sans-serif" font-weight="bold" fill="#fff">RTH</text>' +
+                        '</svg>';
                     var rthMarker = new Feature({ geometry: new Point(oldPos) });
                     rthMarker.setStyle(new Style({
-                        image: new RegularShape({
-                            fill: new Fill({ color: 'rgba(0, 200, 80, ' + markerOpacity + ')' }),
-                            stroke: new Stroke({ color: 'rgba(255, 255, 255, ' + markerOpacity + ')', width: 2 }),
-                            points: 32,
-                            radius: 10,
+                        image: new Icon({
+                            src: 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(rthSvg),
+                            scale: 1,
                             displacement: [MARKER_ICON_OFFSET_X, -MARKER_ICON_OFFSET_Y],
-                        }),
-                        text: new Text({
-                            text: 'RTH',
-                            font: 'bold 8px sans-serif',
-                            offsetX: MARKER_ICON_OFFSET_X,
-                            offsetY: MARKER_ICON_OFFSET_Y,
-                            fill: new Fill({ color: '#fff' }),
                         }),
                     }));
                     var rthSource = new VectorSource({ features: [rthMarker] });
@@ -1710,7 +1706,7 @@ function iconKey(filename) {
                         if (typeof oldPos !== 'undefined') {
                             var headingDeg = element.getP1();
                             // SVG: circle stays fixed, arrow rotates around center via SVG transform
-                            var markerOpacity = 0.60;
+                            var markerOpacity = 0.85;
 
                             var arrowSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" opacity="' + markerOpacity + '">'
                             + '<circle cx="12" cy="12" r="10" fill="#222" stroke="#fff" stroke-width="2"/>'

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1675,7 +1675,7 @@ function iconKey(filename) {
                         }),
                     }));
                     var rthSource = new VectorSource({ features: [rthMarker] });
-                    var rthLayer = new VectorLayer({ source: rthSource });
+                    var rthLayer = new VectorLayer({ source: rthSource, zIndex: 99 });
                     rthLayer.kind = "rth";
                     rthLayer.selection = false;
                     lines.push(rthLayer);
@@ -1697,6 +1697,46 @@ function iconKey(filename) {
                         activatePoi = false;
                         activateHead = true;
                         oldHeading = String(element.getP1());
+
+                        // Black circle with white arrow pointing in the heading direction
+                        if (typeof oldPos !== 'undefined') {
+                            var headingDeg = element.getP1();
+                            var headingRad = headingDeg * Math.PI / 180;
+                            var headMarker = new Feature({ geometry: new Point(oldPos) });
+                            headMarker.setStyle([
+                                new Style({
+                                    image: new RegularShape({
+                                        fill: new Fill({ color: '#222' }),
+                                        stroke: new Stroke({ color: '#fff', width: 2 }),
+                                        points: 32,
+                                        radius: 12,
+                                    }),
+                                }),
+                                new Style({
+                                    text: new Text({
+                                        text: '\u2191',
+                                        font: 'bold 18px sans-serif',
+                                        rotation: headingRad,
+                                        fill: new Fill({ color: '#fff' }),
+                                    }),
+                                }),
+                                new Style({
+                                    text: new Text({
+                                        text: headingDeg + '\u00B0',
+                                        font: 'bold 9px sans-serif',
+                                        offsetY: 18,
+                                        fill: new Fill({ color: '#222' }),
+                                        stroke: new Stroke({ color: '#fff', width: 3 }),
+                                    }),
+                                }),
+                            ]);
+                            var headSource = new VectorSource({ features: [headMarker] });
+                            var headLayer = new VectorLayer({ source: headSource, zIndex: 99 });
+                            headLayer.kind = "heading";
+                            headLayer.selection = false;
+                            lines.push(headLayer);
+                            map.addLayer(headLayer);
+                        }
                     }
                 }
 

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -1609,6 +1609,10 @@ function iconKey(filename) {
         });
     }
 
+    // Vertical pixel offset to push RTH/heading markers below the WP pin (increase to move further down)
+    var MARKER_ICON_OFFSET_Y = 10;
+    var MARKER_ICON_OFFSET_X = -2;  // Match WP pin text offsetX
+
     function repaintLine4Waypoints(mission) {
         let oldPos,
             oldAction,
@@ -1667,10 +1671,13 @@ function iconKey(filename) {
                             stroke: new Stroke({ color: '#fff', width: 2 }),
                             points: 32,
                             radius: 10,
+                            displacement: [MARKER_ICON_OFFSET_X, -MARKER_ICON_OFFSET_Y],
                         }),
                         text: new Text({
                             text: 'RTH',
                             font: 'bold 9px sans-serif',
+                            offsetX: MARKER_ICON_OFFSET_X,
+                            offsetY: MARKER_ICON_OFFSET_Y,
                             fill: new Fill({ color: '#fff' }),
                         }),
                     }));
@@ -1698,10 +1705,14 @@ function iconKey(filename) {
                         activateHead = true;
                         oldHeading = String(element.getP1());
 
-                        // Black circle with white arrow pointing in the heading direction
+                        // Black circle with white direction dot pointing in the heading direction
                         if (typeof oldPos !== 'undefined') {
                             var headingDeg = element.getP1();
                             var headingRad = headingDeg * Math.PI / 180;
+                            // Dot displacement: sin for X (east), cos for Y (north/up) from circle center
+                            var dotRadius = 9;
+                            var dotDx = Math.sin(headingRad) * dotRadius;
+                            var dotDy = Math.cos(headingRad) * dotRadius;
                             var headMarker = new Feature({ geometry: new Point(oldPos) });
                             headMarker.setStyle([
                                 new Style({
@@ -1709,22 +1720,24 @@ function iconKey(filename) {
                                         fill: new Fill({ color: '#222' }),
                                         stroke: new Stroke({ color: '#fff', width: 2 }),
                                         points: 32,
-                                        radius: 12,
+                                        radius: 10,
+                                        displacement: [MARKER_ICON_OFFSET_X, -MARKER_ICON_OFFSET_Y],
                                     }),
                                 }),
                                 new Style({
-                                    text: new Text({
-                                        text: '\u2191',
-                                        font: 'bold 18px sans-serif',
-                                        rotation: headingRad,
+                                    image: new RegularShape({
                                         fill: new Fill({ color: '#fff' }),
+                                        points: 32,
+                                        radius: 4,
+                                        displacement: [MARKER_ICON_OFFSET_X + dotDx, -MARKER_ICON_OFFSET_Y + dotDy],
                                     }),
                                 }),
                                 new Style({
                                     text: new Text({
                                         text: headingDeg + '\u00B0',
                                         font: 'bold 9px sans-serif',
-                                        offsetY: 18,
+                                        offsetX: MARKER_ICON_OFFSET_X,
+                                        offsetY: MARKER_ICON_OFFSET_Y + 18,
                                         fill: new Fill({ color: '#222' }),
                                         stroke: new Stroke({ color: '#fff', width: 3 }),
                                     }),

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -4182,8 +4182,9 @@ function iconKey(filename) {
         let gridPolygonGeom = null;
 
         function getGridParams() {
+            const spacing = Number.parseFloat($('#gridSpacing').val());
             return {
-                spacing: Number.parseFloat($('#gridSpacing').val()) || 25,
+                spacing: Number.isNaN(spacing) ? 100 : spacing,
                 altitude: (Number.parseFloat($('#gridAltitude').val()) || 50) * 100,
                 speed: (Number.parseFloat($('#gridSpeed').val()) || 0) * 100,
                 angle: Number.parseFloat($('#gridAngle').val()) || 0,

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -24,7 +24,7 @@ import Point from 'ol/geom/Point.js';
 import Feature from 'ol/Feature';
 import VectorSource from 'ol/source/Vector.js';
 import VectorLayer from 'ol/layer/Vector.js';
-import { LineString, Polygon } from 'ol/geom';
+import { LineString } from 'ol/geom';
 import Stroke from 'ol/style/Stroke';
 import RegularShape from 'ol/style/RegularShape';
 import Circle from 'ol/geom/Circle';
@@ -2605,7 +2605,7 @@ function iconKey(filename) {
          * @return {boolean} `false` to stop the drag sequence.
          */
         app.handleUpEvent = function (evt) { // NOSONAR - OpenLayers PointerInteraction ends the drag sequence by returning false here.
-            if (!tempMarker || !tempMarker.kind) return false;
+            if (!tempMarker?.kind) return false;
             if (tempMarker.kind == "waypoint") {
                 if (selectedMarker != null && tempMarker.number == selectedMarker.getLayerNumber()) {
                     (async () => {
@@ -4355,9 +4355,12 @@ function iconKey(filename) {
             }
 
             const currentLayerNum = selectedMarker ? selectedMarker.getLayerNumber() : -1;
-            const targetLayerNum = key === 'arrowleft'
-                ? (currentLayerNum > 0 ? currentLayerNum - 1 : waypointList.length - 1)
-                : (currentLayerNum < waypointList.length - 1 ? currentLayerNum + 1 : 0);
+            let targetLayerNum;
+            if (key === 'arrowleft') {
+                targetLayerNum = currentLayerNum > 0 ? currentLayerNum - 1 : waypointList.length - 1;
+            } else {
+                targetLayerNum = currentLayerNum < waypointList.length - 1 ? currentLayerNum + 1 : 0;
+            }
 
             selectWaypointByLayerNumber(targetLayerNum);
             return true;

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -105,6 +105,133 @@ const iconNames = [
 
 const icons = Object.create(null)
 
+function rotateGridPoint(point, angleRad) {
+    const cosAngle = Math.cos(angleRad);
+    const sinAngle = Math.sin(angleRad);
+
+    return [
+        point[0] * cosAngle - point[1] * sinAngle,
+        point[0] * sinAngle + point[1] * cosAngle,
+    ];
+}
+
+function createGridProjection(vertices) {
+    const centroid = vertices.reduce((accumulator, vertex) => [
+        accumulator[0] + vertex[0] / vertices.length,
+        accumulator[1] + vertex[1] / vertices.length,
+    ], [0, 0]);
+    const cosLat = Math.cos(centroid[1] * Math.PI / 180);
+    const metersPerDegLon = 111320 * cosLat;
+    const metersPerDegLat = 110540;
+
+    return {
+        toLocal(lonLat) {
+            return [
+                (lonLat[0] - centroid[0]) * metersPerDegLon,
+                (lonLat[1] - centroid[1]) * metersPerDegLat,
+            ];
+        },
+        toGeo(point) {
+            return [
+                centroid[0] + point[0] / metersPerDegLon,
+                centroid[1] + point[1] / metersPerDegLat,
+            ];
+        },
+    };
+}
+
+function getGridYBounds(vertices) {
+    return vertices.reduce((bounds, vertex) => ({
+        minY: Math.min(bounds.minY, vertex[1]),
+        maxY: Math.max(bounds.maxY, vertex[1]),
+    }), { minY: Infinity, maxY: -Infinity });
+}
+
+function getGridIntersections(vertices, y) {
+    const intersections = [];
+
+    for (let index = 0; index < vertices.length; index++) {
+        const nextIndex = (index + 1) % vertices.length;
+        const y1 = vertices[index][1];
+        const y2 = vertices[nextIndex][1];
+
+        if ((y1 <= y && y2 > y) || (y2 <= y && y1 > y)) {
+            const interpolation = (y - y1) / (y2 - y1);
+            const x = vertices[index][0] + interpolation * (vertices[nextIndex][0] - vertices[index][0]);
+            intersections.push(x);
+        }
+    }
+
+    return intersections.sort((left, right) => left - right);
+}
+
+function createSweepWaypointPair(intersections, pairIndex, y, direction, overshoot, toGeo, angleRad) {
+    let x1 = intersections[pairIndex];
+    let x2 = intersections[pairIndex + 1];
+
+    if (overshoot > 0) {
+        x1 -= overshoot;
+        x2 += overshoot;
+    }
+
+    const pointA = direction > 0 ? [x1, y] : [x2, y];
+    const pointB = direction > 0 ? [x2, y] : [x1, y];
+    const geoA = toGeo(rotateGridPoint(pointA, angleRad));
+    const geoB = toGeo(rotateGridPoint(pointB, angleRad));
+
+    return [
+        { lon: geoA[0], lat: geoA[1] },
+        { lon: geoB[0], lat: geoB[1] },
+    ];
+}
+
+function generateGridWaypoints(coordsLonLat, params) {
+    const vertices = coordsLonLat.slice(0, -1);
+    if (vertices.length < 3 || params.spacing <= 0) {
+        return [];
+    }
+
+    const projection = createGridProjection(vertices);
+    const angleRad = params.angle * Math.PI / 180;
+    const rotatedVertices = vertices
+        .map(projection.toLocal)
+        .map((vertex) => rotateGridPoint(vertex, -angleRad));
+    const { minY, maxY } = getGridYBounds(rotatedVertices);
+    const startY = minY + params.spacing * 0.25;
+    const endY = maxY - params.spacing * 0.25;
+    const waypoints = [];
+    let direction = 1;
+
+    for (let y = startY; y <= endY; y += params.spacing) {
+        const intersections = getGridIntersections(rotatedVertices, y);
+
+        for (let pairIndex = 0; pairIndex + 1 < intersections.length; pairIndex += 2) {
+            waypoints.push(...createSweepWaypointPair(
+                intersections,
+                pairIndex,
+                y,
+                direction,
+                params.overshoot,
+                projection.toGeo,
+                angleRad,
+            ));
+        }
+
+        direction *= -1;
+    }
+
+    return waypoints;
+}
+
+function isMissionControlTypingTarget(target) {
+    return Boolean(target && (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable ||
+        target.tagName === 'SELECT'
+    ));
+}
+
 ////////////////////////////////////
 //
 // Tab mission control block
@@ -1664,7 +1791,7 @@ function iconKey(filename) {
                 }
             }
             else if (element.isAttached()) {
-                if (element.getAction() == MWNP.WPTYPE.RTH && typeof oldPos !== 'undefined') {
+                if (element.getAction() == MWNP.WPTYPE.RTH && oldPos !== undefined) {
                     // RTH marker
                     // RTH marker as SVG
                     const markerOpacity = 0.85;
@@ -1700,13 +1827,13 @@ function iconKey(filename) {
                         activateHead = false;
                         oldHeading = 'undefined'
                     }
-                    else if (typeof element.getP1() != 'undefined' && element.getP1() != -1) {
+                    else if (element.getP1() !== undefined && element.getP1() != -1) {
                         activatePoi = false;
                         activateHead = true;
                         oldHeading = String(element.getP1());
 
                         // Black circle with white arrow pointing in the heading direction
-                        if (typeof oldPos !== 'undefined') {
+                        if (oldPos !== undefined) {
                             const headingDeg = element.getP1();
                             // SVG: circle stays fixed, arrow rotates around center via SVG transform
                             const markerOpacity = 0.85;
@@ -2361,7 +2488,7 @@ function iconKey(filename) {
 
             if (feature) {
                 // Ignore features from layers without a 'kind' (e.g. grid preview)
-                if (!tempMarker || !tempMarker.kind) return false;
+                if (!tempMarker?.kind) return false;
                 this.coordinate_ = evt.coordinate;
                 this.feature_ = feature;
                 this.layer_ = tempMarker;
@@ -2374,7 +2501,7 @@ function iconKey(filename) {
          * @param {ol.MapBrowserEvent} evt Map browser event.
          */
         app.handleDragEvent = function (evt) {
-            if (!tempMarker || !tempMarker.kind) return;
+            if (!tempMarker?.kind) return;
             
             if (tempMarker.kind == "safehomecircle" || tempMarker.kind == "geozonecircle") {
                 return;
@@ -2456,7 +2583,7 @@ function iconKey(filename) {
                     return layer;
                 });
             const element = evt.map.getTargetElement();
-            const isLine = hoverLayer && hoverLayer.kind === 'line' && hoverLayer.selection;
+            const isLine = hoverLayer?.kind === 'line' && hoverLayer.selection;
 
             if (feature && feature.name != "circleFeature" && feature.name != "circleSafeFeature") {
                 if (isLine) {
@@ -2477,7 +2604,7 @@ function iconKey(filename) {
          * @param {ol.MapBrowserEvent} evt Map browser event.
          * @return {boolean} `false` to stop the drag sequence.
          */
-        app.handleUpEvent = function (evt) {
+        app.handleUpEvent = function (evt) { // NOSONAR - OpenLayers PointerInteraction ends the drag sequence by returning false here.
             if (!tempMarker || !tempMarker.kind) return false;
             if (tempMarker.kind == "waypoint") {
                 if (selectedMarker != null && tempMarker.number == selectedMarker.getLayerNumber()) {
@@ -2697,11 +2824,11 @@ function iconKey(filename) {
                 tempMarker = null;
             }
             // Clicking RTH/heading marker selects the parent waypoint
-            if (tempMarker && (tempMarker.kind === 'rth' || tempMarker.kind === 'heading') && tempMarker.parentLayerNumber >= 0) {
+            if ((tempMarker?.kind === 'rth' || tempMarker?.kind === 'heading') && tempMarker.parentLayerNumber >= 0) {
                 selectWaypointByLayerNumber(tempMarker.parentLayerNumber);
                 return;
             }
-            if (selectedFeature && tempMarker && tempMarker.kind == "waypoint") {
+            if (selectedFeature && tempMarker?.kind == "waypoint") {
                 $("#editMission").hide();
                 selectedMarker = mission.getWaypoint(tempMarker.number);
 
@@ -2712,8 +2839,8 @@ function iconKey(filename) {
                     selectedFwApproachWp.setLandAltAsl(settings.fwLandAlt * 100);
                 }
 
-                var geometry = selectedFeature.getGeometry();
-                var coord = toLonLat(geometry.getCoordinates());
+                const geometry = selectedFeature.getGeometry();
+                const coord = toLonLat(geometry.getCoordinates());
 
                 selectedFeature.setStyle(getWaypointIcon(selectedMarker, true));
 
@@ -2725,7 +2852,7 @@ function iconKey(filename) {
                 changeSwitch($('#pointP3UserAction3'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_3));
                 changeSwitch($('#pointP3UserAction4'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_4));
 
-                var altitudeMeters = app.ConvertCentimetersToMeters(selectedMarker.getAlt());
+                const altitudeMeters = app.ConvertCentimetersToMeters(selectedMarker.getAlt());
 
                 if (selectedMarker.getAction() == MWNP.WPTYPE.LAND) {
                     $('#wpFwLanding').fadeIn(300);
@@ -4056,11 +4183,11 @@ function iconKey(filename) {
 
         function getGridParams() {
             return {
-                spacing: parseFloat($('#gridSpacing').val()) || 25,
-                altitude: (parseFloat($('#gridAltitude').val()) || 50) * 100,
-                speed: (parseFloat($('#gridSpeed').val()) || 0) * 100,
-                angle: parseFloat($('#gridAngle').val()) || 0,
-                overshoot: parseFloat($('#gridOvershoot').val()) || 0,
+                spacing: Number.parseFloat($('#gridSpacing').val()) || 25,
+                altitude: (Number.parseFloat($('#gridAltitude').val()) || 50) * 100,
+                speed: (Number.parseFloat($('#gridSpeed').val()) || 0) * 100,
+                angle: Number.parseFloat($('#gridAngle').val()) || 0,
+                overshoot: Number.parseFloat($('#gridOvershoot').val()) || 0,
             };
         }
 
@@ -4181,7 +4308,7 @@ function iconKey(filename) {
 
             // Append RTH waypoint if checkbox is checked
             if ($('#gridEndRTH').is(':checked')) {
-                const lastWp = waypoints[waypoints.length - 1];
+                const lastWp = waypoints.at(-1);
                 const rthWp = new Waypoint(
                     mission.get().length,
                     MWNP.WPTYPE.RTH,
@@ -4207,202 +4334,103 @@ function iconKey(filename) {
             selectWaypointByLayerNumber(0);
         });
 
-        /**
-         * Compute the optimal angle for survey lines by finding the longest edge
-         * of the polygon and using its bearing as the line direction.
-         */
-        function computeOptimalAngle(coordsLonLat) {
-            let maxDist = 0;
-            let bestAngle = 0;
-            for (let i = 0; i < coordsLonLat.length - 1; i++) {
-                const dx = coordsLonLat[i + 1][0] - coordsLonLat[i][0];
-                const dy = coordsLonLat[i + 1][1] - coordsLonLat[i][1];
-                const dist = dx * dx + dy * dy;
-                if (dist > maxDist) {
-                    maxDist = dist;
-                    bestAngle = Math.atan2(dx, dy) * 180 / Math.PI;
-                }
-            }
-            return ((bestAngle % 360) + 360) % 360;
-        }
-
-        /**
-         * Generate lawnmower/zigzag waypoints inside a polygon.
-         * @param {Array} coordsLonLat - Polygon vertices as [lon, lat] pairs (last == first)
-         * @param {Object} params - { spacing (m), angle (deg), overshoot (m) }
-         * @returns {Array} Array of { lat, lon } objects
-         */
-        function generateGridWaypoints(coordsLonLat, params) {
-            const verts = coordsLonLat.slice(0, -1); // Remove closing duplicate
-            if (verts.length < 3) return [];
-
-            // Convert to local meters using centroid as origin
-            const centroid = verts.reduce((acc, v) => [acc[0] + v[0] / verts.length, acc[1] + v[1] / verts.length], [0, 0]);
-            const cosLat = Math.cos(centroid[1] * Math.PI / 180);
-            const metersPerDegLon = 111320 * cosLat;
-            const metersPerDegLat = 110540;
-
-            function toLocal(lonlat) {
-                return [(lonlat[0] - centroid[0]) * metersPerDegLon, (lonlat[1] - centroid[1]) * metersPerDegLat];
-            }
-            function toGeo(xy) {
-                return [centroid[0] + xy[0] / metersPerDegLon, centroid[1] + xy[1] / metersPerDegLat];
-            }
-
-            const localVerts = verts.map(toLocal);
-
-            // Rotate polygon so sweep lines are horizontal
-            const angleRad = params.angle * Math.PI / 180;
-            function rotate(p, a) {
-                const c = Math.cos(a), s = Math.sin(a);
-                return [p[0] * c - p[1] * s, p[0] * s + p[1] * c];
-            }
-            function unrotate(p, a) { return rotate(p, -a); }
-
-            const rotVerts = localVerts.map(v => rotate(v, -angleRad));
-
-            // Find Y extent
-            let minY = Infinity, maxY = -Infinity;
-            rotVerts.forEach(v => { minY = Math.min(minY, v[1]); maxY = Math.max(maxY, v[1]); });
-
-            const spacing = params.spacing;
-            if (spacing <= 0) return [];
-
-            // Generate horizontal sweep lines
-            const waypoints = [];
-            let direction = 1; // 1 = left-to-right, -1 = right-to-left
-
-            // Start first line half-spacing inside the boundary
-            const startY = minY + spacing * 0.25;
-            const endY = maxY - spacing * 0.25;
-
-            for (let y = startY; y <= endY; y += spacing) {
-                // Find intersections of line y=const with polygon edges
-                const intersections = [];
-                for (let i = 0; i < rotVerts.length; i++) {
-                    const j = (i + 1) % rotVerts.length;
-                    const y1 = rotVerts[i][1], y2 = rotVerts[j][1];
-                    if ((y1 <= y && y2 > y) || (y2 <= y && y1 > y)) {
-                        const t = (y - y1) / (y2 - y1);
-                        const x = rotVerts[i][0] + t * (rotVerts[j][0] - rotVerts[i][0]);
-                        intersections.push(x);
-                    }
-                }
-
-                intersections.sort((a, b) => a - b);
-
-                // Process pairs of intersections (entry/exit)
-                for (let k = 0; k + 1 < intersections.length; k += 2) {
-                    let x1 = intersections[k];
-                    let x2 = intersections[k + 1];
-
-                    // Apply overshoot extension
-                    if (params.overshoot > 0) {
-                        x1 -= params.overshoot;
-                        x2 += params.overshoot;
-                    }
-
-                    // Order points based on sweep direction
-                    const ptA = direction > 0 ? [x1, y] : [x2, y];
-                    const ptB = direction > 0 ? [x2, y] : [x1, y];
-
-                    const geoA = toGeo(unrotate(ptA, angleRad));
-                    const geoB = toGeo(unrotate(ptB, angleRad));
-
-                    waypoints.push({ lon: geoA[0], lat: geoA[1] });
-                    waypoints.push({ lon: geoB[0], lat: geoB[1] });
-                }
-
-                direction *= -1; // Alternate sweep direction for lawnmower
-            }
-
-            return waypoints;
-        }
-
         // Keyboard shortcuts (ignored when typing in inputs):
         //  C -> center on latest GPS fix
         //  Ctrl+L -> load mission from file
         //  Ctrl+S -> save mission to file
         //  Ctrl+D -> delete all points
         //  Ctrl+A -> address search dialog
-        $(document).off('keydown.mcCenter').on('keydown.mcCenter', function (e) {
+        function handleWaypointNavigationShortcut(e, key) {
+            if (key !== 'arrowleft' && key !== 'arrowright') {
+                return false;
+            }
+
+            e.preventDefault();
+
+            const waypointList = mission.get().filter(function (waypoint) {
+                return !waypoint.isAttached();
+            });
+            if (waypointList.length === 0) {
+                return true;
+            }
+
+            const currentLayerNum = selectedMarker ? selectedMarker.getLayerNumber() : -1;
+            const targetLayerNum = key === 'arrowleft'
+                ? (currentLayerNum > 0 ? currentLayerNum - 1 : waypointList.length - 1)
+                : (currentLayerNum < waypointList.length - 1 ? currentLayerNum + 1 : 0);
+
+            selectWaypointByLayerNumber(targetLayerNum);
+            return true;
+        }
+
+        function handleMissionControlCtrlShortcut(e, key) {
+            if (e.repeat || !e.ctrlKey) {
+                return false;
+            }
+
+            const shortcutActions = {
+                l() { $('#loadFileMissionButton').trigger('click'); },
+                s() { $('#saveFileMissionButton').trigger('click'); },
+                d() { $('#removeAllPoints').trigger('click'); },
+                a() { $('#searchAddressButton').trigger('click'); },
+                g() { startGridPolygonDraw(); },
+            };
+
+            const shortcutAction = shortcutActions[key];
+            if (!shortcutAction) {
+                return false;
+            }
+
+            e.preventDefault();
+            shortcutAction();
+            return true;
+        }
+
+        function handleMissionControlDeleteShortcut(e, key) {
+            if (key !== 'delete' || !selectedMarker) {
+                return false;
+            }
+
+            e.preventDefault();
+            if (dialog.confirm(i18n.getMessage('confirm_delete_selected_point'))) {
+                $('#removePoint').trigger('click');
+            }
+
+            return true;
+        }
+
+        function handleMissionControlKeydown(e) {
             const key = (e.key || '').toLowerCase();
-            const target = e.target;
-            const isTyping = target && (
-                target.tagName === 'INPUT' ||
-                target.tagName === 'TEXTAREA' ||
-                target.isContentEditable ||
-                target.tagName === 'SELECT'
-            );
-            if (isTyping) return;
-
-            // Center on GPS fix (plain C or Ctrl+C)
-            if (!e.repeat && key === 'c') {
-                if (lastGpsPos && map && map.getView()) {
-                    map.getView().setCenter(lastGpsPos);
-                }
+            if (isMissionControlTypingTarget(e.target)) {
+                return;
             }
 
-            // Ctrl+L: open mission from file
-            if (!e.repeat && e.ctrlKey && key === 'l') {
-                e.preventDefault();
-                $('#loadFileMissionButton').trigger('click');
+            if (!e.repeat && key === 'c' && lastGpsPos && map?.getView()) {
+                map.getView().setCenter(lastGpsPos);
             }
 
-            // Ctrl+S: save mission to file
-            if (!e.repeat && e.ctrlKey && key === 's') {
-                e.preventDefault();
-                $('#saveFileMissionButton').trigger('click');
+            if (handleMissionControlCtrlShortcut(e, key)) {
+                return;
             }
 
-            // Ctrl+D: delete all points
-            if (!e.repeat && e.ctrlKey && key === 'd') {
-                e.preventDefault();
-                $('#removeAllPoints').trigger('click');
+            if (handleMissionControlDeleteShortcut(e, key)) {
+                return;
             }
 
-            // Ctrl+A: address search
-            if (!e.repeat && e.ctrlKey && key === 'a') {
-                e.preventDefault();
-                $('#searchAddressButton').trigger('click');
-            }
+            handleWaypointNavigationShortcut(e, key);
+        }
 
-            // Ctrl+G: grid pattern
-            if (!e.repeat && e.ctrlKey && key === 'g') {
-                e.preventDefault();
-                startGridPolygonDraw();
-            }
-
-            // Delete key: delete selected waypoint with confirmation
-            if (key === 'delete' && selectedMarker && !$(e.target).is('input, select, textarea')) {
-                e.preventDefault();
-                if (dialog.confirm(i18n.getMessage('confirm_delete_selected_point'))) {
-                    $('#removePoint').trigger('click');
-                }
-            }
-
-            // Left/Right arrow keys: navigate between waypoints
-            if ((key === 'arrowleft' || key === 'arrowright') && !$(e.target).is('input, select, textarea')) {
-                e.preventDefault();
-                const wpList = mission.get().filter(function (wp) { return !wp.isAttached(); });
-                if (wpList.length === 0) return;
-
-                const currentLayerNum = selectedMarker ? selectedMarker.getLayerNumber() : -1;
-                let targetLayerNum;
-                if (key === 'arrowleft') {
-                    targetLayerNum = currentLayerNum > 0 ? currentLayerNum - 1 : wpList.length - 1;
-                } else {
-                    targetLayerNum = currentLayerNum < wpList.length - 1 ? currentLayerNum + 1 : 0;
-                }
-                selectWaypointByLayerNumber(targetLayerNum);
-            }
-        });
+        $(document).off('keydown.mcCenter').on('keydown.mcCenter', handleMissionControlKeydown);
 
         // Programmatically select a waypoint by its layer number (0-based display index)
         function selectWaypointByLayerNumber(layerNum) {
             // Deselect current
             if (selectedFeature && selectedMarker) {
-                try { selectedFeature.setStyle(getWaypointIcon(selectedMarker, false)); } catch (e) {}
+                try {
+                    selectedFeature.setStyle(getWaypointIcon(selectedMarker, false));
+                } catch (error) {
+                    console.debug('Ignoring stale waypoint feature during deselection', error);
+                }
             }
             selectedMarker = null;
             selectedFeature = null;
@@ -4465,11 +4493,16 @@ function iconKey(filename) {
             $('#pointP2').val(selectedMarker.getP2());
 
             for (const j in dictOfLabelParameterPoint[selectedMarker.getAction()]) {
-                if (dictOfLabelParameterPoint[selectedMarker.getAction()][j] != '') {
-                    $('#pointP'+String(j).slice(-1)+'class').fadeIn(300);
-                    $('label[for=pointP'+String(j).slice(-1)+']').html(dictOfLabelParameterPoint[selectedMarker.getAction()][j]);
+                const labelText = dictOfLabelParameterPoint[selectedMarker.getAction()][j];
+                const parameterSuffix = String(j).slice(-1);
+
+                if (labelText === '') {
+                    $('#pointP' + parameterSuffix + 'class').fadeOut(300);
+                    continue;
                 }
-                else {$('#pointP'+String(j).slice(-1)+'class').fadeOut(300);}
+
+                $('#pointP' + parameterSuffix + 'class').fadeIn(300);
+                $('label[for=pointP' + parameterSuffix + ']').html(labelText);
             }
             selectedMarker = renderWaypointOptionsTable(selectedMarker);
             $('#EditPointNumber').text("Edit point "+String(selectedMarker.getLayerNumber()+1));
@@ -4486,55 +4519,66 @@ function iconKey(filename) {
             redrawLayer();
         }
 
-        $('#removePoint').on('click', function () {
-            if (selectedMarker) {
-                const prevLayerNum = selectedMarker.getLayerNumber() - 1;
-
-                if (mission.isJumpTargetAttached(selectedMarker)) {
-                    dialog.alert(i18n.getMessage('MissionPlannerJumpTargetRemoval'));
-                }
-                else if (mission.getAttachedFromWaypoint(selectedMarker) && mission.getAttachedFromWaypoint(selectedMarker).length != 0) {
-                    if (dialog.confirm(i18n.getMessage('confirm_delete_point_with_options'))) {
-                        mission.getAttachedFromWaypoint(selectedMarker).forEach(function (element) {
-
-                            if (element.getAction() == MWNP.WPTYPE.LAND) {
-                                FC.FW_APPROACH.clean(element.getNumber());
-                            }
-
-                            mission.dropWaypoint(element);
-                            mission.update(singleMissionActive());
-                        });
-                        mission.dropWaypoint(selectedMarker);
-                        selectedMarker = null;
-                        mission.update(singleMissionActive());
-                        clearEditForm();
-                        refreshLayers();
-                        plotElevation();
-                        updateLocationButtonsVisibility();
-
-                        if (prevLayerNum >= 0 && !mission.isEmpty()) {
-                            selectWaypointByLayerNumber(Math.min(prevLayerNum, mission.get().filter(function (wp) { return !wp.isAttached(); }).length - 1));
-                        }
-                    }
-                }
-                else {
-                    mission.dropWaypoint(selectedMarker);
-                    if (selectedMarker.getAction() == MWNP.WPTYPE.LAND) {
-                        FC.FW_APPROACH.clean(selectedFwApproachWp.getNumber());
-                    }
-                    selectedMarker = null;
-                    mission.update(singleMissionActive());
-                    clearEditForm();
-                    refreshLayers();
-                    plotElevation();
-
-                    if (prevLayerNum >= 0 && !mission.isEmpty()) {
-                        selectWaypointByLayerNumber(Math.min(prevLayerNum, mission.get().filter(function (wp) { return !wp.isAttached(); }).length - 1));
-                    }
-                }
-                updateMultimissionState();
-                updateLocationButtonsVisibility();
+        function selectPreviousWaypoint(prevLayerNum) {
+            if (prevLayerNum < 0 || mission.isEmpty()) {
+                return;
             }
+
+            const waypointCount = mission.get().filter(function (waypoint) {
+                return !waypoint.isAttached();
+            }).length;
+
+            selectWaypointByLayerNumber(Math.min(prevLayerNum, waypointCount - 1));
+        }
+
+        function finalizeWaypointRemoval(prevLayerNum) {
+            mission.update(singleMissionActive());
+            clearEditForm();
+            refreshLayers();
+            plotElevation();
+            selectPreviousWaypoint(prevLayerNum);
+        }
+
+        function removeAttachedWaypoints(attachedWaypoints) {
+            attachedWaypoints.forEach(function (waypoint) {
+                if (waypoint.getAction() == MWNP.WPTYPE.LAND) {
+                    FC.FW_APPROACH.clean(waypoint.getNumber());
+                }
+
+                mission.dropWaypoint(waypoint);
+            });
+        }
+
+        $('#removePoint').on('click', function () {
+            if (!selectedMarker) {
+                return;
+            }
+
+            const prevLayerNum = selectedMarker.getLayerNumber() - 1;
+            const attachedWaypoints = mission.getAttachedFromWaypoint(selectedMarker) || [];
+
+            if (mission.isJumpTargetAttached(selectedMarker)) {
+                dialog.alert(i18n.getMessage('MissionPlannerJumpTargetRemoval'));
+            } else if (attachedWaypoints.length > 0) {
+                if (!dialog.confirm(i18n.getMessage('confirm_delete_point_with_options'))) {
+                    return;
+                }
+
+                removeAttachedWaypoints(attachedWaypoints);
+                mission.dropWaypoint(selectedMarker);
+                selectedMarker = null;
+                finalizeWaypointRemoval(prevLayerNum);
+            } else {
+                mission.dropWaypoint(selectedMarker);
+                if (selectedMarker.getAction() == MWNP.WPTYPE.LAND) {
+                    FC.FW_APPROACH.clean(selectedFwApproachWp.getNumber());
+                }
+                selectedMarker = null;
+                finalizeWaypointRemoval(prevLayerNum);
+            }
+
+            updateMultimissionState();
+            updateLocationButtonsVisibility();
         });
 
         /////////////////////////////////////////////

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -546,15 +546,15 @@ function iconKey(filename) {
     //////////////////////////////////////////////////////////////////////////////////////////////
     //      define & init parameters for Selected Marker
     //////////////////////////////////////////////////////////////////////////////////////////////
-    var selectedMarker = null;
-    var selectedFeature = null;
-    var tempMarker = null;
-    var disableMarkerEdit = false;
-    var selectedFwApproachWp = null;
-    var selectedFwApproachSh = null;
-    var lockShExclHeading = false;
-    var gridDrawInteraction = null;
-    var gridPreviewLayer = null;
+    let selectedMarker = null;
+    let selectedFeature = null;
+    let tempMarker = null;
+    let disableMarkerEdit = false;
+    let selectedFwApproachWp = null;
+    let selectedFwApproachSh = null;
+    let lockShExclHeading = false;
+    let gridDrawInteraction = null;
+    let gridPreviewLayer = null;
 
 
     //////////////////////////////////////////////////////////////////////////////////////////////
@@ -1610,8 +1610,8 @@ function iconKey(filename) {
     }
 
     // Vertical pixel offset to push RTH/heading markers below the WP pin (increase to move further down)
-    var MARKER_ICON_OFFSET_Y = 11;
-    var MARKER_ICON_OFFSET_X = -2;  // Match WP pin text offsetX
+    const MARKER_ICON_OFFSET_Y = 11;
+    const MARKER_ICON_OFFSET_X = -2;  // Match WP pin text offsetX
 
     function repaintLine4Waypoints(mission) {
         let oldPos,
@@ -1667,12 +1667,12 @@ function iconKey(filename) {
                 if (element.getAction() == MWNP.WPTYPE.RTH && typeof oldPos !== 'undefined') {
                     // RTH marker
                     // RTH marker as SVG
-                    var markerOpacity = 0.85;
-                    var rthSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" opacity="' + markerOpacity + '">' +
+                    const markerOpacity = 0.85;
+                    const rthSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" opacity="' + markerOpacity + '">' +
                         '<circle cx="12" cy="12" r="10" fill="#00c850" stroke="#fff" stroke-width="2"/>' +
                         '<text x="12" y="15" text-anchor="middle" font-size="7" font-family="sans-serif" font-weight="bold" fill="#fff">RTH</text>' +
                         '</svg>';
-                    var rthMarker = new Feature({ geometry: new Point(oldPos) });
+                    const rthMarker = new Feature({ geometry: new Point(oldPos) });
                     rthMarker.setStyle(new Style({
                         image: new Icon({
                             src: 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(rthSvg),
@@ -1680,8 +1680,8 @@ function iconKey(filename) {
                             displacement: [MARKER_ICON_OFFSET_X, -MARKER_ICON_OFFSET_Y],
                         }),
                     }));
-                    var rthSource = new VectorSource({ features: [rthMarker] });
-                    var rthLayer = new VectorLayer({ source: rthSource, zIndex: 99 });
+                    const rthSource = new VectorSource({ features: [rthMarker] });
+                    const rthLayer = new VectorLayer({ source: rthSource, zIndex: 99 });
                     rthLayer.kind = "rth";
                     rthLayer.selection = false;
                     rthLayer.parentLayerNumber = lastWaypointLayerNumber;
@@ -1707,17 +1707,17 @@ function iconKey(filename) {
 
                         // Black circle with white arrow pointing in the heading direction
                         if (typeof oldPos !== 'undefined') {
-                            var headingDeg = element.getP1();
+                            const headingDeg = element.getP1();
                             // SVG: circle stays fixed, arrow rotates around center via SVG transform
-                            var markerOpacity = 0.85;
+                            const markerOpacity = 0.85;
 
-                            var arrowSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" opacity="' + markerOpacity + '">'
+                            const arrowSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" opacity="' + markerOpacity + '">'
                             + '<circle cx="12" cy="12" r="10" fill="#222" stroke="#fff" stroke-width="2"/>'
                             + '<line x1="12" y1="2.71" x2="12" y2="12" stroke="#fff" stroke-width="1" transform="rotate(' + headingDeg + ' 12 12)"/>'
                             + '<path d="M12 2.5 L15 8.5 L12 6.5 L9 8.5 Z" fill="#fff" transform="rotate(' + headingDeg + ' 12 12)"/>'
                             + '<circle cx="12" cy="12" r="0.9" fill="#fff"/>'
                             + '</svg>';
-                            var headMarker = new Feature({ geometry: new Point(oldPos) });
+                            const headMarker = new Feature({ geometry: new Point(oldPos) });
                             headMarker.setStyle([
                                 new Style({
                                     image: new Icon({
@@ -1737,8 +1737,8 @@ function iconKey(filename) {
                                     }),
                                 }),
                             ]);
-                            var headSource = new VectorSource({ features: [headMarker] });
-                            var headLayer = new VectorLayer({ source: headSource, zIndex: 99 });
+                            const headSource = new VectorSource({ features: [headMarker] });
+                            const headLayer = new VectorLayer({ source: headSource, zIndex: 99 });
                             headLayer.kind = "heading";
                             headLayer.selection = false;
                             headLayer.parentLayerNumber = lastWaypointLayerNumber;
@@ -2447,16 +2447,16 @@ function iconKey(filename) {
          */
         app.handleMoveEvent = function (evt) {
             var map = evt.map;
-            var feature = map.forEachFeatureAtPixel(evt.pixel,
+            const feature = map.forEachFeatureAtPixel(evt.pixel,
                 function (feature, layer) {
                     return feature;
                 });
-            var hoverLayer = map.forEachFeatureAtPixel(evt.pixel,
+            const hoverLayer = map.forEachFeatureAtPixel(evt.pixel,
                 function (feature, layer) {
                     return layer;
                 });
-            var element = evt.map.getTargetElement();
-            var isLine = hoverLayer && hoverLayer.kind === 'line' && hoverLayer.selection;
+            const element = evt.map.getTargetElement();
+            const isLine = hoverLayer && hoverLayer.kind === 'line' && hoverLayer.selection;
 
             if (feature && feature.name != "circleFeature" && feature.name != "circleSafeFeature") {
                 if (isLine) {
@@ -2624,7 +2624,7 @@ function iconKey(filename) {
             $('.ol-attribution a').attr('target', '_blank');
         }, 100);
         // "Add WP" tooltip overlay shown when hovering on a flight path line
-        var addWpTooltipEl = document.createElement('div');
+        const addWpTooltipEl = document.createElement('div');
         addWpTooltipEl.className = 'add-wp-tooltip';
         addWpTooltipEl.innerHTML = '<span style="font-size:1.1em;font-weight:bold;">＋</span> Add WP';
         Object.assign(addWpTooltipEl.style, {
@@ -2639,7 +2639,7 @@ function iconKey(filename) {
             boxShadow: '0 1px 4px rgba(0,0,0,0.3)',
             display: 'none',
         });
-        var addWpOverlay = new Overlay({
+        const addWpOverlay = new Overlay({
             element: addWpTooltipEl,
             offset: [12, -12],
             positioning: 'bottom-left',
@@ -4051,8 +4051,8 @@ function iconKey(filename) {
             updateGridPreview();
         }
 
-        var gridPolygonCoords = null;
-        var gridPolygonGeom = null;
+        let gridPolygonCoords = null;
+        let gridPolygonGeom = null;
 
         function getGridParams() {
             return {
@@ -4384,11 +4384,11 @@ function iconKey(filename) {
             // Left/Right arrow keys: navigate between waypoints
             if ((key === 'arrowleft' || key === 'arrowright') && !$(e.target).is('input, select, textarea')) {
                 e.preventDefault();
-                var wpList = mission.get().filter(function (wp) { return !wp.isAttached(); });
+                const wpList = mission.get().filter(function (wp) { return !wp.isAttached(); });
                 if (wpList.length === 0) return;
 
-                var currentLayerNum = selectedMarker ? selectedMarker.getLayerNumber() : -1;
-                var targetLayerNum;
+                const currentLayerNum = selectedMarker ? selectedMarker.getLayerNumber() : -1;
+                let targetLayerNum;
                 if (key === 'arrowleft') {
                     targetLayerNum = currentLayerNum > 0 ? currentLayerNum - 1 : wpList.length - 1;
                 } else {
@@ -4409,7 +4409,7 @@ function iconKey(filename) {
             tempMarker = null;
 
             // Find the marker layer with this layerNumber
-            var markerLayer = markers.find(function (m) { return m.layerNumber === layerNum; });
+            const markerLayer = markers.find(function (m) { return m.layerNumber === layerNum; });
             if (!markerLayer) {
                 clearEditForm();
                 return;
@@ -4428,7 +4428,7 @@ function iconKey(filename) {
 
             selectedFeature.setStyle(getWaypointIcon(selectedMarker, true));
 
-            var coord = toLonLat(selectedFeature.getGeometry().getCoordinates());
+            const coord = toLonLat(selectedFeature.getGeometry().getCoordinates());
             let P3Value = selectedMarker.getP3();
 
             changeSwitch($('#pointP3Alt'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.ALT_TYPE));
@@ -4437,7 +4437,7 @@ function iconKey(filename) {
             changeSwitch($('#pointP3UserAction3'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_3));
             changeSwitch($('#pointP3UserAction4'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_4));
 
-            var altitudeMeters = selectedMarker.getAlt() / 100;
+            const altitudeMeters = selectedMarker.getAlt() / 100;
 
             if (selectedMarker.getAction() == MWNP.WPTYPE.LAND) {
                 $('#wpFwLanding').fadeIn(300);
@@ -4464,7 +4464,7 @@ function iconKey(filename) {
             $('#pointP1').val(selectedMarker.getP1());
             $('#pointP2').val(selectedMarker.getP2());
 
-            for (var j in dictOfLabelParameterPoint[selectedMarker.getAction()]) {
+            for (const j in dictOfLabelParameterPoint[selectedMarker.getAction()]) {
                 if (dictOfLabelParameterPoint[selectedMarker.getAction()][j] != '') {
                     $('#pointP'+String(j).slice(-1)+'class').fadeIn(300);
                     $('label[for=pointP'+String(j).slice(-1)+']').html(dictOfLabelParameterPoint[selectedMarker.getAction()][j]);
@@ -4475,7 +4475,7 @@ function iconKey(filename) {
             $('#EditPointNumber').text("Edit point "+String(selectedMarker.getLayerNumber()+1));
 
             // Stop any in-progress fadeOut from clearEditForm, then show card
-            var $card = $('#MPeditPoint');
+            const $card = $('#MPeditPoint');
             $card.stop(true, true);
             if ($card.is(':visible')) {
                 $card.css('opacity', 0.3).animate({ opacity: 1 }, 200);
@@ -4488,7 +4488,7 @@ function iconKey(filename) {
 
         $('#removePoint').on('click', function () {
             if (selectedMarker) {
-                var prevLayerNum = selectedMarker.getLayerNumber() - 1;
+                const prevLayerNum = selectedMarker.getLayerNumber() - 1;
 
                 if (mission.isJumpTargetAttached(selectedMarker)) {
                     dialog.alert(i18n.getMessage('MissionPlannerJumpTargetRemoval'));


### PR DESCRIPTION
Add a lawnmower/grid survey pattern generator that allows users to define a polygon area on the map and automatically generate survey waypoints within it.

Features:
- Grid survey button in Action Menu with polygon drawing interaction
- Sidebar settings card with line spacing, altitude, speed, sweep angle, overshoot, and End with RTH checkbox
- Live auto-preview: polygon outline, dashed survey path, and numbered waypoint dots update as parameters change
- Lawnmower pattern algorithm with configurable sweep angle and overshoot
- RTH waypoint automatically appended when End with RTH is checked
- Waypoint count display with remaining capacity
- Ctrl+G keyboard shortcut to activate grid draw mode
- Full i18n support for all UI strings

Draw complex surveys in seconds
<img width="975" height="780" alt="image" src="https://github.com/user-attachments/assets/aecd00cd-34b0-4bee-b44f-60c422f57cb1" />

Preview and Edit Before you generate the survey, 
<img width="975" height="779" alt="image" src="https://github.com/user-attachments/assets/f4a2b6ff-b32c-4433-96b6-bc27af0afc46" />

Generate mission with clear makings on where the RTH will activate
<img width="1182" height="936" alt="image" src="https://github.com/user-attachments/assets/b020568f-2d69-4676-b6ea-2fba41aa7273" />

Create large surveys with multiple POI in seconds
<img width="1123" height="842" alt="image" src="https://github.com/user-attachments/assets/b6547822-7c78-458b-b9f2-8e1d38f0385d" />

Clearly see RTH and Heading Settings
<img width="1106" height="828" alt="image" src="https://github.com/user-attachments/assets/8b43adff-4f96-4796-8919-7645b2beb55a" />

These missions can be made in seconds.
