### PR TITLE
fixed usb descriptor len mismatch on some chips

### DIFF
--- a/js/protocols/stm32usbdfu.js
+++ b/js/protocols/stm32usbdfu.js
@@ -192,8 +192,13 @@ STM32DFU_protocol.prototype.getString = function (index, callback) {
     self.usbDevice.controlTransferIn(setup, 255).then(result => {
         if (result.status == 'ok') {;
             var length = result.data.getUint8(0);
+            var actualLength = result.data.byteLength;
+            // Some STM32 DFU implementations report incorrect bLength,
+            // so we must clamp it to the actual received buffer size
+            var safeLength = Math.min(length, actualLength);
             var descriptor = "";
-            for (var i = 2; i < length; i += 2) {
+            // Ensure we don't read past buffer (UTF-16 = 2 bytes per char)
+            for (var i = 2; i + 1 < safeLength; i += 2) {
                 var charCode = result.data.getUint16(i, true);
                 descriptor += String.fromCharCode(charCode);
             }

--- a/js/protocols/stm32usbdfu.js
+++ b/js/protocols/stm32usbdfu.js
@@ -191,15 +191,15 @@ STM32DFU_protocol.prototype.getString = function (index, callback) {
     };
     self.usbDevice.controlTransferIn(setup, 255).then(result => {
         if (result.status == 'ok') {;
-            var length = result.data.getUint8(0);
-            var actualLength = result.data.byteLength;
+            const  length = result.data.getUint8(0);
+            const  actualLength = result.data.byteLength;
             // Some STM32 DFU implementations report incorrect bLength,
             // so we must clamp it to the actual received buffer size
-            var safeLength = Math.min(length, actualLength);
-            var descriptor = "";
+            const  safeLength = Math.min(length, actualLength);
+            let descriptor = "";
             // Ensure we don't read past buffer (UTF-16 = 2 bytes per char)
-            for (var i = 2; i + 1 < safeLength; i += 2) {
-                var charCode = result.data.getUint16(i, true);
+            for (let  i = 2; i + 1 < safeLength; i += 2) {
+                const charCode = result.data.getUint16(i, true);
                 descriptor += String.fromCharCode(charCode);
             }
             callback(descriptor, 0);


### PR DESCRIPTION
Some DFU implementations (e.g. STM32 ROM bootloader on certain devices like stm32f427)
may report incorrect bLength in USB string descriptors.

Clamp descriptor length to actual buffer size to avoid out-of-bounds reads.