### PR TITLE
Mixer output mapping: prioritize dedicated timer outputs

### DIFF
--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -86,18 +86,31 @@ var OutputMappingCollection = function () {
 
         for (let i = 0; i < data.length; i++) {
             timerMap[i] = null;
+        }
 
-            if (servosToGo > 0 && BitHelper.bit_check(data[i]['usageFlags'], TIM_USE_LED)) {
-                console.log(i + ": LED");
-                timerMap[i] = OUTPUT_TYPE_LED;
-            } else if (servosToGo > 0 && BitHelper.bit_check(data[i]['usageFlags'], TIM_USE_SERVO)) {
-                console.log(i + ": SERVO");
-                servosToGo--;
-                timerMap[i] = OUTPUT_TYPE_SERVO;
-            } else if (motorsToGo > 0 && BitHelper.bit_check(data[i]['usageFlags'], TIM_USE_MOTOR)) {
-                console.log(i + ": MOTOR");
-                motorsToGo--;
-                timerMap[i] = OUTPUT_TYPE_MOTOR;
+        // Two priority passes: dedicated outputs first, then auto.
+        // Matches firmware pwmBuildTimerOutputList() behavior.
+        for (let priority = 0; priority < 2; priority++) {
+            let isDedicated = (priority === 0);
+
+            for (let i = 0; i < data.length; i++) {
+                if (timerMap[i] !== null) continue;
+
+                let flags = data[i]['usageFlags'];
+                let timerId = data[i]['timerId'];
+                let mode = timerOverrides[timerId] || self.TIMER_OUTPUT_MODE_AUTO;
+
+                if (motorsToGo > 0 && BitHelper.bit_check(flags, TIM_USE_MOTOR)
+                        && (isDedicated ? mode === self.TIMER_OUTPUT_MODE_MOTORS : mode !== self.TIMER_OUTPUT_MODE_MOTORS)) {
+                    timerMap[i] = OUTPUT_TYPE_MOTOR;
+                    motorsToGo--;
+                } else if (servosToGo > 0 && BitHelper.bit_check(flags, TIM_USE_SERVO)
+                        && (isDedicated ? mode === self.TIMER_OUTPUT_MODE_SERVOS : mode !== self.TIMER_OUTPUT_MODE_SERVOS)) {
+                    timerMap[i] = OUTPUT_TYPE_SERVO;
+                    servosToGo--;
+                } else if (!isDedicated && BitHelper.bit_check(flags, TIM_USE_LED)) {
+                    timerMap[i] = OUTPUT_TYPE_LED;
+                }
             }
         }
 


### PR DESCRIPTION
Before, even if the user specifically set MOTOR and SERVO timers (output), it would instead use the AUTO ones, disregarding the user's explicit instructions:

<img width="1010" height="436" alt="image" src="https://github.com/user-attachments/assets/acbc0fc1-7179-4e1c-bf8d-e396a0f3a749" />



Now, it follows instructions - if the user sets a timer as servos, use that for servos first:

<img width="993" height="391" alt="image" src="https://github.com/user-attachments/assets/182205ab-c1f4-4dbc-892b-06a39f5192fb" />


Companion firmware PR:
https://github.com/iNavFlight/inav/pull/11445

## Tests completed

- [x] Connect to FC with `timerOverrides` configured (e.g. TIM1=MOTORS, TIM2=SERVOS in config.c)
- [x] Load airplane preset in mixer tab
- [x] Verify output mapping preview shows motors on dedicated motor timer outputs and servos on dedicated servo timer outputs
- [x] Connect to FC with no `timerOverrides` and verify output mapping preview is unchanged from previous behavior