### PR TITLE
Allow motor test mode when reversible motors (3D) enabled

### DIFF
--- a/tabs/outputs.js
+++ b/tabs/outputs.js
@@ -16,14 +16,12 @@ import interval from './../js/intervals';
 
 TABS.outputs = {
     allowTestMode: false,
-    feature3DEnabled: false,
-    feature3DSupported: false
+    feature3DEnabled: false
 };
 TABS.outputs.initialize = function (callback) {
     var self = this;
 
     self.armed = false;
-    self.feature3DSupported = false;
     self.allowTestMode = true;
 
     var $motorsEnableTestMode;
@@ -402,10 +400,6 @@ TABS.outputs.initialize = function (callback) {
     function process_motors() {
         $motorsEnableTestMode = $('#motorsEnableTestMode');
 
-        if (self.feature3DEnabled && !self.feature3DSupported) {
-            self.allowTestMode = false;
-        }
-
         $motorsEnableTestMode.prop('checked', false);
         $motorsEnableTestMode.prop('disabled', true);
 
@@ -526,10 +520,9 @@ TABS.outputs.initialize = function (callback) {
         $slidersInput.prop('max', FC.MISC.maxthrottle);
         $('div.values li:not(:last)').text(FC.MISC.mincommand);
 
-        if (self.feature3DEnabled && self.feature3DSupported) {
-            //Arbitrary sanity checks
-            //Note: values may need to be revisited
-            if (FC.REVERSIBLE_MOTORS.neutral > 1575 || FC.EVERSIBLE_MOTORS.neutral < 1425)
+        if (self.feature3DEnabled) {
+            // Clamp neutral to safe range around midpoint (1500us); values outside indicate corrupt config
+            if (FC.REVERSIBLE_MOTORS.neutral > 1575 || FC.REVERSIBLE_MOTORS.neutral < 1425)
                 FC.REVERSIBLE_MOTORS.neutral = 1500;
 
             $slidersInput.val(FC.REVERSIBLE_MOTORS.neutral);
@@ -590,7 +583,7 @@ TABS.outputs.initialize = function (callback) {
                 $slidersInput.prop('disabled', true);
 
                 // change all values to default
-                if (self.feature3DEnabled && self.feature3DSupported) {
+                if (self.feature3DEnabled) {
                     $slidersInput.val(FC.REVERSIBLE_MOTORS.neutral);
                 } else {
                     $slidersInput.val(FC.MISC.mincommand);


### PR DESCRIPTION
Needs firmware support for reverse to work

## Summary

Fixes the Outputs tab motor test checkbox being disabled when the REVERSIBLE_MOTORS feature (3D mode / bidirectional ESCs) is enabled.

## Problem

`feature3DSupported` was initialized to `false` and never set to `true` anywhere. This caused the guard `if (self.feature3DEnabled && !self.feature3DSupported)` to always block test mode for 3D users. The variable was a leftover from a removed API version check (commit ef831a3 from 2016).

Additionally, a typo (`FC.EVERSIBLE_MOTORS` instead of `FC.REVERSIBLE_MOTORS`) in the neutral value sanity check would have caused a runtime TypeError if the code path had been reachable.

## Changes

- Removed `feature3DSupported` variable and the guard that blocked test mode
- Simplified `feature3DEnabled && feature3DSupported` checks to just `feature3DEnabled`
- Fixed typo `FC.EVERSIBLE_MOTORS` → `FC.REVERSIBLE_MOTORS`
- Improved comment on neutral value sanity check bounds
- Slider initialize to center when reversible mode is on

## Testing

- Verified motor test checkbox enables correctly with REVERSIBLE_MOTORS feature active
- Sliders initialize to neutral point (1500) in 3D mode
- Motor values display raw PWM in 3D mode
- Normal (non-3D) motor testing unaffected