### PR TITLE
Auto-Backup, Restore & Settings Migration for Firmware Flashing

### DIFF
--- a/assets/linux/45-inav.rules
+++ b/assets/linux/45-inav.rules
@@ -1,0 +1,44 @@
+# INAV Configurator — udev rules for flight controller USB devices
+#
+# Install:
+#   sudo cp 45-inav.rules /etc/udev/rules.d/
+#   sudo udevadm control --reload-rules
+#   sudo udevadm trigger
+#
+# You may need to unplug and re-plug the device after installing.
+
+# --- DFU Bootloaders (needed for firmware flashing) ---
+
+# STM32 DFU Bootloader (0483:df11)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0666"
+
+# AT32 DFU Bootloader (2e3c:df11)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", MODE="0666"
+
+# APM32 DFU Bootloader (314b:0106)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="314b", ATTRS{idProduct}=="0106", MODE="0666"
+
+# --- Serial / VCP devices (for normal connection) ---
+
+# STM32 VCP (0483:5740)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0666"
+
+# STM32 HID (0483:3256)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3256", MODE="0666"
+
+# STM32 STLink VCP — NUCLEO boards (0483:374e)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374e", MODE="0666"
+
+# AT32 VCP (2e3c:5740)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="5740", MODE="0666"
+
+# APM32 VCP (314b:5740)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="314b", ATTRS{idProduct}=="5740", MODE="0666"
+
+# FTDI FT232R (0403:6001)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", MODE="0666"
+
+# Silicon Labs CP210x (10c4:ea60, 10c4:ea61, 10c4:ea62)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea61", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea62", MODE="0666"

--- a/assets/linux/postinst
+++ b/assets/linux/postinst
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Post-installation script: install udev rules for INAV flight controllers
+
+RULES_SRC="/usr/lib/inav-configurator/resources/45-inav.rules"
+RULES_DST="/etc/udev/rules.d/45-inav.rules"
+
+if [ -f "$RULES_SRC" ]; then
+    cp "$RULES_SRC" "$RULES_DST"
+    udevadm control --reload-rules 2>/dev/null || true
+    udevadm trigger 2>/dev/null || true
+fi
+
+exit 0

--- a/assets/linux/postrm
+++ b/assets/linux/postrm
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Post-removal script: remove udev rules
+
+RULES_DST="/etc/udev/rules.d/45-inav.rules"
+
+if [ -f "$RULES_DST" ]; then
+    rm -f "$RULES_DST"
+    udevadm control --reload-rules 2>/dev/null || true
+fi
+
+exit 0

--- a/forge.config.js
+++ b/forge.config.js
@@ -13,7 +13,12 @@ export default {
       'resources/public/sitl'
     ],
   },
-  rebuildConfig: {},
+  rebuildConfig: {
+    // Native modules (serialport, usb) ship with prebuilt binaries for each platform.
+    // vite-plugin-native handles them at build time. Skip electron-rebuild to avoid
+    // requiring Visual Studio Build Tools on Windows during development.
+    onlyModules: [],
+  },
   plugins: [
     {
       name: '@electron-forge/plugin-vite',

--- a/forge.config.js
+++ b/forge.config.js
@@ -10,7 +10,8 @@ export default {
     asar: false,
     icon: 'images/inav',
     extraResource: [
-      'resources/public/sitl'
+      'resources/public/sitl',
+      'assets/linux/45-inav.rules'
     ],
   },
   rebuildConfig: {
@@ -179,7 +180,10 @@ export default {
           icon: "./assets/linux/icon/inav_icon_128.png",
           description: "Configurator for the open source flight controller software INAV.",
           homepage: "https://github.com/inavflight/",
-
+          scripts: {
+            postinst: "./assets/linux/postinst",
+            postrm: "./assets/linux/postrm",
+          },
         }
       },
     },
@@ -194,6 +198,10 @@ export default {
           icon: "./assets/linux/icon/inav_icon_128.png",
           description: "Configurator for the open source flight controller software INAV.",
           homepage: "https://github.com/inavflight/",
+          scripts: {
+            post: "./assets/linux/postinst",
+            postun: "./assets/linux/postrm",
+          },
         }
       },
     },

--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -13,7 +13,6 @@ const LINE_DELAY_MS = 50;
 const PROFILE_SWITCH_DELAY_MS = 100;
 const REBOOT_WAIT_MS = 1500;
 
-// Stores the last auto-backup info for post-flash restore
 let lastAutoBackup = null;
 
 /**
@@ -26,9 +25,6 @@ const BackupRestore = {
     _outputHistory: '',
     _cliReady: false,
 
-    /**
-     * Send a raw string over the active connection.
-     */
     _sendString(str, callback) {
         const buf = new ArrayBuffer(str.length);
         const view = new Uint8Array(buf);
@@ -50,7 +46,6 @@ const BackupRestore = {
 
             let timeoutHandle = null;
 
-            // Set up receive listener
             this._receiveCallback = (info) => {
                 const data = new Uint8Array(info.data);
                 for (let i = 0; i < data.length; i++) {
@@ -69,7 +64,6 @@ const BackupRestore = {
             };
             CONFIGURATOR.connection.addOnReceiveCallback(this._receiveCallback);
 
-            // Timeout
             timeoutHandle = setTimeout(() => {
                 if (!this._cliReady) {
                     this._cleanup();
@@ -77,7 +71,6 @@ const BackupRestore = {
                 }
             }, CLI_ENTER_TIMEOUT_MS);
 
-            // Send '#' to enter CLI
             this._sendString('#');
         });
     },
@@ -101,19 +94,16 @@ const BackupRestore = {
                     this._outputHistory += ch;
 
                     if (data[i] === 10 || data[i] === 13) {
-                        // newline
                         this._cliBuffer = '';
                     } else {
                         this._cliBuffer += ch;
                     }
                 }
 
-                // Detect prompt return: line starting with '# ' (INAV CLI prompt)
                 if (this._cliBuffer.endsWith('# ') || this._cliBuffer === '# ') {
                     if (timeoutHandle) {
                         clearTimeout(timeoutHandle);
                     }
-                    // Restore original callback
                     CONFIGURATOR.connection.removeOnReceiveCallback(this._receiveCallback);
                     this._receiveCallback = originalCallback;
                     if (originalCallback) {
@@ -123,7 +113,6 @@ const BackupRestore = {
                 }
             };
 
-            // Swap callbacks
             if (originalCallback) {
                 CONFIGURATOR.connection.removeOnReceiveCallback(originalCallback);
             }
@@ -142,9 +131,6 @@ const BackupRestore = {
         });
     },
 
-    /**
-     * Clean up receive listener.
-     */
     _cleanup() {
         if (this._receiveCallback) {
             CONFIGURATOR.connection.removeOnReceiveCallback(this._receiveCallback);
@@ -162,17 +148,11 @@ const BackupRestore = {
         return new Promise((resolve) => {
             this._cleanup();
             this._sendString('exit\r', () => {
-                // Give the FC a moment to start processing the exit command
-                // before the caller disconnects the serial port
                 setTimeout(resolve, 500);
             });
         });
     },
 
-    /**
-     * Send 'save' and wait for it to be transmitted.
-     * The FC will write EEPROM and reboot after receiving save.
-     */
     _saveCli() {
         return new Promise((resolve) => {
             this._cleanup();
@@ -182,10 +162,6 @@ const BackupRestore = {
         });
     },
 
-    /**
-     * Generate a backup filename.
-     * @param {string} [prefix=''] - Optional prefix (e.g. 'UPDATE_')
-     */
     generateBackupFilename(prefix) {
         const date = new Date();
         const pad = (n) => String(n).padStart(2, '0');
@@ -213,20 +189,15 @@ const BackupRestore = {
 
         if (onProgress) onProgress('backupRestoreStatusReadingConfig');
 
-        // Send diff all and capture output
         const diffOutput = await this._sendCommand('diff all');
-
-        // Clean the output: remove the command echo and the trailing prompt
         const cleanedOutput = this._cleanDiffOutput(diffOutput);
 
         if (onProgress) onProgress('backupRestoreStatusSavingFile');
 
-        // Get backup directory and save
         const backupDir = await window.electronAPI.getBackupDir();
         const filename = this.generateBackupFilename();
         const filePath = backupDir + '/' + filename;
 
-        // Add header with metadata
         const header = `# INAV Backup\n# Version: ${version}\n# Board: ${FC.CONFIG.target || FC.CONFIG.boardIdentifier}\n# Date: ${new Date().toISOString()}\n# Craft: ${FC.CONFIG.name || ''}\n#\n`;
         const fileContent = header + cleanedOutput;
 
@@ -237,7 +208,6 @@ const BackupRestore = {
 
         if (onProgress) onProgress('backupRestoreStatusExitingCli');
 
-        // Exit CLI (triggers reboot) — wait for command to be sent
         await this._exitCli();
 
         return { filePath, version, data: fileContent };
@@ -291,7 +261,6 @@ const BackupRestore = {
 
         if (onProgress) onProgress('backupRestoreStatusExitingCli');
 
-        // Exit CLI (triggers reboot) — wait for command to be sent
         await this._exitCli();
 
         return { filePath: result.filePath, version, data: fileContent };
@@ -321,8 +290,6 @@ const BackupRestore = {
         report('entering-cli', 0, 0);
         await this._enterCli();
 
-        // Parse lines: filter comments, empty lines, header, and
-        // save/exit commands (handled separately by saveAndReboot/abortRestore)
         const lines = fileContent.split('\n')
             .map(line => line.trim())
             .filter(line => {
@@ -335,11 +302,9 @@ const BackupRestore = {
         const total = lines.length;
         report('restoring', 0, total);
 
-        // Send each line individually and check the response for errors
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
 
-            // Small delay before profile switch commands
             if (line.toLowerCase().includes('_profile')) {
                 await new Promise(resolve => setTimeout(resolve, PROFILE_SWITCH_DELAY_MS));
             }
@@ -347,14 +312,11 @@ const BackupRestore = {
             try {
                 const response = await this._sendCommand(line);
 
-                // Detect error patterns in the FC response
                 const responseLines = response.split('\n');
                 for (const rl of responseLines) {
                     const trimmed = rl.trim();
                     if (trimmed.length === 0) continue;
-                    // Skip the command echo
                     if (trimmed === line) continue;
-                    // Skip prompt-only lines
                     if (trimmed === '#' || trimmed === '# ') continue;
 
                     if (trimmed.includes('### ERROR:') ||
@@ -376,28 +338,14 @@ const BackupRestore = {
         return { errors };
     },
 
-    /**
-     * Save and reboot after restore. Call this after performRestore when
-     * the user confirms they want to keep the restored settings.
-     */
     async saveAndReboot() {
         await this._saveCli();
     },
 
-    /**
-     * Abort restore: exit CLI without saving. The FC will reboot with
-     * previous settings.
-     */
     async abortRestore() {
         await this._exitCli();
     },
 
-    /**
-     * Restore from a user-chosen file.
-     * Opens a file picker starting at the default backup directory.
-     * @param {function} onProgress - Optional callback for status updates
-     * @returns {Promise<boolean>} true if restore was performed, false if cancelled
-     */
     async performRestoreFromFile(onProgress) {
         if (!CONFIGURATOR.connection) {
             throw new Error('Not connected to flight controller');
@@ -427,18 +375,13 @@ const BackupRestore = {
         return true;
     },
 
-    /**
-     * Clean diff all output: remove command echo, ANSI escapes, and trailing prompt.
-     */
     _cleanDiffOutput(raw) {
         let lines = raw.split('\n');
 
-        // Remove first line if it's the command echo
         if (lines.length > 0 && lines[0].includes('diff all')) {
             lines.shift();
         }
 
-        // Remove trailing prompt lines
         while (lines.length > 0) {
             const last = lines[lines.length - 1].trim();
             if (last === '#' || last === '# ' || last === '') {
@@ -448,17 +391,10 @@ const BackupRestore = {
             }
         }
 
-        // Remove ANSI escape sequences
         const ansiRegex = /\x1B\[[0-9;]*[A-Za-z]/g;
         return lines.map(line => line.replace(ansiRegex, '')).join('\n') + '\n';
     },
 
-    /**
-     * Determine the type of version change.
-     * @param {string} fromVersion - e.g. "9.0.0"
-     * @param {string} toVersion - e.g. "9.0.1"
-     * @returns {'major'|'minor'|'patch'|'same'|null}
-     */
     getVersionChangeType(fromVersion, toVersion) {
         if (!fromVersion || !toVersion) return null;
         if (!semver.valid(fromVersion) || !semver.valid(toVersion)) return null;
@@ -466,28 +402,16 @@ const BackupRestore = {
         return semver.diff(fromVersion, toVersion);
     },
 
-    /**
-     * Check if auto-restore is safe for the given version change.
-     * Minor and patch updates are safe (INAV policy: 100% settings compatible).
-     * Major updates are NOT safe for auto-restore.
-     */
     isAutoRestoreSafe(fromVersion, toVersion) {
         const changeType = this.getVersionChangeType(fromVersion, toVersion);
         return changeType === 'minor' || changeType === 'patch' ||
                changeType === 'prepatch' || changeType === 'preminor';
     },
 
-    /**
-     * Get the last auto-backup info (set during flash process).
-     * @returns {{filePath: string, version: string, data: string}|null}
-     */
     getLastAutoBackup() {
         return lastAutoBackup;
     },
 
-    /**
-     * Clear the last auto-backup info.
-     */
     clearLastAutoBackup() {
         lastAutoBackup = null;
     },
@@ -522,16 +446,12 @@ const BackupRestore = {
                 }
             }
 
-            // Detect prompt return after diff all output: line ending with '# '
-            // The prompt appears after all diff output is complete
             if (lineBuffer.endsWith('# ') && outputBuffer.length > 20) {
                 if (timeoutHandle) {
                     clearTimeout(timeoutHandle);
                 }
                 connection.removeOnReceiveCallback(receiveCallback);
 
-                // Extract the real FC version from the diff all header
-                // e.g. "# INAV/MATEKF765 7.1.2 May 15 2024 / 12:00:00 (abc123)"
                 const versionMatch = outputBuffer.match(/INAV\/\S+\s+(\d+\.\d+\.\d+)/);
                 if (versionMatch) {
                     FC.CONFIG.flightControllerVersion = versionMatch[1];
@@ -542,7 +462,6 @@ const BackupRestore = {
 
                 if (onProgress) onProgress('backupRestoreStatusSavingFile');
 
-                // Save to default backup directory
                 self._saveAutoBackup(cleanedOutput).then(function(result) {
                     lastAutoBackup = result;
                     console.log('Auto-backup saved to: ' + result.filePath);
@@ -550,7 +469,6 @@ const BackupRestore = {
                     done();
                 }).catch(function(err) {
                     console.error('Auto-backup failed to save:', err);
-                    // Don't block the flash process even if backup save fails
                     done();
                 });
             }
@@ -558,14 +476,12 @@ const BackupRestore = {
 
         connection.addOnReceiveCallback(receiveCallback);
 
-        // Timeout: if diff all takes too long, proceed anyway
         timeoutHandle = setTimeout(function() {
             console.warn('Auto-backup timed out, proceeding with flash');
             connection.removeOnReceiveCallback(receiveCallback);
             done();
         }, BACKUP_TIMEOUT_MS);
 
-        // Send diff all command
         const cmd = 'diff all\n';
         const buf = new ArrayBuffer(cmd.length);
         const view = new Uint8Array(buf);
@@ -575,10 +491,6 @@ const BackupRestore = {
         connection.send(buf);
     },
 
-    /**
-     * Save auto-backup data to the default backup directory.
-     * @private
-     */
     async _saveAutoBackup(cleanedOutput) {
         const version = FC.CONFIG.flightControllerVersion || 'unknown';
         const backupDir = await window.electronAPI.getBackupDir();
@@ -593,17 +505,11 @@ const BackupRestore = {
             throw new Error('Failed to write backup file: ' + err);
         }
 
-        // Prune old auto-backups: keep only the 10 most recent UPDATE_ files
         await this._pruneAutoBackups(backupDir, 10);
 
         return { filePath, version, data: fileContent };
     },
 
-    /**
-     * Keep only the N most recent auto-backup files (UPDATE_ prefix with standard naming).
-     * Files that have been renamed by the user are not touched.
-     * @private
-     */
     async _pruneAutoBackups(backupDir, maxKeep) {
         const AUTO_BACKUP_PATTERN = /^UPDATE_inav_backup_.*_\d{4}-\d{2}-\d{2}_\d{6}\.txt$/;
 
@@ -612,8 +518,6 @@ const BackupRestore = {
             const autoBackups = allFiles
                 .filter(f => AUTO_BACKUP_PATTERN.test(f))
                 .sort(function(a, b) {
-                    // Sort by timestamp portion (YYYY-MM-DD_HHMMSS) to avoid
-                    // version strings affecting order (e.g. "7.1.2" < "9.0.1")
                     var tsA = a.match(/(\d{4}-\d{2}-\d{2}_\d{6})\.txt$/);
                     var tsB = b.match(/(\d{4}-\d{2}-\d{2}_\d{6})\.txt$/);
                     return (tsA ? tsA[1] : a).localeCompare(tsB ? tsB[1] : b);
@@ -631,13 +535,6 @@ const BackupRestore = {
         }
     },
 
-    /**
-     * Create an onCliReady handler for STM32 flash options.
-     * This handler will capture diff all output while CLI is active during the flash process.
-     *
-     * @param {function} onProgress - Optional progress callback
-     * @returns {function} onCliReady handler for STM32 options
-     */
     createOnCliReadyHandler(onProgress) {
         const self = this;
         return function(connection, done) {

--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -5,6 +5,7 @@ import { GUI } from './gui';
 import FC from './fc';
 import i18n from './localization';
 import semver from 'semver';
+import MigrationHandler from './migration/migration_handler';
 
 const BACKUP_TIMEOUT_MS = 15000;
 const CLI_ENTER_TIMEOUT_MS = 3000;
@@ -627,6 +628,36 @@ const BackupRestore = {
         const self = this;
         return function(connection, done) {
             self.captureCliDiffAll(connection, onProgress, done);
+        };
+    },
+
+    /**
+     * Perform restore with automatic migration if needed.
+     * Detects version mismatch between backup and current FC,
+     * applies migration profiles, and then restores.
+     *
+     * @param {string} fileContent - The backup file content
+     * @param {string} targetVersion - The target INAV version on the FC
+     * @param {function} onProgress - Progress callback
+     * @returns {Promise<{errors: string[], migrationSummary: object|null}>}
+     */
+    async performRestoreWithMigration(fileContent, targetVersion, onProgress) {
+        let dataToRestore = fileContent;
+        let migrationSummary = null;
+
+        if (targetVersion && MigrationHandler.isMigrationNeeded(fileContent, targetVersion)) {
+            const result = MigrationHandler.migrateBackupData(fileContent, targetVersion);
+            dataToRestore = result.migratedContent;
+            migrationSummary = result.summary;
+
+            console.log('Migration applied:', MigrationHandler.formatSummary(result.summary));
+        }
+
+        const restoreResult = await this.performRestore(dataToRestore, onProgress);
+
+        return {
+            errors: restoreResult.errors,
+            migrationSummary,
         };
     },
 };

--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -1,0 +1,605 @@
+'use strict';
+
+import CONFIGURATOR from './data_storage';
+import { GUI } from './gui';
+import FC from './fc';
+import i18n from './localization';
+import semver from 'semver';
+
+const BACKUP_TIMEOUT_MS = 15000;
+const CLI_ENTER_TIMEOUT_MS = 3000;
+const LINE_DELAY_MS = 50;
+const PROFILE_SWITCH_DELAY_MS = 100;
+const REBOOT_WAIT_MS = 1500;
+
+// Stores the last auto-backup info for post-flash restore
+let lastAutoBackup = null;
+
+/**
+ * Backup & Restore module for INAV flight controller settings.
+ * Uses CLI text protocol (diff all / batch commands) over the active connection.
+ */
+const BackupRestore = {
+    _receiveCallback: null,
+    _cliBuffer: '',
+    _outputHistory: '',
+    _cliReady: false,
+
+    /**
+     * Send a raw string over the active connection.
+     */
+    _sendString(str, callback) {
+        const buf = new ArrayBuffer(str.length);
+        const view = new Uint8Array(buf);
+        for (let i = 0; i < str.length; i++) {
+            view[i] = str.charCodeAt(i);
+        }
+        CONFIGURATOR.connection.send(buf, callback);
+    },
+
+    /**
+     * Enter CLI mode by sending '#' and waiting for 'CLI' prompt.
+     * Returns a Promise that resolves when CLI is ready.
+     */
+    _enterCli() {
+        return new Promise((resolve, reject) => {
+            this._cliBuffer = '';
+            this._outputHistory = '';
+            this._cliReady = false;
+
+            let timeoutHandle = null;
+
+            // Set up receive listener
+            this._receiveCallback = (info) => {
+                const data = new Uint8Array(info.data);
+                for (let i = 0; i < data.length; i++) {
+                    const ch = String.fromCharCode(data[i]);
+                    this._outputHistory += ch;
+                    this._cliBuffer += ch;
+                }
+
+                if (this._cliBuffer.includes('CLI')) {
+                    this._cliReady = true;
+                    if (timeoutHandle) {
+                        clearTimeout(timeoutHandle);
+                    }
+                    resolve();
+                }
+            };
+            CONFIGURATOR.connection.addOnReceiveCallback(this._receiveCallback);
+
+            // Timeout
+            timeoutHandle = setTimeout(() => {
+                if (!this._cliReady) {
+                    this._cleanup();
+                    reject(new Error('Timeout entering CLI mode'));
+                }
+            }, CLI_ENTER_TIMEOUT_MS);
+
+            // Send '#' to enter CLI
+            this._sendString('#');
+        });
+    },
+
+    /**
+     * Send a CLI command and wait for the prompt to return.
+     * The prompt is detected by a line ending with '# ' pattern.
+     */
+    _sendCommand(command) {
+        return new Promise((resolve, reject) => {
+            this._outputHistory = '';
+            this._cliBuffer = '';
+
+            let timeoutHandle = null;
+            const originalCallback = this._receiveCallback;
+
+            this._receiveCallback = (info) => {
+                const data = new Uint8Array(info.data);
+                for (let i = 0; i < data.length; i++) {
+                    const ch = String.fromCharCode(data[i]);
+                    this._outputHistory += ch;
+
+                    if (data[i] === 10 || data[i] === 13) {
+                        // newline
+                        this._cliBuffer = '';
+                    } else {
+                        this._cliBuffer += ch;
+                    }
+                }
+
+                // Detect prompt return: line starting with '# ' (INAV CLI prompt)
+                if (this._cliBuffer.endsWith('# ') || this._cliBuffer === '# ') {
+                    if (timeoutHandle) {
+                        clearTimeout(timeoutHandle);
+                    }
+                    // Restore original callback
+                    CONFIGURATOR.connection.removeOnReceiveCallback(this._receiveCallback);
+                    this._receiveCallback = originalCallback;
+                    if (originalCallback) {
+                        CONFIGURATOR.connection.addOnReceiveCallback(originalCallback);
+                    }
+                    resolve(this._outputHistory);
+                }
+            };
+
+            // Swap callbacks
+            if (originalCallback) {
+                CONFIGURATOR.connection.removeOnReceiveCallback(originalCallback);
+            }
+            CONFIGURATOR.connection.addOnReceiveCallback(this._receiveCallback);
+
+            timeoutHandle = setTimeout(() => {
+                CONFIGURATOR.connection.removeOnReceiveCallback(this._receiveCallback);
+                this._receiveCallback = originalCallback;
+                if (originalCallback) {
+                    CONFIGURATOR.connection.addOnReceiveCallback(originalCallback);
+                }
+                reject(new Error('Timeout waiting for CLI response to: ' + command));
+            }, BACKUP_TIMEOUT_MS);
+
+            this._sendString(command + '\n');
+        });
+    },
+
+    /**
+     * Clean up receive listener.
+     */
+    _cleanup() {
+        if (this._receiveCallback) {
+            CONFIGURATOR.connection.removeOnReceiveCallback(this._receiveCallback);
+            this._receiveCallback = null;
+        }
+    },
+
+    /**
+     * Exit CLI mode by sending 'exit' and waiting for the send to complete.
+     * The FC will reboot after receiving the exit command.
+     * Returns a Promise that resolves after the command is sent and a brief
+     * delay to allow the FC to begin processing.
+     */
+    _exitCli() {
+        return new Promise((resolve) => {
+            this._cleanup();
+            this._sendString('exit\r', () => {
+                // Give the FC a moment to start processing the exit command
+                // before the caller disconnects the serial port
+                setTimeout(resolve, 500);
+            });
+        });
+    },
+
+    /**
+     * Send 'save' and wait for it to be transmitted.
+     * The FC will write EEPROM and reboot after receiving save.
+     */
+    _saveCli() {
+        return new Promise((resolve) => {
+            this._cleanup();
+            this._sendString('save\r', () => {
+                setTimeout(resolve, 500);
+            });
+        });
+    },
+
+    /**
+     * Generate a backup filename.
+     * @param {string} [prefix=''] - Optional prefix (e.g. 'UPDATE_')
+     */
+    generateBackupFilename(prefix) {
+        const date = new Date();
+        const pad = (n) => String(n).padStart(2, '0');
+        const version = FC.CONFIG.flightControllerVersion || 'unknown';
+        const board = (FC.CONFIG.target || FC.CONFIG.boardIdentifier || 'unknown').replace(/\s+/g, '_');
+        const timestamp = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}_${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+        return `${prefix || ''}inav_backup_${version}_${board}_${timestamp}.txt`;
+    },
+
+    /**
+     * Perform a backup: enter CLI, run 'diff all', save output to file.
+     * @param {function} onProgress - Optional callback for status updates: onProgress(messageKey)
+     * @returns {Promise<{filePath: string, version: string, data: string}>}
+     */
+    async performBackup(onProgress) {
+        if (!CONFIGURATOR.connection) {
+            throw new Error('Not connected to flight controller');
+        }
+
+        const version = FC.CONFIG.flightControllerVersion;
+
+        if (onProgress) onProgress('backupRestoreStatusEnteringCli');
+
+        await this._enterCli();
+
+        if (onProgress) onProgress('backupRestoreStatusReadingConfig');
+
+        // Send diff all and capture output
+        const diffOutput = await this._sendCommand('diff all');
+
+        // Clean the output: remove the command echo and the trailing prompt
+        const cleanedOutput = this._cleanDiffOutput(diffOutput);
+
+        if (onProgress) onProgress('backupRestoreStatusSavingFile');
+
+        // Get backup directory and save
+        const backupDir = await window.electronAPI.getBackupDir();
+        const filename = this.generateBackupFilename();
+        const filePath = backupDir + '/' + filename;
+
+        // Add header with metadata
+        const header = `# INAV Backup\n# Version: ${version}\n# Board: ${FC.CONFIG.target || FC.CONFIG.boardIdentifier}\n# Date: ${new Date().toISOString()}\n# Craft: ${FC.CONFIG.name || ''}\n#\n`;
+        const fileContent = header + cleanedOutput;
+
+        const err = await window.electronAPI.writeFile(filePath, fileContent);
+        if (err) {
+            throw new Error('Failed to write backup file: ' + err);
+        }
+
+        if (onProgress) onProgress('backupRestoreStatusExitingCli');
+
+        // Exit CLI (triggers reboot) — wait for command to be sent
+        await this._exitCli();
+
+        return { filePath, version, data: fileContent };
+    },
+
+    /**
+     * Perform a backup to a user-chosen file location.
+     * Opens a save dialog starting at the default backup directory.
+     * @param {function} onProgress - Optional callback for status updates
+     * @returns {Promise<{filePath: string, version: string, data: string}|null>} null if user cancelled
+     */
+    async performBackupToFile(onProgress) {
+        if (!CONFIGURATOR.connection) {
+            throw new Error('Not connected to flight controller');
+        }
+
+        const version = FC.CONFIG.flightControllerVersion;
+        const backupDir = await window.electronAPI.getBackupDir();
+        const filename = this.generateBackupFilename();
+
+        const result = await window.electronAPI.showSaveDialog({
+            defaultPath: backupDir + '/' + filename,
+            filters: [
+                { name: 'TXT', extensions: ['txt'] },
+                { name: 'CLI', extensions: ['cli'] },
+            ],
+        });
+
+        if (result.canceled) {
+            return null;
+        }
+
+        if (onProgress) onProgress('backupRestoreStatusEnteringCli');
+
+        await this._enterCli();
+
+        if (onProgress) onProgress('backupRestoreStatusReadingConfig');
+
+        const diffOutput = await this._sendCommand('diff all');
+        const cleanedOutput = this._cleanDiffOutput(diffOutput);
+
+        if (onProgress) onProgress('backupRestoreStatusSavingFile');
+
+        const header = `# INAV Backup\n# Version: ${version}\n# Board: ${FC.CONFIG.target || FC.CONFIG.boardIdentifier}\n# Date: ${new Date().toISOString()}\n# Craft: ${FC.CONFIG.name || ''}\n#\n`;
+        const fileContent = header + cleanedOutput;
+
+        const err = await window.electronAPI.writeFile(result.filePath, fileContent);
+        if (err) {
+            throw new Error('Failed to write backup file: ' + err);
+        }
+
+        if (onProgress) onProgress('backupRestoreStatusExitingCli');
+
+        // Exit CLI (triggers reboot) — wait for command to be sent
+        await this._exitCli();
+
+        return { filePath: result.filePath, version, data: fileContent };
+    },
+
+    /**
+     * Restore settings from a backup file.
+     * Sends each CLI command individually, waits for the FC response, and
+     * detects errors (lines containing "### ERROR:" or "Invalid" or "Error").
+     *
+     * @param {string} fileContent - The content of the backup file
+     * @param {function} onProgress - Callback receiving progress objects:
+     *   { phase: 'entering-cli' | 'restoring' | 'done',
+     *     current: number, total: number, errors: string[] }
+     * @returns {Promise<{errors: string[]}>} List of errors encountered
+     */
+    async performRestore(fileContent, onProgress) {
+        if (!CONFIGURATOR.connection) {
+            throw new Error('Not connected to flight controller');
+        }
+
+        const errors = [];
+        const report = (phase, current, total) => {
+            if (onProgress) onProgress({ phase, current, total, errors: [...errors] });
+        };
+
+        report('entering-cli', 0, 0);
+        await this._enterCli();
+
+        // Parse lines: filter comments, empty lines, header, and
+        // save/exit commands (handled separately by saveAndReboot/abortRestore)
+        const lines = fileContent.split('\n')
+            .map(line => line.trim())
+            .filter(line => {
+                if (line.length === 0 || line.startsWith('#')) return false;
+                const lower = line.toLowerCase();
+                if (lower === 'save' || lower === 'exit') return false;
+                return true;
+            });
+
+        const total = lines.length;
+        report('restoring', 0, total);
+
+        // Send each line individually and check the response for errors
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+
+            // Small delay before profile switch commands
+            if (line.toLowerCase().includes('_profile')) {
+                await new Promise(resolve => setTimeout(resolve, PROFILE_SWITCH_DELAY_MS));
+            }
+
+            try {
+                const response = await this._sendCommand(line);
+
+                // Detect error patterns in the FC response
+                const responseLines = response.split('\n');
+                for (const rl of responseLines) {
+                    const trimmed = rl.trim();
+                    if (trimmed.length === 0) continue;
+                    // Skip the command echo
+                    if (trimmed === line) continue;
+                    // Skip prompt-only lines
+                    if (trimmed === '#' || trimmed === '# ') continue;
+
+                    if (trimmed.includes('### ERROR:') ||
+                        trimmed.includes('Invalid') ||
+                        trimmed.startsWith('ERR') ||
+                        trimmed.includes('Unknown command')) {
+                        errors.push(`Line ${i + 1}: ${line} → ${trimmed}`);
+                    }
+                }
+            } catch (err) {
+                errors.push(`Line ${i + 1}: ${line} → Timeout`);
+            }
+
+            report('restoring', i + 1, total);
+        }
+
+        report('done', total, total);
+
+        return { errors };
+    },
+
+    /**
+     * Save and reboot after restore. Call this after performRestore when
+     * the user confirms they want to keep the restored settings.
+     */
+    async saveAndReboot() {
+        await this._saveCli();
+    },
+
+    /**
+     * Abort restore: exit CLI without saving. The FC will reboot with
+     * previous settings.
+     */
+    async abortRestore() {
+        await this._exitCli();
+    },
+
+    /**
+     * Restore from a user-chosen file.
+     * Opens a file picker starting at the default backup directory.
+     * @param {function} onProgress - Optional callback for status updates
+     * @returns {Promise<boolean>} true if restore was performed, false if cancelled
+     */
+    async performRestoreFromFile(onProgress) {
+        if (!CONFIGURATOR.connection) {
+            throw new Error('Not connected to flight controller');
+        }
+
+        const backupDir = await window.electronAPI.getBackupDir();
+
+        const result = await window.electronAPI.showOpenDialog({
+            defaultPath: backupDir,
+            filters: [
+                { name: 'CLI/TXT', extensions: ['cli', 'txt'] },
+                { name: 'ALL', extensions: ['*'] },
+            ],
+            properties: ['openFile'],
+        });
+
+        if (result.canceled || !result.filePaths || result.filePaths.length === 0) {
+            return false;
+        }
+
+        const response = await window.electronAPI.readFile(result.filePaths[0]);
+        if (response.error) {
+            throw new Error('Failed to read backup file');
+        }
+
+        await this.performRestore(response.data, onProgress);
+        return true;
+    },
+
+    /**
+     * Clean diff all output: remove command echo, ANSI escapes, and trailing prompt.
+     */
+    _cleanDiffOutput(raw) {
+        let lines = raw.split('\n');
+
+        // Remove first line if it's the command echo
+        if (lines.length > 0 && lines[0].includes('diff all')) {
+            lines.shift();
+        }
+
+        // Remove trailing prompt lines
+        while (lines.length > 0) {
+            const last = lines[lines.length - 1].trim();
+            if (last === '#' || last === '# ' || last === '') {
+                lines.pop();
+            } else {
+                break;
+            }
+        }
+
+        // Remove ANSI escape sequences
+        const ansiRegex = /\x1B\[[0-9;]*[A-Za-z]/g;
+        return lines.map(line => line.replace(ansiRegex, '')).join('\n') + '\n';
+    },
+
+    /**
+     * Determine the type of version change.
+     * @param {string} fromVersion - e.g. "9.0.0"
+     * @param {string} toVersion - e.g. "9.0.1"
+     * @returns {'major'|'minor'|'patch'|'same'|null}
+     */
+    getVersionChangeType(fromVersion, toVersion) {
+        if (!fromVersion || !toVersion) return null;
+        if (!semver.valid(fromVersion) || !semver.valid(toVersion)) return null;
+        if (semver.eq(fromVersion, toVersion)) return 'same';
+        return semver.diff(fromVersion, toVersion);
+    },
+
+    /**
+     * Check if auto-restore is safe for the given version change.
+     * Minor and patch updates are safe (INAV policy: 100% settings compatible).
+     * Major updates are NOT safe for auto-restore.
+     */
+    isAutoRestoreSafe(fromVersion, toVersion) {
+        const changeType = this.getVersionChangeType(fromVersion, toVersion);
+        return changeType === 'minor' || changeType === 'patch' ||
+               changeType === 'prepatch' || changeType === 'preminor';
+    },
+
+    /**
+     * Get the last auto-backup info (set during flash process).
+     * @returns {{filePath: string, version: string, data: string}|null}
+     */
+    getLastAutoBackup() {
+        return lastAutoBackup;
+    },
+
+    /**
+     * Clear the last auto-backup info.
+     */
+    clearLastAutoBackup() {
+        lastAutoBackup = null;
+    },
+
+    /**
+     * Capture `diff all` output over a raw serial connection that is already in CLI mode.
+     * Used by the STM32 flash process (onCliReady callback).
+     *
+     * @param {object} connection - The active serial connection
+     * @param {function} onProgress - Optional progress callback: onProgress(messageKey)
+     * @param {function} done - Called when capture is complete
+     */
+    captureCliDiffAll(connection, onProgress, done) {
+        const self = this;
+        let outputBuffer = '';
+        let lineBuffer = '';
+        let receiveCallback = null;
+        let timeoutHandle = null;
+
+        if (onProgress) onProgress('backupRestoreStatusReadingConfig');
+
+        receiveCallback = function(info) {
+            const data = new Uint8Array(info.data);
+            for (let i = 0; i < data.length; i++) {
+                const ch = String.fromCharCode(data[i]);
+                outputBuffer += ch;
+
+                if (data[i] === 10 || data[i] === 13) {
+                    lineBuffer = '';
+                } else {
+                    lineBuffer += ch;
+                }
+            }
+
+            // Detect prompt return after diff all output: line ending with '# '
+            // The prompt appears after all diff output is complete
+            if (lineBuffer.endsWith('# ') && outputBuffer.length > 20) {
+                if (timeoutHandle) {
+                    clearTimeout(timeoutHandle);
+                }
+                connection.removeOnReceiveCallback(receiveCallback);
+
+                const cleanedOutput = self._cleanDiffOutput(outputBuffer);
+
+                if (onProgress) onProgress('backupRestoreStatusSavingFile');
+
+                // Save to default backup directory
+                self._saveAutoBackup(cleanedOutput).then(function(result) {
+                    lastAutoBackup = result;
+                    console.log('Auto-backup saved to: ' + result.filePath);
+                    if (onProgress) onProgress('backupRestoreStatusBackupComplete');
+                    done();
+                }).catch(function(err) {
+                    console.error('Auto-backup failed to save:', err);
+                    // Don't block the flash process even if backup save fails
+                    done();
+                });
+            }
+        };
+
+        connection.addOnReceiveCallback(receiveCallback);
+
+        // Timeout: if diff all takes too long, proceed anyway
+        timeoutHandle = setTimeout(function() {
+            console.warn('Auto-backup timed out, proceeding with flash');
+            connection.removeOnReceiveCallback(receiveCallback);
+            done();
+        }, BACKUP_TIMEOUT_MS);
+
+        // Send diff all command
+        const cmd = 'diff all\n';
+        const buf = new ArrayBuffer(cmd.length);
+        const view = new Uint8Array(buf);
+        for (let i = 0; i < cmd.length; i++) {
+            view[i] = cmd.charCodeAt(i);
+        }
+        connection.send(buf);
+    },
+
+    /**
+     * Save auto-backup data to the default backup directory.
+     * @private
+     */
+    async _saveAutoBackup(cleanedOutput) {
+        const version = FC.CONFIG.flightControllerVersion || 'unknown';
+        const backupDir = await window.electronAPI.getBackupDir();
+        const filename = this.generateBackupFilename('UPDATE_');
+        const filePath = backupDir + '/' + filename;
+
+        const header = `# INAV Auto-Backup (pre-flash)\n# Version: ${version}\n# Board: ${FC.CONFIG.target || FC.CONFIG.boardIdentifier || 'unknown'}\n# Date: ${new Date().toISOString()}\n# Craft: ${FC.CONFIG.name || ''}\n#\n`;
+        const fileContent = header + cleanedOutput;
+
+        const err = await window.electronAPI.writeFile(filePath, fileContent);
+        if (err) {
+            throw new Error('Failed to write backup file: ' + err);
+        }
+
+        return { filePath, version, data: fileContent };
+    },
+
+    /**
+     * Create an onCliReady handler for STM32 flash options.
+     * This handler will capture diff all output while CLI is active during the flash process.
+     *
+     * @param {function} onProgress - Optional progress callback
+     * @returns {function} onCliReady handler for STM32 options
+     */
+    createOnCliReadyHandler(onProgress) {
+        const self = this;
+        return function(connection, done) {
+            self.captureCliDiffAll(connection, onProgress, done);
+        };
+    },
+};
+
+export default BackupRestore;

--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -530,6 +530,14 @@ const BackupRestore = {
                 }
                 connection.removeOnReceiveCallback(receiveCallback);
 
+                // Extract the real FC version from the diff all header
+                // e.g. "# INAV/MATEKF765 7.1.2 May 15 2024 / 12:00:00 (abc123)"
+                const versionMatch = outputBuffer.match(/INAV\/\S+\s+(\d+\.\d+\.\d+)/);
+                if (versionMatch) {
+                    FC.CONFIG.flightControllerVersion = versionMatch[1];
+                    console.log('FC version detected from diff output: ' + versionMatch[1]);
+                }
+
                 const cleanedOutput = self._cleanDiffOutput(outputBuffer);
 
                 if (onProgress) onProgress('backupRestoreStatusSavingFile');
@@ -603,7 +611,13 @@ const BackupRestore = {
             const allFiles = await window.electronAPI.listBackups();
             const autoBackups = allFiles
                 .filter(f => AUTO_BACKUP_PATTERN.test(f))
-                .sort(); // lexicographic sort — filename contains timestamp so this gives chronological order
+                .sort(function(a, b) {
+                    // Sort by timestamp portion (YYYY-MM-DD_HHMMSS) to avoid
+                    // version strings affecting order (e.g. "7.1.2" < "9.0.1")
+                    var tsA = a.match(/(\d{4}-\d{2}-\d{2}_\d{6})\.txt$/);
+                    var tsB = b.match(/(\d{4}-\d{2}-\d{2}_\d{6})\.txt$/);
+                    return (tsA ? tsA[1] : a).localeCompare(tsB ? tsB[1] : b);
+                });
 
             if (autoBackups.length > maxKeep) {
                 const toDelete = autoBackups.slice(0, autoBackups.length - maxKeep);

--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -584,7 +584,36 @@ const BackupRestore = {
             throw new Error('Failed to write backup file: ' + err);
         }
 
+        // Prune old auto-backups: keep only the 10 most recent UPDATE_ files
+        await this._pruneAutoBackups(backupDir, 10);
+
         return { filePath, version, data: fileContent };
+    },
+
+    /**
+     * Keep only the N most recent auto-backup files (UPDATE_ prefix with standard naming).
+     * Files that have been renamed by the user are not touched.
+     * @private
+     */
+    async _pruneAutoBackups(backupDir, maxKeep) {
+        const AUTO_BACKUP_PATTERN = /^UPDATE_inav_backup_.*_\d{4}-\d{2}-\d{2}_\d{6}\.txt$/;
+
+        try {
+            const allFiles = await window.electronAPI.listBackups();
+            const autoBackups = allFiles
+                .filter(f => AUTO_BACKUP_PATTERN.test(f))
+                .sort(); // lexicographic sort — filename contains timestamp so this gives chronological order
+
+            if (autoBackups.length > maxKeep) {
+                const toDelete = autoBackups.slice(0, autoBackups.length - maxKeep);
+                for (const file of toDelete) {
+                    await window.electronAPI.rm(backupDir + '/' + file);
+                }
+                console.log(`Pruned ${toDelete.length} old auto-backup(s)`);
+            }
+        } catch (err) {
+            console.warn('Failed to prune auto-backups:', err);
+        }
     },
 
     /**

--- a/js/main/main.js
+++ b/js/main/main.js
@@ -1,11 +1,11 @@
-import { chmod, rm } from 'node:fs';
+import { chmod, rm, mkdirSync, existsSync } from 'node:fs';
 import { app, BrowserWindow, ipcMain, Menu, MenuItem, shell, dialog } from 'electron';
 import windowStateKeeper from 'electron-window-state';
 import Store from "electron-store";
 import path from 'path';
 import { fileURLToPath } from 'node:url';
 import started from 'electron-squirrel-startup';
-import { writeFile, readFile, appendFile } from 'node:fs/promises';
+import { writeFile, readFile, appendFile, readdir } from 'node:fs/promises';
 
 import tcp from './tcp';
 import udp from './udp';
@@ -410,6 +410,32 @@ app.whenReady().then(() => {
         }
       });
     });
+  });
+
+  ipcMain.handle('getBackupDir', (_event) => {
+    const backupDir = path.join(app.getPath('userData'), 'inav-backups');
+    if (!existsSync(backupDir)) {
+      mkdirSync(backupDir, { recursive: true });
+    }
+    return backupDir;
+  });
+
+  ipcMain.handle('openBackupDir', async (_event) => {
+    const backupDir = path.join(app.getPath('userData'), 'inav-backups');
+    if (!existsSync(backupDir)) {
+      mkdirSync(backupDir, { recursive: true });
+    }
+    await shell.openPath(backupDir);
+    return backupDir;
+  });
+
+  ipcMain.handle('listBackups', async (_event) => {
+    const backupDir = path.join(app.getPath('userData'), 'inav-backups');
+    if (!existsSync(backupDir)) {
+      return [];
+    }
+    const files = await readdir(backupDir);
+    return files.filter(f => f.endsWith('.txt') || f.endsWith('.cli'));
   });
 
   ipcMain.on('startChildProcess', (_event, command, args, opts) => {

--- a/js/main/preload.js
+++ b/js/main/preload.js
@@ -75,6 +75,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   readFile: (filename, encoding = 'utf8') => ipcRenderer.invoke('readFile', filename, encoding),
   rm: (path) => ipcRenderer.invoke('rm', path),
   chmod: (path, mode) => ipcRenderer.invoke('chmod', path, mode),
+  getBackupDir: () => ipcRenderer.invoke('getBackupDir'),
+  openBackupDir: () => ipcRenderer.invoke('openBackupDir'),
+  listBackups: () => ipcRenderer.invoke('listBackups'),
   startChildProcess: (command, args, opts) => ipcRenderer.send('startChildProcess', command, args, opts),
   killChildProcess: () => ipcRenderer.send('killChildProcess'),
   onChildProcessStdout: (callback) => {

--- a/js/migration/7_to_8.json
+++ b/js/migration/7_to_8.json
@@ -1,0 +1,49 @@
+{
+    "fromVersion": "7",
+    "toVersion": "8",
+    "description": "INAV 7.x → 8.0 migration profile",
+
+    "commandRenames": {
+        "profile": "control_profile"
+    },
+
+    "settingRenames": {},
+
+    "valueReplacements": {
+        "gps_provider": {
+            "UBLOX7": "UBLOX"
+        }
+    },
+
+    "removed": [
+        "control_deadband",
+        "cpu_underclock",
+        "disarm_kill_switch",
+        "dji_workarounds",
+        "fw_iterm_limit_stick_position",
+        "gyro_anti_aliasing_lpf_type",
+        "gyro_hardware_lpf",
+        "gyro_main_lpf_type",
+        "gyro_use_dyn_lpf",
+        "inav_use_gps_no_baro",
+        "inav_use_gps_velned",
+        "ledstrip_visual_beeper",
+        "max_throttle",
+        "nav_auto_climb_rate",
+        "nav_manual_climb_rate",
+        "osd_stats_min_voltage_unit",
+        "pidsum_limit",
+        "pidsum_limit_yaw"
+    ],
+
+    "osdCustomElementTypeMapping": {
+        "4": "9",
+        "5": "16",
+        "6": "7",
+        "7": "10"
+    },
+
+    "warnings": [
+        "nav_fw_wp_tracking_accuracy semantics changed: was arbitrary tracking response, now distance in meters. Review your value manually."
+    ]
+}

--- a/js/migration/7_to_8.json
+++ b/js/migration/7_to_8.json
@@ -36,12 +36,13 @@
         "pidsum_limit_yaw"
     ],
 
-    "osdCustomElementTypeMapping": {
-        "4": "9",
-        "5": "16",
-        "6": "7",
-        "7": "10"
-    },
+    "settingPatternMappings": [
+        {
+            "pattern": "^osd_custom_element_\\d+_type$",
+            "valueMap": { "4": "9", "5": "16", "6": "7", "7": "10" },
+            "description": "OSD custom element type IDs were renumbered"
+        }
+    ],
 
     "warnings": [
         "nav_fw_wp_tracking_accuracy semantics changed: was arbitrary tracking response, now distance in meters. Review your value manually."

--- a/js/migration/8_to_9.json
+++ b/js/migration/8_to_9.json
@@ -16,7 +16,7 @@
 
     "removed": [],
 
-    "osdCustomElementTypeMapping": {},
+    "settingPatternMappings": [],
 
     "warnings": [
         "Position estimator defaults changed: w_z_baro_v 0.1→0.35, inav_w_z_gps_p 0.2→0.35, inav_w_z_gps_v 0.1→0.35. Review if you had custom values.",

--- a/js/migration/8_to_9.json
+++ b/js/migration/8_to_9.json
@@ -1,0 +1,25 @@
+{
+    "fromVersion": "8",
+    "toVersion": "9",
+    "description": "INAV 8.0 → 9.0 migration profile",
+
+    "commandRenames": {
+        "controlrate_profile": "use_control_profile"
+    },
+
+    "settingRenames": {
+        "mixer_pid_profile_linking": "mixer_control_profile_linking",
+        "osd_pan_servo_pwm2centideg": "osd_pan_servo_range_decadegrees"
+    },
+
+    "valueReplacements": {},
+
+    "removed": [],
+
+    "osdCustomElementTypeMapping": {},
+
+    "warnings": [
+        "Position estimator defaults changed: w_z_baro_v 0.1→0.35, inav_w_z_gps_p 0.2→0.35, inav_w_z_gps_v 0.1→0.35. Review if you had custom values.",
+        "ahrs_acc_ignore_rate default changed from 20 to 15."
+    ]
+}

--- a/js/migration/migration_handler.js
+++ b/js/migration/migration_handler.js
@@ -1,0 +1,362 @@
+'use strict';
+
+import semver from 'semver';
+
+// Import migration profiles
+import profile_7_to_8 from './7_to_8.json';
+import profile_8_to_9 from './8_to_9.json';
+
+/**
+ * All available migration profiles, ordered by version.
+ * To add a new profile: import the JSON and append it here.
+ */
+const MIGRATION_PROFILES = [
+    profile_7_to_8,
+    profile_8_to_9,
+];
+
+/**
+ * Migration handler for INAV CLI backup data.
+ * Transforms CLI commands from one INAV version to another using
+ * JSON-based migration profiles that can be chained for multi-version jumps.
+ */
+const MigrationHandler = {
+
+    /**
+     * Extract the INAV version from a backup file's header comments.
+     * Looks for "# Version: X.Y.Z" pattern.
+     * @param {string} fileContent - Full backup file content
+     * @returns {string|null} Semver version string or null
+     */
+    extractBackupVersion(fileContent) {
+        const match = fileContent.match(/^#\s*Version:\s*(\S+)/m);
+        if (!match) return null;
+        const ver = match[1];
+        return semver.valid(semver.coerce(ver));
+    },
+
+    /**
+     * Build a chain of migration profiles to go from fromVersion to toVersion.
+     * @param {string} fromVersion - Source version (semver)
+     * @param {string} toVersion - Target version (semver)
+     * @returns {object[]} Ordered array of profiles to apply, or empty if none needed
+     */
+    buildMigrationChain(fromVersion, toVersion) {
+        if (!fromVersion || !toVersion) return [];
+
+        const fromMajor = semver.major(fromVersion);
+        const toMajor = semver.major(toVersion);
+
+        if (fromMajor >= toMajor) return []; // same or downgrade — no migration
+
+        const chain = [];
+        for (const profile of MIGRATION_PROFILES) {
+            const profileFrom = parseInt(profile.fromVersion, 10);
+            const profileTo = parseInt(profile.toVersion, 10);
+
+            // Include this profile if it bridges a gap in our version range
+            if (profileFrom >= fromMajor && profileTo <= toMajor) {
+                chain.push(profile);
+            }
+        }
+
+        // Sort by fromVersion to ensure correct order
+        chain.sort((a, b) => parseInt(a.fromVersion, 10) - parseInt(b.fromVersion, 10));
+
+        return chain;
+    },
+
+    /**
+     * Apply a single migration profile to a CLI command line.
+     * @param {string} line - A single CLI command line (trimmed)
+     * @param {object} profile - Migration profile object
+     * @returns {{line: string|null, changes: string[]}} Transformed line (null = removed) and list of changes
+     */
+    _applyProfileToLine(line, profile) {
+        const changes = [];
+        let currentLine = line;
+
+        // Parse the line into parts: command [subcommand] [setting] [value...]
+        const parts = currentLine.split(/\s+/);
+        if (parts.length === 0) return { line: currentLine, changes };
+
+        const command = parts[0].toLowerCase();
+
+        // 1. Command renames (e.g. "profile" → "control_profile")
+        if (profile.commandRenames) {
+            const lowerParts = parts.map(p => p.toLowerCase());
+            for (const [oldCmd, newCmd] of Object.entries(profile.commandRenames)) {
+                const idx = lowerParts.indexOf(oldCmd);
+                if (idx !== -1) {
+                    parts[idx] = newCmd;
+                    changes.push(`Command renamed: "${oldCmd}" → "${newCmd}"`);
+                }
+            }
+            currentLine = parts.join(' ');
+        }
+
+        // 2. Check if this is a "set" command for setting-level operations
+        if (command === 'set' && parts.length >= 3) {
+            const settingName = parts[1].toLowerCase();
+
+            // 2a. Removed settings — drop the entire line
+            if (profile.removed && profile.removed.includes(settingName)) {
+                changes.push(`Removed setting: "${settingName}"`);
+                return { line: null, changes };
+            }
+
+            // 2b. Setting renames
+            if (profile.settingRenames && profile.settingRenames[settingName]) {
+                const newName = profile.settingRenames[settingName];
+                parts[1] = newName;
+                changes.push(`Setting renamed: "${settingName}" → "${newName}"`);
+                currentLine = parts.join(' ');
+            }
+
+            // 2c. Value replacements
+            if (profile.valueReplacements && profile.valueReplacements[settingName]) {
+                const valueMap = profile.valueReplacements[settingName];
+                // The value is everything after "set <name> = "
+                // Handle the "set name = value" pattern
+                const eqIdx = parts.indexOf('=');
+                if (eqIdx !== -1 && eqIdx + 1 < parts.length) {
+                    const oldValue = parts[eqIdx + 1];
+                    if (valueMap[oldValue]) {
+                        parts[eqIdx + 1] = valueMap[oldValue];
+                        changes.push(`Value replaced: "${settingName}" value "${oldValue}" → "${valueMap[oldValue]}"`);
+                        currentLine = parts.join(' ');
+                    }
+                }
+            }
+        }
+
+        // 3. OSD custom element type remapping
+        //    Lines like: "set osd_custom_element_1_type = 4"
+        if (command === 'set' && profile.osdCustomElementTypeMapping) {
+            const settingName = parts[1] ? parts[1].toLowerCase() : '';
+            if (settingName.match(/^osd_custom_element_\d+_type$/)) {
+                const eqIdx = parts.indexOf('=');
+                if (eqIdx !== -1 && eqIdx + 1 < parts.length) {
+                    const oldTypeId = parts[eqIdx + 1];
+                    if (profile.osdCustomElementTypeMapping[oldTypeId]) {
+                        const newTypeId = profile.osdCustomElementTypeMapping[oldTypeId];
+                        parts[eqIdx + 1] = newTypeId;
+                        changes.push(`OSD custom element type remapped: ${oldTypeId} → ${newTypeId}`);
+                        currentLine = parts.join(' ');
+                    }
+                }
+            }
+        }
+
+        return { line: currentLine, changes };
+    },
+
+    /**
+     * Migrate backup file content from one INAV version to another.
+     * Applies all necessary migration profiles in chain.
+     *
+     * @param {string} fileContent - Full backup file content (with header)
+     * @param {string} targetVersion - Target INAV version (semver)
+     * @returns {{
+     *   migratedContent: string,
+     *   summary: {
+     *     fromVersion: string,
+     *     toVersion: string,
+     *     profilesApplied: string[],
+     *     totalChanges: number,
+     *     removedSettings: string[],
+     *     renamedSettings: string[],
+     *     renamedCommands: string[],
+     *     valueReplacements: string[],
+     *     osdRemappings: string[],
+     *     warnings: string[]
+     *   }
+     * }}
+     */
+    migrateBackupData(fileContent, targetVersion) {
+        const fromVersion = this.extractBackupVersion(fileContent);
+
+        const summary = {
+            fromVersion: fromVersion || 'unknown',
+            toVersion: targetVersion,
+            profilesApplied: [],
+            totalChanges: 0,
+            removedSettings: [],
+            renamedSettings: [],
+            renamedCommands: [],
+            valueReplacements: [],
+            osdRemappings: [],
+            warnings: [],
+        };
+
+        if (!fromVersion || !targetVersion) {
+            return { migratedContent: fileContent, summary };
+        }
+
+        const chain = this.buildMigrationChain(fromVersion, targetVersion);
+
+        if (chain.length === 0) {
+            return { migratedContent: fileContent, summary };
+        }
+
+        // Collect profile descriptions and warnings
+        for (const profile of chain) {
+            summary.profilesApplied.push(`${profile.fromVersion} → ${profile.toVersion}: ${profile.description}`);
+            if (profile.warnings) {
+                summary.warnings.push(...profile.warnings);
+            }
+        }
+
+        // Process each line of the file content
+        const lines = fileContent.split('\n');
+        const migratedLines = [];
+
+        for (const rawLine of lines) {
+            const trimmed = rawLine.trim();
+
+            // Pass through comments, empty lines, and non-command lines unchanged
+            if (trimmed.length === 0 || trimmed.startsWith('#')) {
+                migratedLines.push(rawLine);
+                continue;
+            }
+
+            // Skip save/exit — these are handled by the restore flow
+            const lower = trimmed.toLowerCase();
+            if (lower === 'save' || lower === 'exit') {
+                migratedLines.push(rawLine);
+                continue;
+            }
+
+            // Apply each profile in the chain sequentially
+            let currentLine = trimmed;
+            let lineRemoved = false;
+
+            for (const profile of chain) {
+                if (lineRemoved) break;
+
+                const result = this._applyProfileToLine(currentLine, profile);
+
+                if (result.line === null) {
+                    lineRemoved = true;
+                }  else {
+                    currentLine = result.line;
+                }
+
+                // Categorize changes for the summary
+                for (const change of result.changes) {
+                    summary.totalChanges++;
+                    if (change.startsWith('Removed')) {
+                        summary.removedSettings.push(change);
+                    } else if (change.startsWith('Setting renamed')) {
+                        summary.renamedSettings.push(change);
+                    } else if (change.startsWith('Command renamed')) {
+                        summary.renamedCommands.push(change);
+                    } else if (change.startsWith('Value replaced')) {
+                        summary.valueReplacements.push(change);
+                    } else if (change.startsWith('OSD')) {
+                        summary.osdRemappings.push(change);
+                    }
+                }
+            }
+
+            if (!lineRemoved) {
+                migratedLines.push(currentLine);
+            }
+            // Removed lines are simply not added to migratedLines
+        }
+
+        return {
+            migratedContent: migratedLines.join('\n'),
+            summary,
+        };
+    },
+
+    /**
+     * Check if migration is needed for the given backup content and target version.
+     * @param {string} fileContent - Backup file content
+     * @param {string} targetVersion - Target INAV version
+     * @returns {boolean}
+     */
+    isMigrationNeeded(fileContent, targetVersion) {
+        const fromVersion = this.extractBackupVersion(fileContent);
+        if (!fromVersion || !targetVersion) return false;
+        const chain = this.buildMigrationChain(fromVersion, targetVersion);
+        return chain.length > 0;
+    },
+
+    /**
+     * Get all available migration profiles (for developer tools / UI).
+     * @returns {object[]}
+     */
+    getAvailableProfiles() {
+        return MIGRATION_PROFILES.map(p => ({
+            from: p.fromVersion,
+            to: p.toVersion,
+            description: p.description,
+        }));
+    },
+
+    /**
+     * Format the migration summary for display.
+     * @param {object} summary - Summary from migrateBackupData()
+     * @returns {string} Human-readable summary text
+     */
+    formatSummary(summary) {
+        if (summary.totalChanges === 0 && summary.warnings.length === 0) {
+            return '';
+        }
+
+        const lines = [];
+        lines.push(`Migration: ${summary.fromVersion} → ${summary.toVersion}`);
+
+        if (summary.profilesApplied.length > 0) {
+            lines.push(`Profiles: ${summary.profilesApplied.join(', ')}`);
+        }
+
+        if (summary.removedSettings.length > 0) {
+            lines.push(`\nRemoved settings (${summary.removedSettings.length}):`);
+            for (const r of summary.removedSettings) {
+                lines.push(`  - ${r}`);
+            }
+        }
+
+        if (summary.renamedSettings.length > 0) {
+            lines.push(`\nRenamed settings (${summary.renamedSettings.length}):`);
+            for (const r of summary.renamedSettings) {
+                lines.push(`  - ${r}`);
+            }
+        }
+
+        if (summary.renamedCommands.length > 0) {
+            lines.push(`\nRenamed commands (${summary.renamedCommands.length}):`);
+            for (const r of summary.renamedCommands) {
+                lines.push(`  - ${r}`);
+            }
+        }
+
+        if (summary.valueReplacements.length > 0) {
+            lines.push(`\nValue replacements (${summary.valueReplacements.length}):`);
+            for (const r of summary.valueReplacements) {
+                lines.push(`  - ${r}`);
+            }
+        }
+
+        if (summary.osdRemappings.length > 0) {
+            lines.push(`\nOSD type remappings (${summary.osdRemappings.length}):`);
+            for (const r of summary.osdRemappings) {
+                lines.push(`  - ${r}`);
+            }
+        }
+
+        if (summary.warnings.length > 0) {
+            lines.push(`\nWarnings:`);
+            for (const w of summary.warnings) {
+                lines.push(`  ⚠ ${w}`);
+            }
+        }
+
+        return lines.join('\n');
+    },
+};
+
+export default MigrationHandler;

--- a/js/migration/migration_handler.js
+++ b/js/migration/migration_handler.js
@@ -383,6 +383,32 @@ const MigrationHandler = {
 
         return lines.join('\n');
     },
+
+    /**
+     * Create an empty migration summary object.
+     * Useful when no migration profiles exist but a summary structure is needed.
+     * @param {string} fromVersion
+     * @param {string} toVersion
+     * @param {string} migratedContent - The (unmodified) backup content
+     * @returns {{migratedContent: string, summary: object}}
+     */
+    createEmptyResult(fromVersion, toVersion, migratedContent) {
+        return {
+            migratedContent,
+            summary: {
+                fromVersion: fromVersion || 'unknown',
+                toVersion: toVersion || 'unknown',
+                profilesApplied: [],
+                totalChanges: 0,
+                removedSettings: [],
+                renamedSettings: [],
+                renamedCommands: [],
+                valueReplacements: [],
+                settingRemappings: [],
+                warnings: [],
+            },
+        };
+    },
 };
 
 export default MigrationHandler;

--- a/js/migration/migration_handler.js
+++ b/js/migration/migration_handler.js
@@ -130,20 +130,23 @@ const MigrationHandler = {
             }
         }
 
-        // 3. OSD custom element type remapping
-        //    Lines like: "set osd_custom_element_1_type = 4"
-        if (command === 'set' && profile.osdCustomElementTypeMapping) {
+        // 3. Generic setting pattern mappings (value remapping by regex pattern)
+        //    e.g. OSD custom element type IDs renumbered between versions
+        if (command === 'set' && profile.settingPatternMappings && profile.settingPatternMappings.length > 0) {
             const settingName = parts[1] ? parts[1].toLowerCase() : '';
-            if (settingName.match(/^osd_custom_element_\d+_type$/)) {
-                const eqIdx = parts.indexOf('=');
-                if (eqIdx !== -1 && eqIdx + 1 < parts.length) {
-                    const oldTypeId = parts[eqIdx + 1];
-                    if (profile.osdCustomElementTypeMapping[oldTypeId]) {
-                        const newTypeId = profile.osdCustomElementTypeMapping[oldTypeId];
-                        parts[eqIdx + 1] = newTypeId;
-                        changes.push(`OSD custom element type remapped: ${oldTypeId} → ${newTypeId}`);
-                        currentLine = parts.join(' ');
+            for (const mapping of profile.settingPatternMappings) {
+                if (new RegExp(mapping.pattern).test(settingName)) {
+                    const eqIdx = parts.indexOf('=');
+                    if (eqIdx !== -1 && eqIdx + 1 < parts.length) {
+                        const oldVal = parts[eqIdx + 1];
+                        if (mapping.valueMap[oldVal]) {
+                            parts[eqIdx + 1] = mapping.valueMap[oldVal];
+                            const desc = mapping.description || 'Setting value remapped';
+                            changes.push(`${desc}: "${settingName}" ${oldVal} → ${mapping.valueMap[oldVal]}`);
+                            currentLine = parts.join(' ');
+                        }
                     }
+                    break; // Only first matching pattern applies
                 }
             }
         }
@@ -168,7 +171,7 @@ const MigrationHandler = {
      *     renamedSettings: string[],
      *     renamedCommands: string[],
      *     valueReplacements: string[],
-     *     osdRemappings: string[],
+     *     settingRemappings: string[],
      *     warnings: string[]
      *   }
      * }}
@@ -185,7 +188,7 @@ const MigrationHandler = {
             renamedSettings: [],
             renamedCommands: [],
             valueReplacements: [],
-            osdRemappings: [],
+            settingRemappings: [],
             warnings: [],
         };
 
@@ -253,8 +256,8 @@ const MigrationHandler = {
                         summary.renamedCommands.push(change);
                     } else if (change.startsWith('Value replaced')) {
                         summary.valueReplacements.push(change);
-                    } else if (change.startsWith('OSD')) {
-                        summary.osdRemappings.push(change);
+                    } else {
+                        summary.settingRemappings.push(change);
                     }
                 }
             }
@@ -341,9 +344,9 @@ const MigrationHandler = {
             }
         }
 
-        if (summary.osdRemappings.length > 0) {
-            lines.push(`\nOSD type remappings (${summary.osdRemappings.length}):`);
-            for (const r of summary.osdRemappings) {
+        if (summary.settingRemappings.length > 0) {
+            lines.push(`\nSetting remappings (${summary.settingRemappings.length}):`);
+            for (const r of summary.settingRemappings) {
                 lines.push(`  - ${r}`);
             }
         }

--- a/js/migration/migration_handler.js
+++ b/js/migration/migration_handler.js
@@ -2,7 +2,6 @@
 
 import semver from 'semver';
 
-// Import migration profiles
 import profile_7_to_8 from './7_to_8.json';
 import profile_8_to_9 from './8_to_9.json';
 
@@ -47,20 +46,18 @@ const MigrationHandler = {
         const fromMajor = semver.major(fromVersion);
         const toMajor = semver.major(toVersion);
 
-        if (fromMajor >= toMajor) return []; // same or downgrade — no migration
+        if (fromMajor >= toMajor) return [];
 
         const chain = [];
         for (const profile of MIGRATION_PROFILES) {
             const profileFrom = parseInt(profile.fromVersion, 10);
             const profileTo = parseInt(profile.toVersion, 10);
 
-            // Include this profile if it bridges a gap in our version range
             if (profileFrom >= fromMajor && profileTo <= toMajor) {
                 chain.push(profile);
             }
         }
 
-        // Sort by fromVersion to ensure correct order
         chain.sort((a, b) => parseInt(a.fromVersion, 10) - parseInt(b.fromVersion, 10));
 
         return chain;
@@ -76,13 +73,12 @@ const MigrationHandler = {
         const changes = [];
         let currentLine = line;
 
-        // Parse the line into parts: command [subcommand] [setting] [value...]
         const parts = currentLine.split(/\s+/);
         if (parts.length === 0) return { line: currentLine, changes };
 
         const command = parts[0].toLowerCase();
 
-        // 1. Command renames (e.g. "profile" → "control_profile")
+        // 1. Command renames
         if (profile.commandRenames) {
             const lowerParts = parts.map(p => p.toLowerCase());
             for (const [oldCmd, newCmd] of Object.entries(profile.commandRenames)) {
@@ -116,8 +112,6 @@ const MigrationHandler = {
             // 2c. Value replacements
             if (profile.valueReplacements && profile.valueReplacements[settingName]) {
                 const valueMap = profile.valueReplacements[settingName];
-                // The value is everything after "set <name> = "
-                // Handle the "set name = value" pattern
                 const eqIdx = parts.indexOf('=');
                 if (eqIdx !== -1 && eqIdx + 1 < parts.length) {
                     const oldValue = parts[eqIdx + 1];
@@ -130,8 +124,7 @@ const MigrationHandler = {
             }
         }
 
-        // 3. Generic setting pattern mappings (value remapping by regex pattern)
-        //    e.g. OSD custom element type IDs renumbered between versions
+        // 3. Setting pattern mappings
         if (command === 'set' && profile.settingPatternMappings && profile.settingPatternMappings.length > 0) {
             const settingName = parts[1] ? parts[1].toLowerCase() : '';
             for (const mapping of profile.settingPatternMappings) {
@@ -146,7 +139,7 @@ const MigrationHandler = {
                             currentLine = parts.join(' ');
                         }
                     }
-                    break; // Only first matching pattern applies
+                    break;
                 }
             }
         }
@@ -202,7 +195,6 @@ const MigrationHandler = {
             return { migratedContent: fileContent, summary };
         }
 
-        // Collect profile descriptions and warnings
         for (const profile of chain) {
             summary.profilesApplied.push(`${profile.fromVersion} → ${profile.toVersion}: ${profile.description}`);
             if (profile.warnings) {
@@ -210,27 +202,23 @@ const MigrationHandler = {
             }
         }
 
-        // Process each line of the file content
         const lines = fileContent.split('\n');
         const migratedLines = [];
 
         for (const rawLine of lines) {
             const trimmed = rawLine.trim();
 
-            // Pass through comments, empty lines, and non-command lines unchanged
             if (trimmed.length === 0 || trimmed.startsWith('#')) {
                 migratedLines.push(rawLine);
                 continue;
             }
 
-            // Skip save/exit — these are handled by the restore flow
             const lower = trimmed.toLowerCase();
             if (lower === 'save' || lower === 'exit') {
                 migratedLines.push(rawLine);
                 continue;
             }
 
-            // Apply each profile in the chain sequentially
             let currentLine = trimmed;
             let lineRemoved = false;
 
@@ -245,7 +233,6 @@ const MigrationHandler = {
                     currentLine = result.line;
                 }
 
-                // Categorize changes for the summary
                 for (const change of result.changes) {
                     summary.totalChanges++;
                     if (change.startsWith('Removed')) {
@@ -265,7 +252,6 @@ const MigrationHandler = {
             if (!lineRemoved) {
                 migratedLines.push(currentLine);
             }
-            // Removed lines are simply not added to migratedLines
         }
 
         return {
@@ -301,7 +287,7 @@ const MigrationHandler = {
         const fromMajor = semver.major(semver.coerce(fromVersion));
         const toMajor = semver.major(semver.coerce(targetVersion));
 
-        if (toMajor <= fromMajor) return false; // same or downgrade
+        if (toMajor <= fromMajor) return false;
 
         const chain = this.buildMigrationChain(fromVersion, targetVersion);
         const coveredSteps = chain.length;

--- a/js/migration/migration_handler.js
+++ b/js/migration/migration_handler.js
@@ -288,6 +288,29 @@ const MigrationHandler = {
     },
 
     /**
+     * Check if there is a major version jump that is NOT fully covered by migration profiles.
+     * Returns true when profiles are missing for one or more major version steps.
+     * @param {string} fileContent - Backup file content
+     * @param {string} targetVersion - Target INAV version (semver)
+     * @returns {boolean}
+     */
+    hasMissingProfiles(fileContent, targetVersion) {
+        const fromVersion = this.extractBackupVersion(fileContent);
+        if (!fromVersion || !targetVersion) return false;
+
+        const fromMajor = semver.major(semver.coerce(fromVersion));
+        const toMajor = semver.major(semver.coerce(targetVersion));
+
+        if (toMajor <= fromMajor) return false; // same or downgrade
+
+        const chain = this.buildMigrationChain(fromVersion, targetVersion);
+        const coveredSteps = chain.length;
+        const requiredSteps = toMajor - fromMajor;
+
+        return coveredSteps < requiredSteps;
+    },
+
+    /**
      * Get all available migration profiles (for developer tools / UI).
      * @returns {object[]}
      */

--- a/js/protocols/stm32.js
+++ b/js/protocols/stm32.js
@@ -57,14 +57,13 @@ var STM32_protocol = function () {
     this.useExtendedErase = false;
 };
 
-// Polls for reboot completion by checking for DFU device or serial port
 STM32_protocol.prototype.pollForRebootCompletion = function(port, hex, options, onSuccess, onTimeout) {
     var self = this;
     var intervalMs = 250;
     var retries = 0;
-    var maxRetries = 40; // timeout after intervalMs * 40 (10 seconds)
-    var portAbsentCount = 0; // Count how many times the port has been absent
-    var portAbsentThreshold = 8; // Require port to be absent this many times (2 seconds) before trying to connect
+    var maxRetries = 40;
+    var portAbsentCount = 0;
+    var portAbsentThreshold = 8;
     var connectingInProgress = false;
     var pollInterval = null;
 
@@ -76,12 +75,10 @@ STM32_protocol.prototype.pollForRebootCompletion = function(port, hex, options, 
             return;
         }
 
-        // Don't start new operations if we're already trying to connect
         if (connectingInProgress) {
             return;
         }
 
-        // Check for DFU devices first (preferred path for STM32 with DFU bootloader)
         PortHandler.check_usb_devices(function(dfu_available) {
             if (dfu_available) {
                 console.log('DFU device detected');
@@ -90,18 +87,14 @@ STM32_protocol.prototype.pollForRebootCompletion = function(port, hex, options, 
                 return;
             }
 
-            // Check for serial port
             ConnectionSerial.getDevices().then(function(devices) {
                 if (devices && devices.includes(port)) {
-                    // Port is present
-                    // Only attempt connection if port was absent for a while (device has fully rebooted)
-                    // This prevents connecting during USB re-enumeration when device is transitioning to DFU
+                    // Only connect if port was absent long enough (full reboot cycle)
                     if (portAbsentCount >= portAbsentThreshold) {
                         console.log('Port ' + port + ' reappeared after being absent, attempting connection...');
                         connectingInProgress = true;
                         clearInterval(pollInterval);
 
-                        // Extra delay to let the serial port fully stabilize
                         setTimeout(function() {
                             CONFIGURATOR.connection.connect(port, {bitrate: self.baud, parityBit: 'even', stopBits: 'one'}, function (openInfo) {
                                 if (openInfo) {
@@ -118,7 +111,6 @@ STM32_protocol.prototype.pollForRebootCompletion = function(port, hex, options, 
                         console.log('Port ' + port + ' present but waiting for reboot cycle (absent count: ' + portAbsentCount + '/' + portAbsentThreshold + ')');
                     }
                 } else {
-                    // Port is absent - device is rebooting
                     portAbsentCount++;
                     if (portAbsentCount <= portAbsentThreshold) {
                         console.log('Port ' + port + ' absent (' + portAbsentCount + '/' + portAbsentThreshold + ')');
@@ -131,8 +123,7 @@ STM32_protocol.prototype.pollForRebootCompletion = function(port, hex, options, 
     }, intervalMs);
 };
 
- // Waits for a specific response from the serial connection with timeout
-STM32_protocol.prototype.waitForResponse = function(expectedString, timeoutMs, callback) {
+ STM32_protocol.prototype.waitForResponse = function(expectedString, timeoutMs, callback) {
     var receivedData = '';
     var timeoutHandle = null;
     var onReceiveListener = null;
@@ -149,7 +140,6 @@ STM32_protocol.prototype.waitForResponse = function(expectedString, timeoutMs, c
         }
     };
 
-    // Set up timeout
     timeoutHandle = setTimeout(function() {
         if (callbackFired) return;
         callbackFired = true;
@@ -158,14 +148,12 @@ STM32_protocol.prototype.waitForResponse = function(expectedString, timeoutMs, c
         callback(false, receivedData);
     }, timeoutMs);
 
-    // Set up receive listener
     onReceiveListener = function(info) {
         if (callbackFired) return;
         var data = new Uint8Array(info.data);
         var str = String.fromCharCode.apply(null, data);
         receivedData += str;
 
-        // Check if we received the expected string
         if (receivedData.includes(expectedString)) {
             callbackFired = true;
             cleanup();
@@ -183,7 +171,7 @@ STM32_protocol.prototype.waitForResponse = function(expectedString, timeoutMs, c
  */
 STM32_protocol.prototype.sendRebootCommand = function(callback) {
     var self = this;
-    var responseWaiter = null; // Store reference to cleanup later
+    var responseWaiter = null;
 
     console.log('Entering CLI to send DFU command');
 
@@ -196,9 +184,8 @@ STM32_protocol.prototype.sendRebootCommand = function(callback) {
             }
         };
 
-        // On Linux the serial port vanishes before disconnect() runs,
-        // so _connectionId may already be false and the callback never fires.
-        // Use a timeout as safety net to guarantee the flash flow continues.
+        // On Linux the serial port may vanish before disconnect() runs,
+        // so _connectionId may be false and the callback never fires.
         var fallback = setTimeout(fireCallback, 3000);
 
         try {
@@ -229,7 +216,6 @@ STM32_protocol.prototype.sendRebootCommand = function(callback) {
         });
     };
 
-    // Step 1: Set up response listener before sending # (to avoid missing the response)
     self.waitForResponse('CLI', 2000, function(success, receivedData) {
         if (!success) {
             console.log('Failed to enter CLI mode, timeout waiting for prompt');
@@ -240,8 +226,6 @@ STM32_protocol.prototype.sendRebootCommand = function(callback) {
 
         console.log('CLI mode entered');
 
-        // If onCliReady callback is set, call it before sending DFU command
-        // This allows pre-flash backup (diff all) while CLI is active
         if (self.options.onCliReady) {
             self.options.onCliReady(CONFIGURATOR.connection, function() {
                 sendDfuCommand();
@@ -251,7 +235,7 @@ STM32_protocol.prototype.sendRebootCommand = function(callback) {
         }
     });
 
-    // Step 2: Send '####\r\n' to enter CLI (listener is already set up above)
+    // Send '####\r\n' to enter CLI (listener already set up above)
     var cliEnterStr = '####\r\n';
     var cliEnterBuffer = new ArrayBuffer(cliEnterStr.length);
     var cliEnterView = new Uint8Array(cliEnterBuffer);
@@ -293,7 +277,6 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
         self.options.onCliReady = options.onCliReady;
     }
 
-    // Check if device is already in DFU mode before attempting serial connection
     PortHandler.check_usb_devices(function(dfu_available) {
         if (dfu_available) {
             console.log('Device already in DFU mode, connecting directly');
@@ -302,12 +285,10 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
             return;
         }
 
-        // Device not in DFU mode, proceed with normal flow
         self.connectSerial(port, hex, options);
     });
 };
 
-// Internal method to handle serial connection flow
 STM32_protocol.prototype.connectSerial = function(port, hex, options) {
     var self = this;
 
@@ -323,14 +304,12 @@ STM32_protocol.prototype.connectSerial = function(port, hex, options) {
             }
         });
     } else {
-        // Need to send reboot command to enter DFU/bootloader
         CONFIGURATOR.connection.connect(port, {bitrate: self.options.reboot_baud}, function (openInfo) {
             if (!openInfo) {
                 GUI.log(i18n.getMessage('failedToOpenSerialPort'));
                 return;
             }
 
-            // Connected - lock UI and send reboot command
             GUI.connect_lock = true;
 
             self.sendRebootCommand(function(disconnectResult) {
@@ -339,17 +318,14 @@ STM32_protocol.prototype.connectSerial = function(port, hex, options) {
                     return;
                 }
 
-                // Poll for device to reboot and reappear
                 self.pollForRebootCompletion(
                     port,
                     hex,
                     options,
                     function onSuccess() {
-                        // Device reconnected via serial
                         self.initialize();
                     },
                     function onTimeout() {
-                        // Polling timed out — DFU device not detected
                         console.log('DFU/bootloader detection timed out on port ' + port);
                         GUI.log(i18n.getMessage('failedToFlash') + port);
                         $('span.progressLabel').text(i18n.getMessage('failedToFlash') + port);

--- a/js/protocols/stm32.js
+++ b/js/protocols/stm32.js
@@ -329,8 +329,11 @@ STM32_protocol.prototype.connectSerial = function(port, hex, options) {
                         self.initialize();
                     },
                     function onTimeout() {
-                        // Polling timed out
+                        // Polling timed out — DFU device not detected
+                        console.log('DFU/bootloader detection timed out on port ' + port);
                         GUI.log(i18n.getMessage('failedToFlash') + port);
+                        $('span.progressLabel').text(i18n.getMessage('failedToFlash') + port);
+                        GUI.connect_lock = false;
                     }
                 );
             });

--- a/js/protocols/stm32.js
+++ b/js/protocols/stm32.js
@@ -188,9 +188,29 @@ STM32_protocol.prototype.sendRebootCommand = function(callback) {
     console.log('Entering CLI to send DFU command');
 
     var cleanupAndDisconnect = function(success) {
-        CONFIGURATOR.connection.disconnect(function(result) {
-            callback(success);
-        });
+        var done = false;
+        var fireCallback = function() {
+            if (!done) {
+                done = true;
+                callback(success);
+            }
+        };
+
+        // On Linux the serial port vanishes before disconnect() runs,
+        // so _connectionId may already be false and the callback never fires.
+        // Use a timeout as safety net to guarantee the flash flow continues.
+        var fallback = setTimeout(fireCallback, 3000);
+
+        try {
+            CONFIGURATOR.connection.disconnect(function(result) {
+                clearTimeout(fallback);
+                fireCallback();
+            });
+        } catch (e) {
+            clearTimeout(fallback);
+            console.warn('Disconnect threw during DFU reboot:', e);
+            fireCallback();
+        }
     };
 
     var sendDfuCommand = function() {

--- a/js/protocols/stm32.js
+++ b/js/protocols/stm32.js
@@ -86,7 +86,7 @@ STM32_protocol.prototype.pollForRebootCompletion = function(port, hex, options, 
             if (dfu_available) {
                 console.log('DFU device detected');
                 clearInterval(pollInterval);
-                STM32DFU.connect(usbDevices, hex, options);
+                STM32DFU.connect(usbDevices, hex, options, self.callback);
                 return;
             }
 
@@ -178,7 +178,7 @@ STM32_protocol.prototype.waitForResponse = function(expectedString, timeoutMs, c
 
 /**
  * Sends reboot command to enter DFU mode using new CLI-based protocol
- * Protocol: Send '#' -> Wait for CLI prompt -> Send 'dfu\r\n' -> Disconnect
+ * Protocol: Send '#' -> Wait for CLI prompt -> (optional: onCliReady callback) -> Send 'dfu\r\n' -> Disconnect
  * @param {function} callback - Called after command sequence completes with (success)
  */
 STM32_protocol.prototype.sendRebootCommand = function(callback) {
@@ -193,18 +193,9 @@ STM32_protocol.prototype.sendRebootCommand = function(callback) {
         });
     };
 
-    // Step 1: Set up response listener before sending # (to avoid missing the response)
-    self.waitForResponse('CLI', 2000, function(success, receivedData) {
-        if (!success) {
-            console.log('Failed to enter CLI mode, timeout waiting for prompt');
-            console.log('Received data:', receivedData);
-            cleanupAndDisconnect(false);
-            return;
-        }
+    var sendDfuCommand = function() {
+        console.log('Sending dfu command');
 
-        console.log('CLI mode entered, sending dfu command');
-
-        // Step 3: Send 'dfu\r\n' command
         var dfuCommandStr = 'dfu\r\n';
         var dfuBuffer = new ArrayBuffer(dfuCommandStr.length);
         var dfuView = new Uint8Array(dfuBuffer);
@@ -216,6 +207,28 @@ STM32_protocol.prototype.sendRebootCommand = function(callback) {
             console.log('DFU command sent, disconnecting');
             cleanupAndDisconnect(true);
         });
+    };
+
+    // Step 1: Set up response listener before sending # (to avoid missing the response)
+    self.waitForResponse('CLI', 2000, function(success, receivedData) {
+        if (!success) {
+            console.log('Failed to enter CLI mode, timeout waiting for prompt');
+            console.log('Received data:', receivedData);
+            cleanupAndDisconnect(false);
+            return;
+        }
+
+        console.log('CLI mode entered');
+
+        // If onCliReady callback is set, call it before sending DFU command
+        // This allows pre-flash backup (diff all) while CLI is active
+        if (self.options.onCliReady) {
+            self.options.onCliReady(CONFIGURATOR.connection, function() {
+                sendDfuCommand();
+            });
+        } else {
+            sendDfuCommand();
+        }
     });
 
     // Step 2: Send '####\r\n' to enter CLI (listener is already set up above)
@@ -242,7 +255,8 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
     self.options = {
         no_reboot:      false,
         reboot_baud:    false,
-        erase_chip:     false
+        erase_chip:     false,
+        onCliReady:     null
     };
 
     if (options.no_reboot) {
@@ -255,12 +269,16 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
         self.options.erase_chip = true;
     }
 
+    if (options.onCliReady) {
+        self.options.onCliReady = options.onCliReady;
+    }
+
     // Check if device is already in DFU mode before attempting serial connection
     PortHandler.check_usb_devices(function(dfu_available) {
         if (dfu_available) {
             console.log('Device already in DFU mode, connecting directly');
             GUI.connect_lock = true;
-            STM32DFU.connect(usbDevices, hex, options);
+            STM32DFU.connect(usbDevices, hex, options, self.callback);
             return;
         }
 

--- a/js/protocols/stm32usbdfu.js
+++ b/js/protocols/stm32usbdfu.js
@@ -128,6 +128,7 @@ STM32DFU_protocol.prototype.openDevice = function () {
         if(GUI.operating_system === 'Linux') {
             GUI.log(i18n.getMessage('usbDeviceUdevNotice'));
         }
+        GUI.connect_lock = false;
     });
 };
 

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6397,5 +6397,17 @@
     },
     "backupRestoreAutoRestoreWaitingPort": {
         "message": "Waiting for $1 to become available..."
+    },
+    "firmwareFlasherVersionWarningTitle": {
+        "message": "⚠ Version Update Warning"
+    },
+    "firmwareFlasherVersionWarningText": {
+        "message": "Updating from $1 to $2 without full chip erase can cause unpredictable issues or configuration corruption. Configurator will not restore your FC configuration automatically."
+    },
+    "firmwareFlasherVersionWarningContinue": {
+        "message": "Continue without erase"
+    },
+    "firmwareFlasherVersionWarningCancel": {
+        "message": "Cancel"
     }
 }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6298,5 +6298,104 @@
     },
     "searchPlaceholder": {
         "message": "Search settings..."
+    },
+    "backupRestoreButtonBackup": {
+        "message": "Backup Config"
+    },
+    "backupRestoreButtonRestore": {
+        "message": "Restore Config"
+    },
+    "backupRestoreOpenBackupsFolder": {
+        "message": "Open Backups"
+    },
+    "backupRestoreStatusConnecting": {
+        "message": "Connecting to flight controller..."
+    },
+    "backupRestoreStatusEnteringCli": {
+        "message": "Entering CLI mode..."
+    },
+    "backupRestoreStatusReadingConfig": {
+        "message": "Reading configuration (diff all)..."
+    },
+    "backupRestoreStatusSavingFile": {
+        "message": "Saving backup file..."
+    },
+    "backupRestoreStatusExitingCli": {
+        "message": "Exiting CLI (rebooting)..."
+    },
+    "backupRestoreStatusRestoringConfig": {
+        "message": "Restoring configuration..."
+    },
+    "backupRestoreStatusSaving": {
+        "message": "Saving and rebooting..."
+    },
+    "backupRestoreStatusBackupComplete": {
+        "message": "Backup complete. Proceeding with flash..."
+    },
+    "backupRestoreBackupSaved": {
+        "message": "Configuration backup saved to: $1"
+    },
+    "backupRestoreAutoBackupSaved": {
+        "message": "Auto-backup saved to: $1"
+    },
+    "backupRestoreBackupComplete": {
+        "message": "Backup complete."
+    },
+    "backupRestoreBackupCancelled": {
+        "message": "Backup cancelled."
+    },
+    "backupRestoreBackupFailed": {
+        "message": "Backup failed."
+    },
+    "backupRestoreRestoreComplete": {
+        "message": "Configuration restored. Flight controller is rebooting."
+    },
+    "backupRestoreRestoreCancelled": {
+        "message": "Restore cancelled."
+    },
+    "backupRestoreRestoreFailed": {
+        "message": "Restore failed."
+    },
+    "backupRestoreFlashCompleteBackupSaved": {
+        "message": "Flash complete. Configuration backup was saved."
+    },
+    "backupRestoreOverlayTitle": {
+        "message": "Restoring Configuration"
+    },
+    "backupRestoreStatusRestoringProgress": {
+        "message": "Restoring configuration... ($1 / $2)"
+    },
+    "backupRestoreRestoreAborted": {
+        "message": "Restore aborted — settings were NOT saved."
+    },
+    "backupRestoreErrorTitle": {
+        "message": "Errors During Restore"
+    },
+    "backupRestoreErrorText": {
+        "message": "The following errors were reported by the flight controller. You can save the settings anyway or abort without saving."
+    },
+    "backupRestoreErrorAbort": {
+        "message": "Abort (Don't Save)"
+    },
+    "backupRestoreErrorSave": {
+        "message": "Save Anyway"
+    },
+    "backupRestoreFlashCompleteOfferRestore": {
+        "message": "Flash complete. A backup was saved before flashing."
+    },
+    "backupRestoreAutoRestoreConfirm": {
+        "message": "Full chip erase was performed. Would you like to restore the configuration backup that was saved before flashing?"
+    },
+    "backupRestoreAutoRestoreWaiting": {
+        "message": "Waiting for flight controller to boot..."
+    },
+    "backupRestoreAutoRestoreYes": {
+        "message": "Yes, Restore"
+    },
+    "backupRestoreAutoRestoreNo": {
+        "message": "No, Skip"
+    },
+    "backupRestoreAutoRestoreWaitingPort": {
+        "message": "Waiting for $1 to become available..."
     }
 }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6445,5 +6445,8 @@
     },
     "migrationPreviewCancel": {
         "message": "Cancel (Manual Review)"
+    },
+    "migrationMissingProfileWarning": {
+        "message": "No migration profile available for version $1 → $2. Settings will be restored without conversion — some may fail or be ignored by the firmware."
     }
 }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6409,5 +6409,41 @@
     },
     "firmwareFlasherVersionWarningCancel": {
         "message": "Cancel"
+    },
+    "backupRestoreMigrationApplied": {
+        "message": "Migration applied: $1 → $2 ($3 changes)"
+    },
+    "backupRestoreMigrationWarningsHeader": {
+        "message": "Migration Warnings:"
+    },
+    "backupRestoreDowngradeNoAutoRestore": {
+        "message": "Major version downgrade detected. Auto-restore is not available — please restore your backup manually after verifying settings."
+    },
+    "migrationPreviewTitle": {
+        "message": "Settings Migration Required"
+    },
+    "migrationPreviewSubtitle": {
+        "message": "Your backup ($1) will be migrated to match the new firmware ($2). The following changes will be applied:"
+    },
+    "migrationPreviewRemovedHeader": {
+        "message": "Removed settings ($1):"
+    },
+    "migrationPreviewRenamedSettingsHeader": {
+        "message": "Renamed settings ($1):"
+    },
+    "migrationPreviewRenamedCommandsHeader": {
+        "message": "Renamed commands ($1):"
+    },
+    "migrationPreviewValueReplacementsHeader": {
+        "message": "Value replacements ($1):"
+    },
+    "migrationPreviewOsdRemappingsHeader": {
+        "message": "OSD type remappings ($1):"
+    },
+    "migrationPreviewContinue": {
+        "message": "Continue with Restore"
+    },
+    "migrationPreviewCancel": {
+        "message": "Cancel (Manual Review)"
     }
 }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6437,8 +6437,8 @@
     "migrationPreviewValueReplacementsHeader": {
         "message": "Value replacements ($1):"
     },
-    "migrationPreviewOsdRemappingsHeader": {
-        "message": "OSD type remappings ($1):"
+    "migrationPreviewSettingRemappingsHeader": {
+        "message": "Setting remappings ($1):"
     },
     "migrationPreviewContinue": {
         "message": "Continue with Restore"

--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -281,6 +281,86 @@
     font-weight: normal;
 }
 
+/* Version warning overlay: minor/major update without chip erase */
+#version-warning-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#version-warning-overlay.is-hidden {
+    display: none;
+}
+
+.version-warning-overlay__content {
+    background: #fff;
+    border-radius: 8px;
+    padding: 2em 3em;
+    min-width: 380px;
+    max-width: 560px;
+    text-align: center;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.version-warning-overlay__title {
+    font-size: 1.3em;
+    font-weight: bold;
+    margin-bottom: 1em;
+    color: #c00;
+}
+
+.version-warning-overlay__text {
+    font-size: 1em;
+    margin-bottom: 1.5em;
+    color: #555;
+    line-height: 1.6;
+}
+
+.version-warning-overlay__buttons {
+    display: flex;
+    justify-content: center;
+    gap: 1em;
+}
+
+.version-warning-overlay__btn {
+    padding: 0.7em 1.5em;
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 0.95em;
+    cursor: pointer;
+    text-decoration: none;
+    text-align: center;
+    transition: all ease 0.2s;
+}
+
+.version-warning-overlay__btn--continue {
+    background: #c00;
+    border: 1px solid #a00;
+    color: #fff;
+}
+
+.version-warning-overlay__btn--continue:hover {
+    background: #a00;
+}
+
+.version-warning-overlay__btn--cancel {
+    background: #37a8db;
+    border: 1px solid #3a9dbf;
+    color: #fff;
+    text-shadow: 0 1px rgba(0, 0, 0, 0.25);
+}
+
+.version-warning-overlay__btn--cancel:hover {
+    background: #3394b5;
+}
+
 /* Restore overlay: blocks entire tab during restore */
 #restore-overlay {
     position: fixed;

--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -606,3 +606,120 @@
 .restore-error-dialog__btn--save:hover {
     background: #3394b5;
 }
+
+/* Migration preview overlay: shown before restore when migration is needed */
+#migration-preview-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#migration-preview-overlay.is-hidden {
+    display: none;
+}
+
+.migration-preview__content {
+    background: #fff;
+    border-radius: 8px;
+    padding: 2em;
+    min-width: 420px;
+    max-width: 640px;
+    max-height: 80vh;
+    overflow-y: auto;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.migration-preview__title {
+    font-size: 1.3em;
+    font-weight: bold;
+    margin-bottom: 0.5em;
+    color: #333;
+}
+
+.migration-preview__subtitle {
+    font-size: 1em;
+    margin-bottom: 1.2em;
+    color: #555;
+}
+
+.migration-preview__changes {
+    max-height: 300px;
+    overflow-y: auto;
+    background: #f9f9f9;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 0.8em;
+    margin-bottom: 1em;
+    font-family: monospace;
+    font-size: 0.85em;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.migration-preview__changes:empty {
+    display: none;
+}
+
+.migration-preview__warnings {
+    background: #fff8e1;
+    border: 1px solid #ffe082;
+    border-radius: 4px;
+    padding: 0.8em;
+    margin-bottom: 1.5em;
+    font-size: 0.9em;
+    line-height: 1.6;
+    color: #795548;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.migration-preview__warnings:empty {
+    display: none;
+}
+
+.migration-preview__buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1em;
+}
+
+.migration-preview__btn {
+    padding: 0.7em 1.5em;
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 0.95em;
+    cursor: pointer;
+    text-decoration: none;
+    text-align: center;
+    transition: all ease 0.2s;
+}
+
+.migration-preview__btn--cancel {
+    background: #fff;
+    border: 1px solid #888;
+    color: #555;
+}
+
+.migration-preview__btn--cancel:hover {
+    background: #eee;
+    color: #333;
+}
+
+.migration-preview__btn--continue {
+    background: #37a8db;
+    border: 1px solid #3a9dbf;
+    color: #fff;
+    text-shadow: 0 1px rgba(0, 0, 0, 0.25);
+}
+
+.migration-preview__btn--continue:hover {
+    background: #3394b5;
+}

--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -280,3 +280,249 @@
     font-size: 12px;
     font-weight: normal;
 }
+
+/* Restore overlay: blocks entire tab during restore */
+#restore-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#restore-overlay.is-hidden {
+    display: none;
+}
+
+.restore-overlay__content {
+    background: #fff;
+    border-radius: 8px;
+    padding: 2em 3em;
+    min-width: 380px;
+    max-width: 500px;
+    text-align: center;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.restore-overlay__title {
+    font-size: 1.4em;
+    font-weight: bold;
+    margin-bottom: 1em;
+    color: #333;
+}
+
+.restore-overlay__status {
+    font-size: 1.1em;
+    margin-bottom: 1em;
+    color: #555;
+}
+
+.restore-overlay__progress-bar {
+    width: 100%;
+    height: 22px;
+    background: #4f4f4f;
+    border-radius: 4px;
+    overflow: hidden;
+    box-shadow: inset 0 0 5px #2f2f2f;
+}
+
+.restore-overlay__progress-fill {
+    height: 100%;
+    width: 0%;
+    background: #37a8db;
+    border-radius: 4px;
+    transition: width 0.15s ease;
+}
+
+.restore-overlay__progress-text {
+    margin-top: 0.5em;
+    font-size: 0.95em;
+    color: #777;
+}
+
+/* Confirm overlay: auto-restore prompt after flash */
+#restore-confirm-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#restore-confirm-overlay.is-hidden {
+    display: none;
+}
+
+.restore-confirm-overlay__content {
+    background: #fff;
+    border-radius: 8px;
+    padding: 2em 3em;
+    min-width: 380px;
+    max-width: 520px;
+    text-align: center;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.restore-confirm-overlay__title {
+    font-size: 1.2em;
+    font-weight: bold;
+    margin-bottom: 1em;
+    color: #333;
+    line-height: 1.5;
+}
+
+.restore-confirm-overlay__status {
+    font-size: 1em;
+    margin-bottom: 1em;
+    color: #555;
+}
+
+.restore-confirm-overlay__status:empty {
+    display: none;
+}
+
+.restore-confirm-overlay__buttons {
+    display: flex;
+    justify-content: center;
+    gap: 1em;
+    margin-top: 1.5em;
+}
+
+.restore-confirm-overlay__btn {
+    padding: 0.7em 1.5em;
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 0.95em;
+    cursor: pointer;
+    text-decoration: none;
+    text-align: center;
+    transition: all ease 0.2s;
+}
+
+.restore-confirm-overlay__btn--no {
+    background: #fff;
+    border: 1px solid #888;
+    color: #555;
+}
+
+.restore-confirm-overlay__btn--no:hover {
+    background: #eee;
+    color: #333;
+}
+
+.restore-confirm-overlay__btn--yes {
+    background: #37a8db;
+    border: 1px solid #3a9dbf;
+    color: #fff;
+    text-shadow: 0 1px rgba(0, 0, 0, 0.25);
+}
+
+.restore-confirm-overlay__btn--yes:hover {
+    background: #3394b5;
+}
+
+/* Error dialog overlay after restore */
+#restore-error-dialog {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 10001;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#restore-error-dialog.is-hidden {
+    display: none;
+}
+
+.restore-error-dialog__content {
+    background: #fff;
+    border-radius: 8px;
+    padding: 2em;
+    min-width: 400px;
+    max-width: 600px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.restore-error-dialog__title {
+    font-size: 1.3em;
+    font-weight: bold;
+    color: darkred;
+    margin-bottom: 0.8em;
+}
+
+.restore-error-dialog__text {
+    font-size: 1em;
+    color: #555;
+    margin-bottom: 1em;
+    line-height: 1.5;
+}
+
+.restore-error-dialog__errors {
+    max-height: 200px;
+    overflow-y: auto;
+    background: #f5f5f5;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 0.8em;
+    margin-bottom: 1.5em;
+    font-family: monospace;
+    font-size: 0.85em;
+    line-height: 1.6;
+    color: #c00;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.restore-error-dialog__buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1em;
+}
+
+.restore-error-dialog__btn {
+    padding: 0.7em 1.5em;
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 0.95em;
+    cursor: pointer;
+    text-decoration: none;
+    text-align: center;
+    transition: all ease 0.2s;
+}
+
+.restore-error-dialog__btn--abort {
+    background: #fff;
+    border: 1px solid #c00;
+    color: #c00;
+}
+
+.restore-error-dialog__btn--abort:hover {
+    background: #c00;
+    color: #fff;
+}
+
+.restore-error-dialog__btn--save {
+    background: #37a8db;
+    border: 1px solid #3a9dbf;
+    color: #fff;
+    text-shadow: 0 1px rgba(0, 0, 0, 0.25);
+}
+
+.restore-error-dialog__btn--save:hover {
+    background: #3394b5;
+}

--- a/tabs/firmware_flasher.html
+++ b/tabs/firmware_flasher.html
@@ -11,6 +11,18 @@
         </div>
     </div>
 
+    <!-- Version warning overlay: shown when minor/major update without chip erase -->
+    <div id="version-warning-overlay" class="is-hidden">
+        <div class="version-warning-overlay__content">
+            <div class="version-warning-overlay__title" i18n="firmwareFlasherVersionWarningTitle"></div>
+            <div class="version-warning-overlay__text"></div>
+            <div class="version-warning-overlay__buttons">
+                <a class="version-warning-overlay__btn version-warning-overlay__btn--continue" href="#" i18n="firmwareFlasherVersionWarningContinue"></a>
+                <a class="version-warning-overlay__btn version-warning-overlay__btn--cancel" href="#" i18n="firmwareFlasherVersionWarningCancel"></a>
+            </div>
+        </div>
+    </div>
+
     <!-- Confirm overlay: ask user if they want to auto-restore after flash -->
     <div id="restore-confirm-overlay" class="is-hidden">
         <div class="restore-confirm-overlay__content">

--- a/tabs/firmware_flasher.html
+++ b/tabs/firmware_flasher.html
@@ -1,4 +1,41 @@
 <div class="tab-firmware_flasher toolbar_fixed_bottom">
+    <!-- Restore overlay: blocks UI during restore operation -->
+    <div id="restore-overlay" class="is-hidden">
+        <div class="restore-overlay__content">
+            <div class="restore-overlay__title" i18n="backupRestoreOverlayTitle"></div>
+            <div class="restore-overlay__status" i18n="backupRestoreStatusEnteringCli"></div>
+            <div class="restore-overlay__progress-bar">
+                <div class="restore-overlay__progress-fill"></div>
+            </div>
+            <div class="restore-overlay__progress-text">0 / 0</div>
+        </div>
+    </div>
+
+    <!-- Confirm overlay: ask user if they want to auto-restore after flash -->
+    <div id="restore-confirm-overlay" class="is-hidden">
+        <div class="restore-confirm-overlay__content">
+            <div class="restore-confirm-overlay__title" i18n="backupRestoreAutoRestoreConfirm"></div>
+            <div class="restore-confirm-overlay__status"></div>
+            <div class="restore-confirm-overlay__buttons">
+                <a class="restore-confirm-overlay__btn restore-confirm-overlay__btn--no" href="#" i18n="backupRestoreAutoRestoreNo"></a>
+                <a class="restore-confirm-overlay__btn restore-confirm-overlay__btn--yes" href="#" i18n="backupRestoreAutoRestoreYes"></a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Error dialog: shown after restore if errors were detected -->
+    <div id="restore-error-dialog" class="is-hidden">
+        <div class="restore-error-dialog__content">
+            <div class="restore-error-dialog__title" i18n="backupRestoreErrorTitle"></div>
+            <div class="restore-error-dialog__text" i18n="backupRestoreErrorText"></div>
+            <div class="restore-error-dialog__errors"></div>
+            <div class="restore-error-dialog__buttons">
+                <a class="restore-error-dialog__btn restore-error-dialog__btn--abort" href="#" i18n="backupRestoreErrorAbort"></a>
+                <a class="restore-error-dialog__btn restore-error-dialog__btn--save" href="#" i18n="backupRestoreErrorSave"></a>
+            </div>
+        </div>
+    </div>
+
     <div class="content_wrapper">
         <div class="options gui_box">
             <div class="spacer">
@@ -126,6 +163,15 @@
         </div>
         <div class="btn">
             <a class="flash_firmware disabled" href="#progressbar" i18n="firmwareFlasherFlashFirmware"></a>
+        </div>
+        <div class="btn">
+            <a class="backup_config" href="#" i18n="backupRestoreButtonBackup"></a>
+        </div>
+        <div class="btn">
+            <a class="restore_config" href="#" i18n="backupRestoreButtonRestore"></a>
+        </div>
+        <div class="btn">
+            <a class="open_backups_folder" href="#" i18n="backupRestoreOpenBackupsFolder"></a>
         </div>
     </div>
 </div>

--- a/tabs/firmware_flasher.html
+++ b/tabs/firmware_flasher.html
@@ -48,6 +48,20 @@
         </div>
     </div>
 
+    <!-- Migration preview overlay: shown before restore when migration is needed -->
+    <div id="migration-preview-overlay" class="is-hidden">
+        <div class="migration-preview__content">
+            <div class="migration-preview__title" i18n="migrationPreviewTitle"></div>
+            <div class="migration-preview__subtitle"></div>
+            <div class="migration-preview__changes"></div>
+            <div class="migration-preview__warnings"></div>
+            <div class="migration-preview__buttons">
+                <a class="migration-preview__btn migration-preview__btn--cancel" href="#" i18n="migrationPreviewCancel"></a>
+                <a class="migration-preview__btn migration-preview__btn--continue" href="#" i18n="migrationPreviewContinue"></a>
+            </div>
+        </div>
+    </div>
+
     <div class="content_wrapper">
         <div class="options gui_box">
             <div class="spacer">

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -572,9 +572,6 @@ TABS.firmware_flasher.initialize = function (callback) {
             }
         });
 
-        // --- Shared helpers for migration preview (used by flash + manual restore) ---
-
-        // Show progress label with a link to open the backups folder
         function showBackupSavedMessage(messageKey) {
             $('span.progressLabel').html(
                 i18n.getMessage(messageKey) +
@@ -587,7 +584,6 @@ TABS.firmware_flasher.initialize = function (callback) {
             });
         }
 
-        // Build migration changes text for preview overlay
         function buildMigrationChangesText(summary) {
             var sections = [
                 { key: 'removedSettings', header: 'migrationPreviewRemovedHeader' },
@@ -610,7 +606,6 @@ TABS.firmware_flasher.initialize = function (callback) {
             return lines.join('\n');
         }
 
-        // Show migration preview overlay with changes and warnings
         function showMigrationPreview(summary, onContinue, onCancel) {
             var $preview = $('#migration-preview-overlay');
             var $changes = $preview.find('.migration-preview__changes');
@@ -662,11 +657,9 @@ TABS.firmware_flasher.initialize = function (callback) {
                             options.erase_chip = true;
                         }
 
-                        // Save original port before flash (port picker may change during DFU)
                         var originalPort = String($('div#port-picker #port').val());
                         var originalBaud = parseInt($('div#port-picker #baud').val());
 
-                        // Determine version update type (patch / minor / major)
                         var currentVersion = (FC.CONFIG && FC.CONFIG.flightControllerVersion) ? FC.CONFIG.flightControllerVersion : null;
                         var selectedSummary = $('select[name="firmware_version"] option:selected').data('summary');
                         var targetVersion = (!localFirmwareLoaded && selectedSummary) ? semver.clean(selectedSummary.version) : null;
@@ -674,13 +667,11 @@ TABS.firmware_flasher.initialize = function (callback) {
 
                         if (currentVersion && targetVersion && semver.valid(currentVersion) && semver.valid(targetVersion)) {
                             var diffType = semver.diff(currentVersion, targetVersion);
-                            // minor, major, premajor, preminor all count as non-patch
                             if (diffType && diffType !== 'patch' && diffType !== 'prepatch' && diffType !== 'prerelease') {
                                 isMinorOrMajorUpdate = true;
                             }
                         }
 
-                        // Version check gate: warn if minor/major update without chip erase
                         if (isMinorOrMajorUpdate && !options.erase_chip) {
                             showVersionWarning(currentVersion, targetVersion, function onContinue() {
                                 skipAutoRestore = true;
@@ -692,7 +683,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                         proceedWithFlash();
                         return;
 
-                        // Shows the version warning overlay; calls onContinue if user proceeds
                         function showVersionWarning(fromVer, toVer, onContinue) {
                             var $warn = $('#version-warning-overlay');
                             $warn.find('.version-warning-overlay__text').text(
@@ -713,7 +703,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                             $cancelBtn.on('click.versionWarn', function(e) {
                                 e.preventDefault();
                                 cleanup();
-                                // User cancelled — do nothing
                             });
 
                             $continueBtn.on('click.versionWarn', function(e) {
@@ -725,10 +714,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
                         function proceedWithFlash() {
 
-                        // Common completion handler for both serial and DFU flash paths
                         function onFlashComplete() {
-                            // Update stored FC version to what we just flashed
-                            // so subsequent version checks are accurate without reconnecting
                             if (targetVersion && FC.CONFIG) {
                                 FC.CONFIG.flightControllerVersion = targetVersion;
                             }
@@ -737,7 +723,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                             if (backup) {
                                 GUI.log(i18n.getMessage('backupRestoreAutoBackupSaved', [backup.filePath]));
 
-                                // Check for major version downgrade — no auto-restore for downgrades
                                 var backupVersion = MigrationHandler.extractBackupVersion(backup.data);
                                 var isMajorDowngrade = false;
                                 if (backupVersion && targetVersion && semver.valid(backupVersion) && semver.valid(targetVersion)) {
@@ -747,18 +732,13 @@ TABS.firmware_flasher.initialize = function (callback) {
                                 }
 
                                 if (!targetVersion) {
-                                    // Local firmware file — unknown target version, no auto-restore
                                     showBackupSavedMessage('backupRestoreFlashCompleteBackupSaved');
                                     BackupRestore.clearLastAutoBackup();
                                 } else if (isMajorDowngrade) {
-                                    // Major downgrade — inform user, no auto-restore
                                     GUI.log(i18n.getMessage('backupRestoreDowngradeNoAutoRestore'));
                                     showBackupSavedMessage('backupRestoreDowngradeNoAutoRestore');
                                     BackupRestore.clearLastAutoBackup();
                                 } else if (options.erase_chip && !skipAutoRestore) {
-                                    // Full chip erase — offer auto-restore
-
-                                    // Pre-compute migration to decide which dialog to show
                                     var migrationNeeded = targetVersion && MigrationHandler.isMigrationNeeded(backup.data, targetVersion);
                                     var missingProfiles = targetVersion && MigrationHandler.hasMissingProfiles(backup.data, targetVersion);
                                     var migrationResult = null;
@@ -769,7 +749,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                                         dataToRestore = migrationResult.migratedContent;
                                     }
 
-                                    // Inject missing-profile warning into summary if applicable
                                     if (missingProfiles) {
                                         if (!migrationResult) {
                                             var backupVer = MigrationHandler.extractBackupVersion(backup.data) || 'unknown';
@@ -784,9 +763,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                                     }
 
                                     if (migrationResult && (migrationResult.summary.totalChanges > 0 || migrationResult.summary.warnings.length > 0)) {
-                                        // Show migration preview overlay instead of simple confirm
                                         showMigrationPreview(migrationResult.summary, function onContinue() {
-                                            // Log migration info
                                             GUI.log(i18n.getMessage('backupRestoreMigrationApplied', [
                                                 migrationResult.summary.fromVersion,
                                                 migrationResult.summary.toVersion,
@@ -798,7 +775,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                                             showBackupSavedMessage('backupRestoreFlashCompleteBackupSaved');
                                         });
                                     } else {
-                                        // No migration needed — show simple confirm overlay
                                         $('span.progressLabel').text(i18n.getMessage('backupRestoreFlashCompleteOfferRestore'));
 
                                         var $confirmOverlay = $('#restore-confirm-overlay');
@@ -828,14 +804,12 @@ TABS.firmware_flasher.initialize = function (callback) {
                                         });
                                     }
                                 } else {
-                                    // No full chip erase — just show backup info
                                     showBackupSavedMessage('backupRestoreFlashCompleteBackupSaved');
                                     BackupRestore.clearLastAutoBackup();
                                 }
                             }
                         }
 
-                        // Start port polling and auto-restore with given data
                         function startPortPollingAndRestore(restoreData) {
                             var restorePort = originalPort;
                             var restoreBaud = originalBaud;
@@ -875,7 +849,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                             }, 500);
                         }
 
-                        // Extracted restore logic — restoreData is already migrated if needed
                         function doAutoRestore(restorePort, restoreBaud, restoreData, $overlay, $overlayStatus, $overlayFill, $overlayText) {
                             GUI.connect_lock = true;
 
@@ -904,7 +877,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                                     $overlay.addClass('is-hidden');
 
                                     if (result.errors.length > 0) {
-                                        // Show error dialog
                                         var $errorDlg = $('#restore-error-dialog');
                                         $errorDlg.find('.restore-error-dialog__errors').text(result.errors.join('\n'));
                                         $errorDlg.removeClass('is-hidden');
@@ -992,8 +964,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                                     baud = parseInt($('#flash_manual_baud_rate').val());
                                 }
 
-                                // Add auto-backup handler: captures diff all while CLI is
-                                // active during the reboot sequence (before DFU command)
                                 if (!options.no_reboot) {
                                     options.onCliReady = BackupRestore.createOnCliReadyHandler(function(msgKey) {
                                         $('span.progressLabel').text(i18n.getMessage(msgKey));
@@ -1018,7 +988,6 @@ TABS.firmware_flasher.initialize = function (callback) {
             }
         });
 
-        // Backup Config button
         $('a.backup_config').on('click', function () {
             if (GUI.connect_lock) return;
 
@@ -1030,7 +999,6 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             $('span.progressLabel').text(i18n.getMessage('backupRestoreStatusConnecting'));
 
-            // Connect to FC, perform backup via CLI, then disconnect
             var rebootBaud = parseInt($('div#port-picker #baud').val());
             GUI.connect_lock = true;
 
@@ -1050,7 +1018,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                     } else {
                         $('span.progressLabel').text(i18n.getMessage('backupRestoreBackupCancelled'));
                     }
-                    // FC reboots after CLI exit, disconnect and unlock
                     disconnectSafely(function() {
                         GUI.connect_lock = false;
                     });
@@ -1065,7 +1032,6 @@ TABS.firmware_flasher.initialize = function (callback) {
             });
         });
 
-        // Restore Config button
         $('a.restore_config').on('click', async function () {
             if (GUI.connect_lock) return;
 
@@ -1075,7 +1041,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                 return;
             }
 
-            // Show file dialog BEFORE connecting to avoid idle connection during user interaction
             var backupDir = await window.electronAPI.getBackupDir();
             var fileResult = await window.electronAPI.showOpenDialog({
                 defaultPath: backupDir,
@@ -1100,7 +1065,6 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             var fileData = fileResponse.data;
 
-            // Show overlay and lock UI
             var $overlay = $('#restore-overlay');
             var $overlayStatus = $overlay.find('.restore-overlay__status');
             var $overlayFill = $overlay.find('.restore-overlay__progress-fill');
@@ -1123,9 +1087,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                     return;
                 }
 
-                // Query actual FC version via MSP before deciding on migration.
-                // The cached FC.CONFIG.flightControllerVersion may be stale after
-                // a flash (e.g. targetVersion was null for a local firmware file).
                 $overlayStatus.text(i18n.getMessage('backupRestoreStatusConnecting'));
                 MSP.disconnect_cleanup();
                 var mspListener = function(info) { MSP.read(info); };
@@ -1153,7 +1114,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                 function proceedAfterVersionQuery() {
                     var currentFcVersion = FC.CONFIG.flightControllerVersion;
 
-                    // Run migration check with the real FC version
                     var migrationNeeded = currentFcVersion && MigrationHandler.isMigrationNeeded(fileData, currentFcVersion);
                     var missingProfiles = currentFcVersion && MigrationHandler.hasMissingProfiles(fileData, currentFcVersion);
                     var migrationResult = null;
@@ -1163,7 +1123,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                         fileData = migrationResult.migratedContent;
                     }
 
-                    // Inject missing-profile warning if applicable
                     if (missingProfiles) {
                         if (!migrationResult) {
                             var backupVer = MigrationHandler.extractBackupVersion(fileData) || 'unknown';
@@ -1177,9 +1136,8 @@ TABS.firmware_flasher.initialize = function (callback) {
                         );
                     }
 
-                    // If migration has changes or warnings, show preview and wait for user decision
                     if (migrationResult && (migrationResult.summary.totalChanges > 0 || migrationResult.summary.warnings.length > 0)) {
-                        $overlay.addClass('is-hidden'); // hide connecting overlay for preview
+                        $overlay.addClass('is-hidden');
                         showMigrationPreview(migrationResult.summary, function onContinue() {
                             GUI.log(i18n.getMessage('backupRestoreMigrationApplied', [
                                 migrationResult.summary.fromVersion,
@@ -1201,7 +1159,6 @@ TABS.firmware_flasher.initialize = function (callback) {
 
                 function doRestore() {
 
-                // Progress callback from performRestore
                 function onProgress(info) {
                     switch (info.phase) {
                         case 'entering-cli':
@@ -1227,13 +1184,11 @@ TABS.firmware_flasher.initialize = function (callback) {
                     $overlay.addClass('is-hidden');
 
                     if (result.errors.length > 0) {
-                        // Show error dialog — let user decide to save or abort
                         var $errorDlg = $('#restore-error-dialog');
                         var $errorList = $errorDlg.find('.restore-error-dialog__errors');
                         $errorList.text(result.errors.join('\n'));
                         $errorDlg.removeClass('is-hidden');
 
-                        // Wait for user choice via one-time click handlers
                         var $saveBtn = $errorDlg.find('.restore-error-dialog__btn--save');
                         var $abortBtn = $errorDlg.find('.restore-error-dialog__btn--abort');
 
@@ -1268,7 +1223,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                             });
                         });
                     } else {
-                        // No errors — save immediately
                         $('span.progressLabel').text(i18n.getMessage('backupRestoreStatusSaving'));
                         BackupRestore.saveAndReboot().then(function() {
                             GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
@@ -1291,7 +1245,6 @@ TABS.firmware_flasher.initialize = function (callback) {
             });
         });
 
-        // Open Backups Folder button
         $('a.open_backups_folder').on('click', function () {
             window.electronAPI.openBackupDir();
         });

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -540,6 +540,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                 if (!GUI.connect_lock) { // button disabled while flashing is in progress
                     if (parsed_hex != false) {
                         var options = {};
+                        var skipAutoRestore = false;
 
                         if ($('input.erase_chip').is(':checked')) {
                             options.erase_chip = true;
@@ -549,14 +550,79 @@ TABS.firmware_flasher.initialize = function (callback) {
                         var originalPort = String($('div#port-picker #port').val());
                         var originalBaud = parseInt($('div#port-picker #baud').val());
 
+                        // Determine version update type (patch / minor / major)
+                        var currentVersion = FC.CONFIG.flightControllerVersion;
+                        var selectedSummary = $('select[name="firmware_version"] option:selected').data('summary');
+                        var targetVersion = selectedSummary ? semver.clean(selectedSummary.version) : null;
+                        var isMinorOrMajorUpdate = false;
+
+                        if (currentVersion && targetVersion && semver.valid(currentVersion) && semver.valid(targetVersion)) {
+                            var diffType = semver.diff(currentVersion, targetVersion);
+                            // minor, major, premajor, preminor all count as non-patch
+                            if (diffType && diffType !== 'patch' && diffType !== 'prepatch' && diffType !== 'prerelease') {
+                                isMinorOrMajorUpdate = true;
+                            }
+                        }
+
+                        // Version check gate: warn if minor/major update without chip erase
+                        if (isMinorOrMajorUpdate && !options.erase_chip) {
+                            showVersionWarning(currentVersion, targetVersion, function onContinue() {
+                                skipAutoRestore = true;
+                                proceedWithFlash();
+                            });
+                            return; // wait for user decision
+                        }
+
+                        proceedWithFlash();
+                        return;
+
+                        // Shows the version warning overlay; calls onContinue if user proceeds
+                        function showVersionWarning(fromVer, toVer, onContinue) {
+                            var $warn = $('#version-warning-overlay');
+                            $warn.find('.version-warning-overlay__text').text(
+                                i18n.getMessage('firmwareFlasherVersionWarningText', [fromVer, toVer])
+                            );
+                            $warn.removeClass('is-hidden');
+                            i18n.localize($warn);
+
+                            var $continueBtn = $warn.find('.version-warning-overlay__btn--continue');
+                            var $cancelBtn = $warn.find('.version-warning-overlay__btn--cancel');
+
+                            function cleanup() {
+                                $continueBtn.off('click.versionWarn');
+                                $cancelBtn.off('click.versionWarn');
+                                $warn.addClass('is-hidden');
+                            }
+
+                            $cancelBtn.on('click.versionWarn', function(e) {
+                                e.preventDefault();
+                                cleanup();
+                                // User cancelled — do nothing
+                            });
+
+                            $continueBtn.on('click.versionWarn', function(e) {
+                                e.preventDefault();
+                                cleanup();
+                                onContinue();
+                            });
+                        }
+
+                        function proceedWithFlash() {
+
                         // Common completion handler for both serial and DFU flash paths
                         function onFlashComplete() {
+                            // Update stored FC version to what we just flashed
+                            // so subsequent version checks are accurate without reconnecting
+                            if (targetVersion) {
+                                FC.CONFIG.flightControllerVersion = targetVersion;
+                            }
+
                             var backup = BackupRestore.getLastAutoBackup();
                             if (backup) {
                                 GUI.log(i18n.getMessage('backupRestoreAutoBackupSaved', [backup.filePath]));
 
-                                if (options.erase_chip) {
-                                    // Full chip erase — offer auto-restore via in-app overlay
+                                if (options.erase_chip && !skipAutoRestore) {
+                                    // Full chip erase + patch-only update — offer auto-restore via in-app overlay
                                     $('span.progressLabel').text(i18n.getMessage('backupRestoreFlashCompleteOfferRestore'));
 
                                     // Show confirm overlay (non-blocking — lets FC reboot from DFU in the background)
@@ -778,6 +844,9 @@ TABS.firmware_flasher.initialize = function (callback) {
                         } else {
                             STM32DFU.connect(usbDevices, parsed_hex, options, onFlashComplete);
                         }
+
+                        } // end proceedWithFlash
+
                     } else {
                         $('span.progressLabel').text(i18n.getMessage('firmwareFlasherFirmwareNotLoaded'));
                     }

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -800,10 +800,10 @@ TABS.firmware_flasher.initialize = function (callback) {
                                 }
                                 changesLines.push('');
                             }
-                            if (summary.osdRemappings.length > 0) {
-                                changesLines.push(i18n.getMessage('migrationPreviewOsdRemappingsHeader', [summary.osdRemappings.length.toString()]));
-                                for (var i = 0; i < summary.osdRemappings.length; i++) {
-                                    changesLines.push('  • ' + summary.osdRemappings[i]);
+                            if (summary.settingRemappings.length > 0) {
+                                changesLines.push(i18n.getMessage('migrationPreviewSettingRemappingsHeader', [summary.settingRemappings.length.toString()]));
+                                for (var i = 0; i < summary.settingRemappings.length; i++) {
+                                    changesLines.push('  • ' + summary.settingRemappings[i]);
                                 }
                             }
                             $changes.text(changesLines.join('\n'));
@@ -1193,10 +1193,10 @@ TABS.firmware_flasher.initialize = function (callback) {
                     }
                     changesLines.push('');
                 }
-                if (summary.osdRemappings.length > 0) {
-                    changesLines.push(i18n.getMessage('migrationPreviewOsdRemappingsHeader', [summary.osdRemappings.length.toString()]));
-                    for (var ci = 0; ci < summary.osdRemappings.length; ci++) {
-                        changesLines.push('  • ' + summary.osdRemappings[ci]);
+                if (summary.settingRemappings.length > 0) {
+                    changesLines.push(i18n.getMessage('migrationPreviewSettingRemappingsHeader', [summary.settingRemappings.length.toString()]));
+                    for (var ci = 0; ci < summary.settingRemappings.length; ci++) {
+                        changesLines.push('  • ' + summary.settingRemappings[ci]);
                     }
                 }
                 $changes.text(changesLines.join('\n'));

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -682,6 +682,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
                                     // Pre-compute migration to decide which dialog to show
                                     var migrationNeeded = targetVersion && MigrationHandler.isMigrationNeeded(backup.data, targetVersion);
+                                    var missingProfiles = targetVersion && MigrationHandler.hasMissingProfiles(backup.data, targetVersion);
                                     var migrationResult = null;
                                     var dataToRestore = backup.data;
 
@@ -690,7 +691,35 @@ TABS.firmware_flasher.initialize = function (callback) {
                                         dataToRestore = migrationResult.migratedContent;
                                     }
 
-                                    if (migrationNeeded && migrationResult.summary.totalChanges > 0) {
+                                    // Inject missing-profile warning into summary if applicable
+                                    if (missingProfiles) {
+                                        if (!migrationResult) {
+                                            var backupVer = MigrationHandler.extractBackupVersion(backup.data) || 'unknown';
+                                            migrationResult = {
+                                                migratedContent: dataToRestore,
+                                                summary: {
+                                                    fromVersion: backupVer,
+                                                    toVersion: targetVersion,
+                                                    profilesApplied: [],
+                                                    totalChanges: 0,
+                                                    removedSettings: [],
+                                                    renamedSettings: [],
+                                                    renamedCommands: [],
+                                                    valueReplacements: [],
+                                                    settingRemappings: [],
+                                                    warnings: [],
+                                                },
+                                            };
+                                        }
+                                        migrationResult.summary.warnings.push(
+                                            i18n.getMessage('migrationMissingProfileWarning', [
+                                                migrationResult.summary.fromVersion,
+                                                migrationResult.summary.toVersion,
+                                            ])
+                                        );
+                                    }
+
+                                    if (migrationResult && (migrationResult.summary.totalChanges > 0 || migrationResult.summary.warnings.length > 0)) {
                                         // Show migration preview overlay instead of simple confirm
                                         showMigrationPreview(migrationResult.summary, function onContinue() {
                                             // Log migration info
@@ -1109,6 +1138,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             // Run migration before connecting (text-only, no FC needed)
             var migrationNeeded = currentFcVersion && MigrationHandler.isMigrationNeeded(fileData, currentFcVersion);
+            var missingProfiles = currentFcVersion && MigrationHandler.hasMissingProfiles(fileData, currentFcVersion);
             var migrationResult = null;
 
             if (migrationNeeded) {
@@ -1116,8 +1146,36 @@ TABS.firmware_flasher.initialize = function (callback) {
                 fileData = migrationResult.migratedContent;
             }
 
-            // If migration has changes, show preview overlay and wait for user decision
-            if (migrationResult && migrationResult.summary.totalChanges > 0) {
+            // Inject missing-profile warning if applicable
+            if (missingProfiles) {
+                if (!migrationResult) {
+                    var backupVer = MigrationHandler.extractBackupVersion(fileResponse.data) || 'unknown';
+                    migrationResult = {
+                        migratedContent: fileData,
+                        summary: {
+                            fromVersion: backupVer,
+                            toVersion: currentFcVersion,
+                            profilesApplied: [],
+                            totalChanges: 0,
+                            removedSettings: [],
+                            renamedSettings: [],
+                            renamedCommands: [],
+                            valueReplacements: [],
+                            settingRemappings: [],
+                            warnings: [],
+                        },
+                    };
+                }
+                migrationResult.summary.warnings.push(
+                    i18n.getMessage('migrationMissingProfileWarning', [
+                        migrationResult.summary.fromVersion,
+                        migrationResult.summary.toVersion,
+                    ])
+                );
+            }
+
+            // If migration has changes or warnings, show preview overlay and wait for user decision
+            if (migrationResult && (migrationResult.summary.totalChanges > 0 || migrationResult.summary.warnings.length > 0)) {
                 await new Promise(function(resolve) {
                     showManualMigrationPreview(migrationResult.summary, function onContinue() {
                         GUI.log(i18n.getMessage('backupRestoreMigrationApplied', [

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -17,9 +17,11 @@ import mspQueue from './../js/serial_queue';
 import mspHelper from './../js/msp/MSPHelper';
 import STM32 from './../js/protocols/stm32';
 import STM32DFU from './../js/protocols/stm32usbdfu';
+import ConnectionSerial from './../js/connection/connectionSerial';
 import mspDeduplicationQueue from './../js/msp/mspDeduplicationQueue';
 import store from './../js/store';
 import dialog from '../js/dialog.js';
+import BackupRestore from './../js/backup_restore';
 
 TABS.firmware_flasher = {};
 
@@ -543,6 +545,195 @@ TABS.firmware_flasher.initialize = function (callback) {
                             options.erase_chip = true;
                         }
 
+                        // Save original port before flash (port picker may change during DFU)
+                        var originalPort = String($('div#port-picker #port').val());
+                        var originalBaud = parseInt($('div#port-picker #baud').val());
+
+                        // Common completion handler for both serial and DFU flash paths
+                        function onFlashComplete() {
+                            var backup = BackupRestore.getLastAutoBackup();
+                            if (backup) {
+                                GUI.log(i18n.getMessage('backupRestoreAutoBackupSaved', [backup.filePath]));
+
+                                if (options.erase_chip) {
+                                    // Full chip erase — offer auto-restore via in-app overlay
+                                    $('span.progressLabel').text(i18n.getMessage('backupRestoreFlashCompleteOfferRestore'));
+
+                                    // Show confirm overlay (non-blocking — lets FC reboot from DFU in the background)
+                                    var $confirmOverlay = $('#restore-confirm-overlay');
+                                    $confirmOverlay.removeClass('is-hidden');
+                                    i18n.localize($confirmOverlay);
+
+                                    var $yesBtn = $confirmOverlay.find('.restore-confirm-overlay__btn--yes');
+                                    var $noBtn = $confirmOverlay.find('.restore-confirm-overlay__btn--no');
+                                    var $confirmStatus = $confirmOverlay.find('.restore-confirm-overlay__status');
+
+                                    function confirmCleanup() {
+                                        $yesBtn.off('click.autoRestore');
+                                        $noBtn.off('click.autoRestore');
+                                        $confirmOverlay.addClass('is-hidden');
+                                    }
+
+                                    $noBtn.on('click.autoRestore', function(e) {
+                                        e.preventDefault();
+                                        confirmCleanup();
+                                        BackupRestore.clearLastAutoBackup();
+                                        $('span.progressLabel').text(i18n.getMessage('backupRestoreFlashCompleteBackupSaved'));
+                                    });
+
+                                    $yesBtn.on('click.autoRestore', function(e) {
+                                        e.preventDefault();
+                                        // Hide confirm overlay, show waiting status
+                                        $yesBtn.off('click.autoRestore');
+                                        $noBtn.off('click.autoRestore');
+
+                                        // Use the original port saved before flash (port picker may show DFU)
+                                        var restorePort = originalPort;
+                                        var restoreBaud = originalBaud;
+
+                                        // Show restore progress overlay
+                                        var $overlay = $('#restore-overlay');
+                                        var $overlayStatus = $overlay.find('.restore-overlay__status');
+                                        var $overlayFill = $overlay.find('.restore-overlay__progress-fill');
+                                        var $overlayText = $overlay.find('.restore-overlay__progress-text');
+                                        $overlayFill.css('width', '0%');
+                                        $overlayText.text('');
+                                        $overlayStatus.text(i18n.getMessage('backupRestoreAutoRestoreWaitingPort', [restorePort]));
+                                        $confirmOverlay.addClass('is-hidden');
+                                        $overlay.removeClass('is-hidden');
+
+                                        // Poll for COM port to appear (FC rebooting from DFU to normal)
+                                        var portPollRetries = 0;
+                                        var maxPortPollRetries = 60; // 30 seconds max
+                                        var portPollInterval = setInterval(function() {
+                                            portPollRetries++;
+                                            if (portPollRetries > maxPortPollRetries) {
+                                                clearInterval(portPollInterval);
+                                                $overlay.addClass('is-hidden');
+                                                GUI.connect_lock = false;
+                                                GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
+                                                $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
+                                                BackupRestore.clearLastAutoBackup();
+                                                return;
+                                            }
+
+                                            ConnectionSerial.getDevices().then(function(devices) {
+                                                if (devices && devices.includes(restorePort)) {
+                                                    clearInterval(portPollInterval);
+                                                    // Port found — wait a moment for it to stabilize, then connect
+                                                    $overlayStatus.text(i18n.getMessage('backupRestoreStatusConnecting'));
+                                                    setTimeout(function() {
+                                                        doAutoRestore(restorePort, restoreBaud, backup, $overlay, $overlayStatus, $overlayFill, $overlayText);
+                                                    }, 2000);
+                                                }
+                                            });
+                                        }, 500);
+                                    });
+                                } else {
+                                    // No full chip erase — just show backup info
+                                    $('span.progressLabel').html(
+                                        i18n.getMessage('backupRestoreFlashCompleteBackupSaved') +
+                                        ' <a class="open_backup_dir" href="#">' +
+                                        i18n.getMessage('backupRestoreOpenBackupsFolder') + '</a>'
+                                    );
+                                    $('.open_backup_dir').on('click', function(e) {
+                                        e.preventDefault();
+                                        window.electronAPI.openBackupDir();
+                                    });
+                                    BackupRestore.clearLastAutoBackup();
+                                }
+                            }
+                        }
+
+                        // Extracted restore logic to keep onFlashComplete readable
+                        function doAutoRestore(restorePort, restoreBaud, backup, $overlay, $overlayStatus, $overlayFill, $overlayText) {
+                            GUI.connect_lock = true;
+
+                            CONFIGURATOR.connection.connect(restorePort, {bitrate: restoreBaud}, function(openInfo) {
+                                if (!openInfo) {
+                                    $overlay.addClass('is-hidden');
+                                    GUI.connect_lock = false;
+                                    GUI.log(i18n.getMessage('failedToOpenSerialPort'));
+                                    $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
+                                    BackupRestore.clearLastAutoBackup();
+                                    return;
+                                }
+
+                                function onProgress(info) {
+                                    if (info.phase === 'entering-cli') {
+                                        $overlayStatus.text(i18n.getMessage('backupRestoreStatusEnteringCli'));
+                                    } else if (info.phase === 'restoring') {
+                                        var pct = info.total > 0 ? Math.round((info.current / info.total) * 100) : 0;
+                                        $overlayStatus.text(i18n.getMessage('backupRestoreStatusRestoringProgress', [info.current, info.total]));
+                                        $overlayFill.css('width', pct + '%');
+                                        $overlayText.text(info.current + ' / ' + info.total);
+                                    }
+                                }
+
+                                BackupRestore.performRestore(backup.data, onProgress).then(function(result) {
+                                    $overlay.addClass('is-hidden');
+
+                                    if (result.errors.length > 0) {
+                                        // Show error dialog
+                                        var $errorDlg = $('#restore-error-dialog');
+                                        $errorDlg.find('.restore-error-dialog__errors').text(result.errors.join('\n'));
+                                        $errorDlg.removeClass('is-hidden');
+
+                                        var $saveBtn = $errorDlg.find('.restore-error-dialog__btn--save');
+                                        var $abortBtn = $errorDlg.find('.restore-error-dialog__btn--abort');
+
+                                        function cleanup() {
+                                            $saveBtn.off('click.restoreErr');
+                                            $abortBtn.off('click.restoreErr');
+                                            $errorDlg.addClass('is-hidden');
+                                        }
+
+                                        $saveBtn.on('click.restoreErr', function(e) {
+                                            e.preventDefault();
+                                            cleanup();
+                                            BackupRestore.saveAndReboot().then(function() {
+                                                GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
+                                                $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
+                                                CONFIGURATOR.connection.disconnect(function() {
+                                                    GUI.connect_lock = false;
+                                                });
+                                            });
+                                        });
+
+                                        $abortBtn.on('click.restoreErr', function(e) {
+                                            e.preventDefault();
+                                            cleanup();
+                                            BackupRestore.abortRestore().then(function() {
+                                                GUI.log(i18n.getMessage('backupRestoreRestoreAborted'));
+                                                $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreAborted'));
+                                                CONFIGURATOR.connection.disconnect(function() {
+                                                    GUI.connect_lock = false;
+                                                });
+                                            });
+                                        });
+                                    } else {
+                                        BackupRestore.saveAndReboot().then(function() {
+                                            GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
+                                            $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
+                                            CONFIGURATOR.connection.disconnect(function() {
+                                                GUI.connect_lock = false;
+                                            });
+                                        });
+                                    }
+                                    BackupRestore.clearLastAutoBackup();
+                                }).catch(function(err) {
+                                    $overlay.addClass('is-hidden');
+                                    console.error('Auto-restore failed:', err);
+                                    GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
+                                    $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
+                                    BackupRestore.clearLastAutoBackup();
+                                    CONFIGURATOR.connection.disconnect(function() {
+                                        GUI.connect_lock = false;
+                                    });
+                                });
+                            });
+                        }
+
                         if (String($('div#port-picker #port').val()) != 'DFU') {
                             if (String($('div#port-picker #port').val()) != '0') {
                                 var port = String($('div#port-picker #port').val()),
@@ -571,20 +762,224 @@ TABS.firmware_flasher.initialize = function (callback) {
                                     baud = parseInt($('#flash_manual_baud_rate').val());
                                 }
 
+                                // Add auto-backup handler: captures diff all while CLI is
+                                // active during the reboot sequence (before DFU command)
+                                if (!options.no_reboot) {
+                                    options.onCliReady = BackupRestore.createOnCliReadyHandler(function(msgKey) {
+                                        $('span.progressLabel').text(i18n.getMessage(msgKey));
+                                    });
+                                }
 
-                                STM32.connect(port, baud, parsed_hex, options);
+                                STM32.connect(port, baud, parsed_hex, options, onFlashComplete);
                             } else {
                                 console.log('Please select valid serial port');
                                 GUI.log(i18n.getMessage('selectValidSerialPort'));
                             }
                         } else {
-                            STM32DFU.connect(usbDevices, parsed_hex, options);
+                            STM32DFU.connect(usbDevices, parsed_hex, options, onFlashComplete);
                         }
                     } else {
                         $('span.progressLabel').text(i18n.getMessage('firmwareFlasherFirmwareNotLoaded'));
                     }
                 }
             }
+        });
+
+        // Backup Config button
+        $('a.backup_config').on('click', function () {
+            if (GUI.connect_lock) return;
+
+            var port = String($('div#port-picker #port').val());
+            if (port === '0' || port === 'DFU') {
+                GUI.log(i18n.getMessage('selectValidSerialPort'));
+                return;
+            }
+
+            $('span.progressLabel').text(i18n.getMessage('backupRestoreStatusConnecting'));
+
+            // Connect to FC, perform backup via CLI, then disconnect
+            var rebootBaud = parseInt($('div#port-picker #baud').val());
+            GUI.connect_lock = true;
+
+            CONFIGURATOR.connection.connect(port, {bitrate: rebootBaud}, function(openInfo) {
+                if (!openInfo) {
+                    GUI.connect_lock = false;
+                    GUI.log(i18n.getMessage('failedToOpenSerialPort'));
+                    return;
+                }
+
+                BackupRestore.performBackupToFile(function(msgKey) {
+                    $('span.progressLabel').text(i18n.getMessage(msgKey));
+                }).then(function(result) {
+                    if (result) {
+                        GUI.log(i18n.getMessage('backupRestoreBackupSaved', [result.filePath]));
+                        $('span.progressLabel').text(i18n.getMessage('backupRestoreBackupComplete'));
+                    } else {
+                        $('span.progressLabel').text(i18n.getMessage('backupRestoreBackupCancelled'));
+                    }
+                    // FC reboots after CLI exit, disconnect and unlock
+                    CONFIGURATOR.connection.disconnect(function() {
+                        GUI.connect_lock = false;
+                    });
+                }).catch(function(err) {
+                    console.error('Backup failed:', err);
+                    GUI.log(i18n.getMessage('backupRestoreBackupFailed'));
+                    $('span.progressLabel').text(i18n.getMessage('backupRestoreBackupFailed'));
+                    CONFIGURATOR.connection.disconnect(function() {
+                        GUI.connect_lock = false;
+                    });
+                });
+            });
+        });
+
+        // Restore Config button
+        $('a.restore_config').on('click', async function () {
+            if (GUI.connect_lock) return;
+
+            var port = String($('div#port-picker #port').val());
+            if (port === '0' || port === 'DFU') {
+                GUI.log(i18n.getMessage('selectValidSerialPort'));
+                return;
+            }
+
+            // Show file dialog BEFORE connecting to avoid idle connection during user interaction
+            var backupDir = await window.electronAPI.getBackupDir();
+            var fileResult = await window.electronAPI.showOpenDialog({
+                defaultPath: backupDir,
+                filters: [
+                    { name: 'CLI/TXT', extensions: ['cli', 'txt'] },
+                    { name: 'ALL', extensions: ['*'] },
+                ],
+                properties: ['openFile'],
+            });
+
+            if (fileResult.canceled || !fileResult.filePaths || fileResult.filePaths.length === 0) {
+                $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreCancelled'));
+                return;
+            }
+
+            var fileResponse = await window.electronAPI.readFile(fileResult.filePaths[0]);
+            if (fileResponse.error) {
+                GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
+                $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
+                return;
+            }
+
+            // Show overlay and lock UI
+            var $overlay = $('#restore-overlay');
+            var $overlayStatus = $overlay.find('.restore-overlay__status');
+            var $overlayFill = $overlay.find('.restore-overlay__progress-fill');
+            var $overlayText = $overlay.find('.restore-overlay__progress-text');
+            $overlayFill.css('width', '0%');
+            $overlayText.text('');
+            $overlayStatus.text(i18n.getMessage('backupRestoreStatusConnecting'));
+            $overlay.removeClass('is-hidden');
+
+            $('span.progressLabel').text(i18n.getMessage('backupRestoreStatusConnecting'));
+
+            var rebootBaud = parseInt($('div#port-picker #baud').val());
+            GUI.connect_lock = true;
+
+            CONFIGURATOR.connection.connect(port, {bitrate: rebootBaud}, function(openInfo) {
+                if (!openInfo) {
+                    $overlay.addClass('is-hidden');
+                    GUI.connect_lock = false;
+                    GUI.log(i18n.getMessage('failedToOpenSerialPort'));
+                    return;
+                }
+
+                // Progress callback from performRestore
+                function onProgress(info) {
+                    switch (info.phase) {
+                        case 'entering-cli':
+                            $overlayStatus.text(i18n.getMessage('backupRestoreStatusEnteringCli'));
+                            $overlayFill.css('width', '0%');
+                            $overlayText.text('');
+                            break;
+                        case 'restoring':
+                            $overlayStatus.text(i18n.getMessage('backupRestoreStatusRestoringProgress', [info.current, info.total]));
+                            var pct = info.total > 0 ? Math.round((info.current / info.total) * 100) : 0;
+                            $overlayFill.css('width', pct + '%');
+                            $overlayText.text(info.current + ' / ' + info.total);
+                            $('span.progressLabel').text(i18n.getMessage('backupRestoreStatusRestoringProgress', [info.current, info.total]));
+                            break;
+                        case 'saving':
+                            $overlayStatus.text(i18n.getMessage('backupRestoreStatusSaving'));
+                            $overlayFill.css('width', '100%');
+                            break;
+                    }
+                }
+
+                BackupRestore.performRestore(fileResponse.data, onProgress).then(function(result) {
+                    $overlay.addClass('is-hidden');
+
+                    if (result.errors.length > 0) {
+                        // Show error dialog — let user decide to save or abort
+                        var $errorDlg = $('#restore-error-dialog');
+                        var $errorList = $errorDlg.find('.restore-error-dialog__errors');
+                        $errorList.text(result.errors.join('\n'));
+                        $errorDlg.removeClass('is-hidden');
+
+                        // Wait for user choice via one-time click handlers
+                        var $saveBtn = $errorDlg.find('.restore-error-dialog__btn--save');
+                        var $abortBtn = $errorDlg.find('.restore-error-dialog__btn--abort');
+
+                        function cleanup() {
+                            $saveBtn.off('click.restoreErr');
+                            $abortBtn.off('click.restoreErr');
+                            $errorDlg.addClass('is-hidden');
+                        }
+
+                        $saveBtn.on('click.restoreErr', function(e) {
+                            e.preventDefault();
+                            cleanup();
+                            $('span.progressLabel').text(i18n.getMessage('backupRestoreStatusSaving'));
+                            BackupRestore.saveAndReboot().then(function() {
+                                GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
+                                $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
+                                CONFIGURATOR.connection.disconnect(function() {
+                                    GUI.connect_lock = false;
+                                });
+                            });
+                        });
+
+                        $abortBtn.on('click.restoreErr', function(e) {
+                            e.preventDefault();
+                            cleanup();
+                            $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreAborted'));
+                            BackupRestore.abortRestore().then(function() {
+                                GUI.log(i18n.getMessage('backupRestoreRestoreAborted'));
+                                CONFIGURATOR.connection.disconnect(function() {
+                                    GUI.connect_lock = false;
+                                });
+                            });
+                        });
+                    } else {
+                        // No errors — save immediately
+                        $('span.progressLabel').text(i18n.getMessage('backupRestoreStatusSaving'));
+                        BackupRestore.saveAndReboot().then(function() {
+                            GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
+                            $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
+                            CONFIGURATOR.connection.disconnect(function() {
+                                GUI.connect_lock = false;
+                            });
+                        });
+                    }
+                }).catch(function(err) {
+                    $overlay.addClass('is-hidden');
+                    console.error('Restore failed:', err);
+                    GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
+                    $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
+                    CONFIGURATOR.connection.disconnect(function() {
+                        GUI.connect_lock = false;
+                    });
+                });
+            });
+        });
+
+        // Open Backups Folder button
+        $('a.open_backups_folder').on('click', function () {
+            window.electronAPI.openBackupDir();
         });
 
         $(document).on('click', 'span.progressLabel a.save_firmware', function () {

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -74,6 +74,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
     var intel_hex = false, // standard intel hex in string format
         parsed_hex = false, // parsed raw hex in array format
+        localFirmwareLoaded = false, // true when firmware loaded from local file
         fileName = "inav.hex";
 
     import('./firmware_flasher.html?raw').then(({default: html}) => GUI.load(html, function () {
@@ -453,6 +454,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         parsed_hex = data;
 
                         if (parsed_hex) {
+                            localFirmwareLoaded = true;
                             $('a.flash_firmware').removeClass('disabled');
 
                             $('span.progressLabel').text('Loaded Local Firmware: (' + parsed_hex.bytes_total + ' bytes)');
@@ -489,6 +491,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             function process_hex(data, summary) {
                 intel_hex = data;
+                localFirmwareLoaded = false;
 
                 parse_hex(intel_hex, function (data) {
                     parsed_hex = data;
@@ -664,9 +667,9 @@ TABS.firmware_flasher.initialize = function (callback) {
                         var originalBaud = parseInt($('div#port-picker #baud').val());
 
                         // Determine version update type (patch / minor / major)
-                        var currentVersion = FC.CONFIG.flightControllerVersion;
+                        var currentVersion = (FC.CONFIG && FC.CONFIG.flightControllerVersion) ? FC.CONFIG.flightControllerVersion : null;
                         var selectedSummary = $('select[name="firmware_version"] option:selected').data('summary');
-                        var targetVersion = selectedSummary ? semver.clean(selectedSummary.version) : null;
+                        var targetVersion = (!localFirmwareLoaded && selectedSummary) ? semver.clean(selectedSummary.version) : null;
                         var isMinorOrMajorUpdate = false;
 
                         if (currentVersion && targetVersion && semver.valid(currentVersion) && semver.valid(targetVersion)) {
@@ -726,7 +729,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         function onFlashComplete() {
                             // Update stored FC version to what we just flashed
                             // so subsequent version checks are accurate without reconnecting
-                            if (targetVersion) {
+                            if (targetVersion && FC.CONFIG) {
                                 FC.CONFIG.flightControllerVersion = targetVersion;
                             }
 
@@ -743,7 +746,11 @@ TABS.firmware_flasher.initialize = function (callback) {
                                     }
                                 }
 
-                                if (isMajorDowngrade) {
+                                if (!targetVersion) {
+                                    // Local firmware file — unknown target version, no auto-restore
+                                    showBackupSavedMessage('backupRestoreFlashCompleteBackupSaved');
+                                    BackupRestore.clearLastAutoBackup();
+                                } else if (isMajorDowngrade) {
                                     // Major downgrade — inform user, no auto-restore
                                     GUI.log(i18n.getMessage('backupRestoreDowngradeNoAutoRestore'));
                                     showBackupSavedMessage('backupRestoreDowngradeNoAutoRestore');
@@ -1092,53 +1099,6 @@ TABS.firmware_flasher.initialize = function (callback) {
             }
 
             var fileData = fileResponse.data;
-            var currentFcVersion = FC.CONFIG.flightControllerVersion;
-
-            // Run migration before connecting (text-only, no FC needed)
-            var migrationNeeded = currentFcVersion && MigrationHandler.isMigrationNeeded(fileData, currentFcVersion);
-            var missingProfiles = currentFcVersion && MigrationHandler.hasMissingProfiles(fileData, currentFcVersion);
-            var migrationResult = null;
-
-            if (migrationNeeded) {
-                migrationResult = MigrationHandler.migrateBackupData(fileData, currentFcVersion);
-                fileData = migrationResult.migratedContent;
-            }
-
-            // Inject missing-profile warning if applicable
-            if (missingProfiles) {
-                if (!migrationResult) {
-                    var backupVer = MigrationHandler.extractBackupVersion(fileResponse.data) || 'unknown';
-                    migrationResult = MigrationHandler.createEmptyResult(backupVer, currentFcVersion, fileData);
-                }
-                migrationResult.summary.warnings.push(
-                    i18n.getMessage('migrationMissingProfileWarning', [
-                        migrationResult.summary.fromVersion,
-                        migrationResult.summary.toVersion,
-                    ])
-                );
-            }
-
-            // If migration has changes or warnings, show preview overlay and wait for user decision
-            if (migrationResult && (migrationResult.summary.totalChanges > 0 || migrationResult.summary.warnings.length > 0)) {
-                await new Promise(function(resolve) {
-                    showMigrationPreview(migrationResult.summary, function onContinue() {
-                        GUI.log(i18n.getMessage('backupRestoreMigrationApplied', [
-                            migrationResult.summary.fromVersion,
-                            migrationResult.summary.toVersion,
-                            migrationResult.summary.totalChanges.toString()
-                        ]));
-                        resolve(true);
-                    }, function onCancel() {
-                        fileData = null; // signal cancellation
-                        resolve(false);
-                    });
-                });
-
-                if (!fileData) {
-                    $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreCancelled'));
-                    return;
-                }
-            }
 
             // Show overlay and lock UI
             var $overlay = $('#restore-overlay');
@@ -1162,6 +1122,84 @@ TABS.firmware_flasher.initialize = function (callback) {
                     GUI.log(i18n.getMessage('failedToOpenSerialPort'));
                     return;
                 }
+
+                // Query actual FC version via MSP before deciding on migration.
+                // The cached FC.CONFIG.flightControllerVersion may be stale after
+                // a flash (e.g. targetVersion was null for a local firmware file).
+                $overlayStatus.text(i18n.getMessage('backupRestoreStatusConnecting'));
+                MSP.disconnect_cleanup();
+                var mspListener = function(info) { MSP.read(info); };
+                CONFIGURATOR.connection.addOnReceiveCallback(mspListener);
+
+                var versionQueryDone = false;
+                var versionQueryTimeout = setTimeout(function() {
+                    if (!versionQueryDone) {
+                        versionQueryDone = true;
+                        CONFIGURATOR.connection.removeOnReceiveCallback(mspListener);
+                        console.warn('MSP_FC_VERSION query timed out, using cached version');
+                        proceedAfterVersionQuery();
+                    }
+                }, 3000);
+
+                MSP.send_message(MSPCodes.MSP_FC_VERSION, false, false, function() {
+                    if (!versionQueryDone) {
+                        versionQueryDone = true;
+                        clearTimeout(versionQueryTimeout);
+                        CONFIGURATOR.connection.removeOnReceiveCallback(mspListener);
+                        proceedAfterVersionQuery();
+                    }
+                });
+
+                function proceedAfterVersionQuery() {
+                    var currentFcVersion = FC.CONFIG.flightControllerVersion;
+
+                    // Run migration check with the real FC version
+                    var migrationNeeded = currentFcVersion && MigrationHandler.isMigrationNeeded(fileData, currentFcVersion);
+                    var missingProfiles = currentFcVersion && MigrationHandler.hasMissingProfiles(fileData, currentFcVersion);
+                    var migrationResult = null;
+
+                    if (migrationNeeded) {
+                        migrationResult = MigrationHandler.migrateBackupData(fileData, currentFcVersion);
+                        fileData = migrationResult.migratedContent;
+                    }
+
+                    // Inject missing-profile warning if applicable
+                    if (missingProfiles) {
+                        if (!migrationResult) {
+                            var backupVer = MigrationHandler.extractBackupVersion(fileData) || 'unknown';
+                            migrationResult = MigrationHandler.createEmptyResult(backupVer, currentFcVersion, fileData);
+                        }
+                        migrationResult.summary.warnings.push(
+                            i18n.getMessage('migrationMissingProfileWarning', [
+                                migrationResult.summary.fromVersion,
+                                migrationResult.summary.toVersion,
+                            ])
+                        );
+                    }
+
+                    // If migration has changes or warnings, show preview and wait for user decision
+                    if (migrationResult && (migrationResult.summary.totalChanges > 0 || migrationResult.summary.warnings.length > 0)) {
+                        $overlay.addClass('is-hidden'); // hide connecting overlay for preview
+                        showMigrationPreview(migrationResult.summary, function onContinue() {
+                            GUI.log(i18n.getMessage('backupRestoreMigrationApplied', [
+                                migrationResult.summary.fromVersion,
+                                migrationResult.summary.toVersion,
+                                migrationResult.summary.totalChanges.toString()
+                            ]));
+                            $overlay.removeClass('is-hidden');
+                            doRestore();
+                        }, function onCancel() {
+                            $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreCancelled'));
+                            disconnectSafely(function() {
+                                GUI.connect_lock = false;
+                            });
+                        });
+                    } else {
+                        doRestore();
+                    }
+                }
+
+                function doRestore() {
 
                 // Progress callback from performRestore
                 function onProgress(info) {
@@ -1249,6 +1287,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         GUI.connect_lock = false;
                     });
                 });
+                } // doRestore
             });
         });
 

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -22,6 +22,7 @@ import mspDeduplicationQueue from './../js/msp/mspDeduplicationQueue';
 import store from './../js/store';
 import dialog from '../js/dialog.js';
 import BackupRestore from './../js/backup_restore';
+import MigrationHandler from './../js/migration/migration_handler';
 
 TABS.firmware_flasher = {};
 
@@ -30,6 +31,39 @@ TABS.firmware_flasher = {};
 function normalizeTargetName(name) {
     if (name == null) return '';
     return String(name).replace(/-/g, '_');
+}
+
+/**
+ * Disconnect with a timeout fallback.
+ * After save/exit the FC reboots and the serial port may vanish before
+ * the disconnect callback fires, which would leave connect_lock stuck.
+ */
+function disconnectSafely(callback) {
+    var done = false;
+    var fallback = setTimeout(function() {
+        if (!done) {
+            done = true;
+            console.warn('Disconnect timed out, forcing unlock');
+            callback();
+        }
+    }, 3000);
+
+    try {
+        CONFIGURATOR.connection.disconnect(function() {
+            if (!done) {
+                done = true;
+                clearTimeout(fallback);
+                callback();
+            }
+        });
+    } catch (e) {
+        if (!done) {
+            done = true;
+            clearTimeout(fallback);
+            console.warn('Disconnect threw:', e);
+            callback();
+        }
+    }
 }
 
 TABS.firmware_flasher.initialize = function (callback) {
@@ -621,80 +655,93 @@ TABS.firmware_flasher.initialize = function (callback) {
                             if (backup) {
                                 GUI.log(i18n.getMessage('backupRestoreAutoBackupSaved', [backup.filePath]));
 
-                                if (options.erase_chip && !skipAutoRestore) {
-                                    // Full chip erase + patch-only update — offer auto-restore via in-app overlay
-                                    $('span.progressLabel').text(i18n.getMessage('backupRestoreFlashCompleteOfferRestore'));
+                                // Check for major version downgrade — no auto-restore for downgrades
+                                var backupVersion = MigrationHandler.extractBackupVersion(backup.data);
+                                var isMajorDowngrade = false;
+                                if (backupVersion && targetVersion && semver.valid(backupVersion) && semver.valid(targetVersion)) {
+                                    if (semver.major(backupVersion) > semver.major(targetVersion)) {
+                                        isMajorDowngrade = true;
+                                    }
+                                }
 
-                                    // Show confirm overlay (non-blocking — lets FC reboot from DFU in the background)
-                                    var $confirmOverlay = $('#restore-confirm-overlay');
-                                    $confirmOverlay.removeClass('is-hidden');
-                                    i18n.localize($confirmOverlay);
+                                if (isMajorDowngrade) {
+                                    // Major downgrade — inform user, no auto-restore
+                                    GUI.log(i18n.getMessage('backupRestoreDowngradeNoAutoRestore'));
+                                    $('span.progressLabel').html(
+                                        i18n.getMessage('backupRestoreDowngradeNoAutoRestore') +
+                                        ' <a class="open_backup_dir" href="#">' +
+                                        i18n.getMessage('backupRestoreOpenBackupsFolder') + '</a>'
+                                    );
+                                    $('.open_backup_dir').on('click', function(e) {
+                                        e.preventDefault();
+                                        window.electronAPI.openBackupDir();
+                                    });
+                                    BackupRestore.clearLastAutoBackup();
+                                } else if (options.erase_chip && !skipAutoRestore) {
+                                    // Full chip erase — offer auto-restore
 
-                                    var $yesBtn = $confirmOverlay.find('.restore-confirm-overlay__btn--yes');
-                                    var $noBtn = $confirmOverlay.find('.restore-confirm-overlay__btn--no');
-                                    var $confirmStatus = $confirmOverlay.find('.restore-confirm-overlay__status');
+                                    // Pre-compute migration to decide which dialog to show
+                                    var migrationNeeded = targetVersion && MigrationHandler.isMigrationNeeded(backup.data, targetVersion);
+                                    var migrationResult = null;
+                                    var dataToRestore = backup.data;
 
-                                    function confirmCleanup() {
-                                        $yesBtn.off('click.autoRestore');
-                                        $noBtn.off('click.autoRestore');
-                                        $confirmOverlay.addClass('is-hidden');
+                                    if (migrationNeeded) {
+                                        migrationResult = MigrationHandler.migrateBackupData(backup.data, targetVersion);
+                                        dataToRestore = migrationResult.migratedContent;
                                     }
 
-                                    $noBtn.on('click.autoRestore', function(e) {
-                                        e.preventDefault();
-                                        confirmCleanup();
-                                        BackupRestore.clearLastAutoBackup();
-                                        $('span.progressLabel').text(i18n.getMessage('backupRestoreFlashCompleteBackupSaved'));
-                                    });
-
-                                    $yesBtn.on('click.autoRestore', function(e) {
-                                        e.preventDefault();
-                                        // Hide confirm overlay, show waiting status
-                                        $yesBtn.off('click.autoRestore');
-                                        $noBtn.off('click.autoRestore');
-
-                                        // Use the original port saved before flash (port picker may show DFU)
-                                        var restorePort = originalPort;
-                                        var restoreBaud = originalBaud;
-
-                                        // Show restore progress overlay
-                                        var $overlay = $('#restore-overlay');
-                                        var $overlayStatus = $overlay.find('.restore-overlay__status');
-                                        var $overlayFill = $overlay.find('.restore-overlay__progress-fill');
-                                        var $overlayText = $overlay.find('.restore-overlay__progress-text');
-                                        $overlayFill.css('width', '0%');
-                                        $overlayText.text('');
-                                        $overlayStatus.text(i18n.getMessage('backupRestoreAutoRestoreWaitingPort', [restorePort]));
-                                        $confirmOverlay.addClass('is-hidden');
-                                        $overlay.removeClass('is-hidden');
-
-                                        // Poll for COM port to appear (FC rebooting from DFU to normal)
-                                        var portPollRetries = 0;
-                                        var maxPortPollRetries = 60; // 30 seconds max
-                                        var portPollInterval = setInterval(function() {
-                                            portPollRetries++;
-                                            if (portPollRetries > maxPortPollRetries) {
-                                                clearInterval(portPollInterval);
-                                                $overlay.addClass('is-hidden');
-                                                GUI.connect_lock = false;
-                                                GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
-                                                $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
-                                                BackupRestore.clearLastAutoBackup();
-                                                return;
-                                            }
-
-                                            ConnectionSerial.getDevices().then(function(devices) {
-                                                if (devices && devices.includes(restorePort)) {
-                                                    clearInterval(portPollInterval);
-                                                    // Port found — wait a moment for it to stabilize, then connect
-                                                    $overlayStatus.text(i18n.getMessage('backupRestoreStatusConnecting'));
-                                                    setTimeout(function() {
-                                                        doAutoRestore(restorePort, restoreBaud, backup, $overlay, $overlayStatus, $overlayFill, $overlayText);
-                                                    }, 2000);
-                                                }
+                                    if (migrationNeeded && migrationResult.summary.totalChanges > 0) {
+                                        // Show migration preview overlay instead of simple confirm
+                                        showMigrationPreview(migrationResult.summary, function onContinue() {
+                                            // Log migration info
+                                            GUI.log(i18n.getMessage('backupRestoreMigrationApplied', [
+                                                migrationResult.summary.fromVersion,
+                                                migrationResult.summary.toVersion,
+                                                migrationResult.summary.totalChanges.toString()
+                                            ]));
+                                            startPortPollingAndRestore(dataToRestore);
+                                        }, function onCancel() {
+                                            BackupRestore.clearLastAutoBackup();
+                                            $('span.progressLabel').html(
+                                                i18n.getMessage('backupRestoreFlashCompleteBackupSaved') +
+                                                ' <a class="open_backup_dir" href="#">' +
+                                                i18n.getMessage('backupRestoreOpenBackupsFolder') + '</a>'
+                                            );
+                                            $('.open_backup_dir').on('click', function(e) {
+                                                e.preventDefault();
+                                                window.electronAPI.openBackupDir();
                                             });
-                                        }, 500);
-                                    });
+                                        });
+                                    } else {
+                                        // No migration needed — show simple confirm overlay
+                                        $('span.progressLabel').text(i18n.getMessage('backupRestoreFlashCompleteOfferRestore'));
+
+                                        var $confirmOverlay = $('#restore-confirm-overlay');
+                                        $confirmOverlay.removeClass('is-hidden');
+                                        i18n.localize($confirmOverlay);
+
+                                        var $yesBtn = $confirmOverlay.find('.restore-confirm-overlay__btn--yes');
+                                        var $noBtn = $confirmOverlay.find('.restore-confirm-overlay__btn--no');
+
+                                        function confirmCleanup() {
+                                            $yesBtn.off('click.autoRestore');
+                                            $noBtn.off('click.autoRestore');
+                                            $confirmOverlay.addClass('is-hidden');
+                                        }
+
+                                        $noBtn.on('click.autoRestore', function(e) {
+                                            e.preventDefault();
+                                            confirmCleanup();
+                                            BackupRestore.clearLastAutoBackup();
+                                            $('span.progressLabel').text(i18n.getMessage('backupRestoreFlashCompleteBackupSaved'));
+                                        });
+
+                                        $yesBtn.on('click.autoRestore', function(e) {
+                                            e.preventDefault();
+                                            confirmCleanup();
+                                            startPortPollingAndRestore(dataToRestore);
+                                        });
+                                    }
                                 } else {
                                     // No full chip erase — just show backup info
                                     $('span.progressLabel').html(
@@ -711,8 +758,131 @@ TABS.firmware_flasher.initialize = function (callback) {
                             }
                         }
 
-                        // Extracted restore logic to keep onFlashComplete readable
-                        function doAutoRestore(restorePort, restoreBaud, backup, $overlay, $overlayStatus, $overlayFill, $overlayText) {
+                        // Show migration preview overlay with changes and warnings
+                        function showMigrationPreview(summary, onContinue, onCancel) {
+                            var $preview = $('#migration-preview-overlay');
+                            var $subtitle = $preview.find('.migration-preview__subtitle');
+                            var $changes = $preview.find('.migration-preview__changes');
+                            var $warnings = $preview.find('.migration-preview__warnings');
+                            var $continueBtn = $preview.find('.migration-preview__btn--continue');
+                            var $cancelBtn = $preview.find('.migration-preview__btn--cancel');
+
+                            // Populate subtitle
+                            $subtitle.text(i18n.getMessage('migrationPreviewSubtitle', [summary.fromVersion, summary.toVersion]));
+
+                            // Build changes text
+                            var changesLines = [];
+                            if (summary.removedSettings.length > 0) {
+                                changesLines.push(i18n.getMessage('migrationPreviewRemovedHeader', [summary.removedSettings.length.toString()]));
+                                for (var i = 0; i < summary.removedSettings.length; i++) {
+                                    changesLines.push('  • ' + summary.removedSettings[i]);
+                                }
+                                changesLines.push('');
+                            }
+                            if (summary.renamedSettings.length > 0) {
+                                changesLines.push(i18n.getMessage('migrationPreviewRenamedSettingsHeader', [summary.renamedSettings.length.toString()]));
+                                for (var i = 0; i < summary.renamedSettings.length; i++) {
+                                    changesLines.push('  • ' + summary.renamedSettings[i]);
+                                }
+                                changesLines.push('');
+                            }
+                            if (summary.renamedCommands.length > 0) {
+                                changesLines.push(i18n.getMessage('migrationPreviewRenamedCommandsHeader', [summary.renamedCommands.length.toString()]));
+                                for (var i = 0; i < summary.renamedCommands.length; i++) {
+                                    changesLines.push('  • ' + summary.renamedCommands[i]);
+                                }
+                                changesLines.push('');
+                            }
+                            if (summary.valueReplacements.length > 0) {
+                                changesLines.push(i18n.getMessage('migrationPreviewValueReplacementsHeader', [summary.valueReplacements.length.toString()]));
+                                for (var i = 0; i < summary.valueReplacements.length; i++) {
+                                    changesLines.push('  • ' + summary.valueReplacements[i]);
+                                }
+                                changesLines.push('');
+                            }
+                            if (summary.osdRemappings.length > 0) {
+                                changesLines.push(i18n.getMessage('migrationPreviewOsdRemappingsHeader', [summary.osdRemappings.length.toString()]));
+                                for (var i = 0; i < summary.osdRemappings.length; i++) {
+                                    changesLines.push('  • ' + summary.osdRemappings[i]);
+                                }
+                            }
+                            $changes.text(changesLines.join('\n'));
+
+                            // Build warnings text
+                            if (summary.warnings.length > 0) {
+                                var warnLines = [];
+                                for (var i = 0; i < summary.warnings.length; i++) {
+                                    warnLines.push('⚠ ' + summary.warnings[i]);
+                                }
+                                $warnings.text(warnLines.join('\n'));
+                            } else {
+                                $warnings.text('');
+                            }
+
+                            $preview.removeClass('is-hidden');
+                            i18n.localize($preview);
+
+                            function cleanup() {
+                                $continueBtn.off('click.migPreview');
+                                $cancelBtn.off('click.migPreview');
+                                $preview.addClass('is-hidden');
+                            }
+
+                            $cancelBtn.on('click.migPreview', function(e) {
+                                e.preventDefault();
+                                cleanup();
+                                onCancel();
+                            });
+
+                            $continueBtn.on('click.migPreview', function(e) {
+                                e.preventDefault();
+                                cleanup();
+                                onContinue();
+                            });
+                        }
+
+                        // Start port polling and auto-restore with given data
+                        function startPortPollingAndRestore(restoreData) {
+                            var restorePort = originalPort;
+                            var restoreBaud = originalBaud;
+
+                            var $overlay = $('#restore-overlay');
+                            var $overlayStatus = $overlay.find('.restore-overlay__status');
+                            var $overlayFill = $overlay.find('.restore-overlay__progress-fill');
+                            var $overlayText = $overlay.find('.restore-overlay__progress-text');
+                            $overlayFill.css('width', '0%');
+                            $overlayText.text('');
+                            $overlayStatus.text(i18n.getMessage('backupRestoreAutoRestoreWaitingPort', [restorePort]));
+                            $overlay.removeClass('is-hidden');
+
+                            var portPollRetries = 0;
+                            var maxPortPollRetries = 60; // 30 seconds max
+                            var portPollInterval = setInterval(function() {
+                                portPollRetries++;
+                                if (portPollRetries > maxPortPollRetries) {
+                                    clearInterval(portPollInterval);
+                                    $overlay.addClass('is-hidden');
+                                    GUI.connect_lock = false;
+                                    GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
+                                    $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
+                                    BackupRestore.clearLastAutoBackup();
+                                    return;
+                                }
+
+                                ConnectionSerial.getDevices().then(function(devices) {
+                                    if (devices && devices.includes(restorePort)) {
+                                        clearInterval(portPollInterval);
+                                        $overlayStatus.text(i18n.getMessage('backupRestoreStatusConnecting'));
+                                        setTimeout(function() {
+                                            doAutoRestore(restorePort, restoreBaud, restoreData, $overlay, $overlayStatus, $overlayFill, $overlayText);
+                                        }, 2000);
+                                    }
+                                });
+                            }, 500);
+                        }
+
+                        // Extracted restore logic — restoreData is already migrated if needed
+                        function doAutoRestore(restorePort, restoreBaud, restoreData, $overlay, $overlayStatus, $overlayFill, $overlayText) {
                             GUI.connect_lock = true;
 
                             CONFIGURATOR.connection.connect(restorePort, {bitrate: restoreBaud}, function(openInfo) {
@@ -736,7 +906,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                                     }
                                 }
 
-                                BackupRestore.performRestore(backup.data, onProgress).then(function(result) {
+                                BackupRestore.performRestore(restoreData, onProgress).then(function(result) {
                                     $overlay.addClass('is-hidden');
 
                                     if (result.errors.length > 0) {
@@ -760,7 +930,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                                             BackupRestore.saveAndReboot().then(function() {
                                                 GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
                                                 $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
-                                                CONFIGURATOR.connection.disconnect(function() {
+                                                disconnectSafely(function() {
                                                     GUI.connect_lock = false;
                                                 });
                                             });
@@ -772,7 +942,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                                             BackupRestore.abortRestore().then(function() {
                                                 GUI.log(i18n.getMessage('backupRestoreRestoreAborted'));
                                                 $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreAborted'));
-                                                CONFIGURATOR.connection.disconnect(function() {
+                                                disconnectSafely(function() {
                                                     GUI.connect_lock = false;
                                                 });
                                             });
@@ -781,7 +951,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                                         BackupRestore.saveAndReboot().then(function() {
                                             GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
                                             $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
-                                            CONFIGURATOR.connection.disconnect(function() {
+                                            disconnectSafely(function() {
                                                 GUI.connect_lock = false;
                                             });
                                         });
@@ -793,7 +963,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                                     GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
                                     $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
                                     BackupRestore.clearLastAutoBackup();
-                                    CONFIGURATOR.connection.disconnect(function() {
+                                    disconnectSafely(function() {
                                         GUI.connect_lock = false;
                                     });
                                 });
@@ -887,14 +1057,14 @@ TABS.firmware_flasher.initialize = function (callback) {
                         $('span.progressLabel').text(i18n.getMessage('backupRestoreBackupCancelled'));
                     }
                     // FC reboots after CLI exit, disconnect and unlock
-                    CONFIGURATOR.connection.disconnect(function() {
+                    disconnectSafely(function() {
                         GUI.connect_lock = false;
                     });
                 }).catch(function(err) {
                     console.error('Backup failed:', err);
                     GUI.log(i18n.getMessage('backupRestoreBackupFailed'));
                     $('span.progressLabel').text(i18n.getMessage('backupRestoreBackupFailed'));
-                    CONFIGURATOR.connection.disconnect(function() {
+                    disconnectSafely(function() {
                         GUI.connect_lock = false;
                     });
                 });
@@ -934,6 +1104,40 @@ TABS.firmware_flasher.initialize = function (callback) {
                 return;
             }
 
+            var fileData = fileResponse.data;
+            var currentFcVersion = FC.CONFIG.flightControllerVersion;
+
+            // Run migration before connecting (text-only, no FC needed)
+            var migrationNeeded = currentFcVersion && MigrationHandler.isMigrationNeeded(fileData, currentFcVersion);
+            var migrationResult = null;
+
+            if (migrationNeeded) {
+                migrationResult = MigrationHandler.migrateBackupData(fileData, currentFcVersion);
+                fileData = migrationResult.migratedContent;
+            }
+
+            // If migration has changes, show preview overlay and wait for user decision
+            if (migrationResult && migrationResult.summary.totalChanges > 0) {
+                await new Promise(function(resolve) {
+                    showManualMigrationPreview(migrationResult.summary, function onContinue() {
+                        GUI.log(i18n.getMessage('backupRestoreMigrationApplied', [
+                            migrationResult.summary.fromVersion,
+                            migrationResult.summary.toVersion,
+                            migrationResult.summary.totalChanges.toString()
+                        ]));
+                        resolve(true);
+                    }, function onCancel() {
+                        fileData = null; // signal cancellation
+                        resolve(false);
+                    });
+                });
+
+                if (!fileData) {
+                    $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreCancelled'));
+                    return;
+                }
+            }
+
             // Show overlay and lock UI
             var $overlay = $('#restore-overlay');
             var $overlayStatus = $overlay.find('.restore-overlay__status');
@@ -948,6 +1152,86 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             var rebootBaud = parseInt($('div#port-picker #baud').val());
             GUI.connect_lock = true;
+
+            // Show migration preview for manual restore
+            function showManualMigrationPreview(summary, onContinue, onCancel) {
+                var $preview = $('#migration-preview-overlay');
+                var $subtitle = $preview.find('.migration-preview__subtitle');
+                var $changes = $preview.find('.migration-preview__changes');
+                var $warnings = $preview.find('.migration-preview__warnings');
+                var $continueBtn = $preview.find('.migration-preview__btn--continue');
+                var $cancelBtn = $preview.find('.migration-preview__btn--cancel');
+
+                $subtitle.text(i18n.getMessage('migrationPreviewSubtitle', [summary.fromVersion, summary.toVersion]));
+
+                var changesLines = [];
+                if (summary.removedSettings.length > 0) {
+                    changesLines.push(i18n.getMessage('migrationPreviewRemovedHeader', [summary.removedSettings.length.toString()]));
+                    for (var ci = 0; ci < summary.removedSettings.length; ci++) {
+                        changesLines.push('  • ' + summary.removedSettings[ci]);
+                    }
+                    changesLines.push('');
+                }
+                if (summary.renamedSettings.length > 0) {
+                    changesLines.push(i18n.getMessage('migrationPreviewRenamedSettingsHeader', [summary.renamedSettings.length.toString()]));
+                    for (var ci = 0; ci < summary.renamedSettings.length; ci++) {
+                        changesLines.push('  • ' + summary.renamedSettings[ci]);
+                    }
+                    changesLines.push('');
+                }
+                if (summary.renamedCommands.length > 0) {
+                    changesLines.push(i18n.getMessage('migrationPreviewRenamedCommandsHeader', [summary.renamedCommands.length.toString()]));
+                    for (var ci = 0; ci < summary.renamedCommands.length; ci++) {
+                        changesLines.push('  • ' + summary.renamedCommands[ci]);
+                    }
+                    changesLines.push('');
+                }
+                if (summary.valueReplacements.length > 0) {
+                    changesLines.push(i18n.getMessage('migrationPreviewValueReplacementsHeader', [summary.valueReplacements.length.toString()]));
+                    for (var ci = 0; ci < summary.valueReplacements.length; ci++) {
+                        changesLines.push('  • ' + summary.valueReplacements[ci]);
+                    }
+                    changesLines.push('');
+                }
+                if (summary.osdRemappings.length > 0) {
+                    changesLines.push(i18n.getMessage('migrationPreviewOsdRemappingsHeader', [summary.osdRemappings.length.toString()]));
+                    for (var ci = 0; ci < summary.osdRemappings.length; ci++) {
+                        changesLines.push('  • ' + summary.osdRemappings[ci]);
+                    }
+                }
+                $changes.text(changesLines.join('\n'));
+
+                if (summary.warnings.length > 0) {
+                    var warnLines = [];
+                    for (var wi = 0; wi < summary.warnings.length; wi++) {
+                        warnLines.push('⚠ ' + summary.warnings[wi]);
+                    }
+                    $warnings.text(warnLines.join('\n'));
+                } else {
+                    $warnings.text('');
+                }
+
+                $preview.removeClass('is-hidden');
+                i18n.localize($preview);
+
+                function cleanup() {
+                    $continueBtn.off('click.migPreview');
+                    $cancelBtn.off('click.migPreview');
+                    $preview.addClass('is-hidden');
+                }
+
+                $cancelBtn.on('click.migPreview', function(e) {
+                    e.preventDefault();
+                    cleanup();
+                    onCancel();
+                });
+
+                $continueBtn.on('click.migPreview', function(e) {
+                    e.preventDefault();
+                    cleanup();
+                    onContinue();
+                });
+            }
 
             CONFIGURATOR.connection.connect(port, {bitrate: rebootBaud}, function(openInfo) {
                 if (!openInfo) {
@@ -979,7 +1263,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                     }
                 }
 
-                BackupRestore.performRestore(fileResponse.data, onProgress).then(function(result) {
+                BackupRestore.performRestore(fileData, onProgress).then(function(result) {
                     $overlay.addClass('is-hidden');
 
                     if (result.errors.length > 0) {
@@ -1006,7 +1290,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                             BackupRestore.saveAndReboot().then(function() {
                                 GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
                                 $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
-                                CONFIGURATOR.connection.disconnect(function() {
+                                disconnectSafely(function() {
                                     GUI.connect_lock = false;
                                 });
                             });
@@ -1018,7 +1302,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                             $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreAborted'));
                             BackupRestore.abortRestore().then(function() {
                                 GUI.log(i18n.getMessage('backupRestoreRestoreAborted'));
-                                CONFIGURATOR.connection.disconnect(function() {
+                                disconnectSafely(function() {
                                     GUI.connect_lock = false;
                                 });
                             });
@@ -1029,7 +1313,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         BackupRestore.saveAndReboot().then(function() {
                             GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
                             $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
-                            CONFIGURATOR.connection.disconnect(function() {
+                            disconnectSafely(function() {
                                 GUI.connect_lock = false;
                             });
                         });
@@ -1039,7 +1323,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                     console.error('Restore failed:', err);
                     GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
                     $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
-                    CONFIGURATOR.connection.disconnect(function() {
+                    disconnectSafely(function() {
                         GUI.connect_lock = false;
                     });
                 });

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -569,6 +569,85 @@ TABS.firmware_flasher.initialize = function (callback) {
             }
         });
 
+        // --- Shared helpers for migration preview (used by flash + manual restore) ---
+
+        // Show progress label with a link to open the backups folder
+        function showBackupSavedMessage(messageKey) {
+            $('span.progressLabel').html(
+                i18n.getMessage(messageKey) +
+                ' <a class="open_backup_dir" href="#">' +
+                i18n.getMessage('backupRestoreOpenBackupsFolder') + '</a>'
+            );
+            $('.open_backup_dir').on('click', function(e) {
+                e.preventDefault();
+                window.electronAPI.openBackupDir();
+            });
+        }
+
+        // Build migration changes text for preview overlay
+        function buildMigrationChangesText(summary) {
+            var sections = [
+                { key: 'removedSettings', header: 'migrationPreviewRemovedHeader' },
+                { key: 'renamedSettings', header: 'migrationPreviewRenamedSettingsHeader' },
+                { key: 'renamedCommands', header: 'migrationPreviewRenamedCommandsHeader' },
+                { key: 'valueReplacements', header: 'migrationPreviewValueReplacementsHeader' },
+                { key: 'settingRemappings', header: 'migrationPreviewSettingRemappingsHeader' },
+            ];
+            var lines = [];
+            for (var s = 0; s < sections.length; s++) {
+                var items = summary[sections[s].key];
+                if (items && items.length > 0) {
+                    if (lines.length > 0) lines.push('');
+                    lines.push(i18n.getMessage(sections[s].header, [items.length.toString()]));
+                    for (var j = 0; j < items.length; j++) {
+                        lines.push('  • ' + items[j]);
+                    }
+                }
+            }
+            return lines.join('\n');
+        }
+
+        // Show migration preview overlay with changes and warnings
+        function showMigrationPreview(summary, onContinue, onCancel) {
+            var $preview = $('#migration-preview-overlay');
+            var $changes = $preview.find('.migration-preview__changes');
+            var $warnings = $preview.find('.migration-preview__warnings');
+            var $continueBtn = $preview.find('.migration-preview__btn--continue');
+            var $cancelBtn = $preview.find('.migration-preview__btn--cancel');
+
+            $preview.find('.migration-preview__subtitle').text(
+                i18n.getMessage('migrationPreviewSubtitle', [summary.fromVersion, summary.toVersion])
+            );
+            $changes.text(buildMigrationChangesText(summary));
+
+            if (summary.warnings.length > 0) {
+                $warnings.text(summary.warnings.map(function(w) { return '⚠ ' + w; }).join('\n'));
+            } else {
+                $warnings.text('');
+            }
+
+            $preview.removeClass('is-hidden');
+            i18n.localize($preview);
+
+            function cleanup() {
+                $continueBtn.off('click.migPreview');
+                $cancelBtn.off('click.migPreview');
+                $preview.addClass('is-hidden');
+            }
+
+            $cancelBtn.on('click.migPreview', function(e) {
+                e.preventDefault();
+                cleanup();
+                onCancel();
+            });
+
+            $continueBtn.on('click.migPreview', function(e) {
+                e.preventDefault();
+                cleanup();
+                onContinue();
+            });
+        }
+
         $('a.flash_firmware').on('click', function () {
             if (!$(this).hasClass('disabled')) {
                 if (!GUI.connect_lock) { // button disabled while flashing is in progress
@@ -667,15 +746,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                                 if (isMajorDowngrade) {
                                     // Major downgrade — inform user, no auto-restore
                                     GUI.log(i18n.getMessage('backupRestoreDowngradeNoAutoRestore'));
-                                    $('span.progressLabel').html(
-                                        i18n.getMessage('backupRestoreDowngradeNoAutoRestore') +
-                                        ' <a class="open_backup_dir" href="#">' +
-                                        i18n.getMessage('backupRestoreOpenBackupsFolder') + '</a>'
-                                    );
-                                    $('.open_backup_dir').on('click', function(e) {
-                                        e.preventDefault();
-                                        window.electronAPI.openBackupDir();
-                                    });
+                                    showBackupSavedMessage('backupRestoreDowngradeNoAutoRestore');
                                     BackupRestore.clearLastAutoBackup();
                                 } else if (options.erase_chip && !skipAutoRestore) {
                                     // Full chip erase — offer auto-restore
@@ -695,21 +766,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                                     if (missingProfiles) {
                                         if (!migrationResult) {
                                             var backupVer = MigrationHandler.extractBackupVersion(backup.data) || 'unknown';
-                                            migrationResult = {
-                                                migratedContent: dataToRestore,
-                                                summary: {
-                                                    fromVersion: backupVer,
-                                                    toVersion: targetVersion,
-                                                    profilesApplied: [],
-                                                    totalChanges: 0,
-                                                    removedSettings: [],
-                                                    renamedSettings: [],
-                                                    renamedCommands: [],
-                                                    valueReplacements: [],
-                                                    settingRemappings: [],
-                                                    warnings: [],
-                                                },
-                                            };
+                                            migrationResult = MigrationHandler.createEmptyResult(backupVer, targetVersion, dataToRestore);
                                         }
                                         migrationResult.summary.warnings.push(
                                             i18n.getMessage('migrationMissingProfileWarning', [
@@ -731,15 +788,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                                             startPortPollingAndRestore(dataToRestore);
                                         }, function onCancel() {
                                             BackupRestore.clearLastAutoBackup();
-                                            $('span.progressLabel').html(
-                                                i18n.getMessage('backupRestoreFlashCompleteBackupSaved') +
-                                                ' <a class="open_backup_dir" href="#">' +
-                                                i18n.getMessage('backupRestoreOpenBackupsFolder') + '</a>'
-                                            );
-                                            $('.open_backup_dir').on('click', function(e) {
-                                                e.preventDefault();
-                                                window.electronAPI.openBackupDir();
-                                            });
+                                            showBackupSavedMessage('backupRestoreFlashCompleteBackupSaved');
                                         });
                                     } else {
                                         // No migration needed — show simple confirm overlay
@@ -773,101 +822,10 @@ TABS.firmware_flasher.initialize = function (callback) {
                                     }
                                 } else {
                                     // No full chip erase — just show backup info
-                                    $('span.progressLabel').html(
-                                        i18n.getMessage('backupRestoreFlashCompleteBackupSaved') +
-                                        ' <a class="open_backup_dir" href="#">' +
-                                        i18n.getMessage('backupRestoreOpenBackupsFolder') + '</a>'
-                                    );
-                                    $('.open_backup_dir').on('click', function(e) {
-                                        e.preventDefault();
-                                        window.electronAPI.openBackupDir();
-                                    });
+                                    showBackupSavedMessage('backupRestoreFlashCompleteBackupSaved');
                                     BackupRestore.clearLastAutoBackup();
                                 }
                             }
-                        }
-
-                        // Show migration preview overlay with changes and warnings
-                        function showMigrationPreview(summary, onContinue, onCancel) {
-                            var $preview = $('#migration-preview-overlay');
-                            var $subtitle = $preview.find('.migration-preview__subtitle');
-                            var $changes = $preview.find('.migration-preview__changes');
-                            var $warnings = $preview.find('.migration-preview__warnings');
-                            var $continueBtn = $preview.find('.migration-preview__btn--continue');
-                            var $cancelBtn = $preview.find('.migration-preview__btn--cancel');
-
-                            // Populate subtitle
-                            $subtitle.text(i18n.getMessage('migrationPreviewSubtitle', [summary.fromVersion, summary.toVersion]));
-
-                            // Build changes text
-                            var changesLines = [];
-                            if (summary.removedSettings.length > 0) {
-                                changesLines.push(i18n.getMessage('migrationPreviewRemovedHeader', [summary.removedSettings.length.toString()]));
-                                for (var i = 0; i < summary.removedSettings.length; i++) {
-                                    changesLines.push('  • ' + summary.removedSettings[i]);
-                                }
-                                changesLines.push('');
-                            }
-                            if (summary.renamedSettings.length > 0) {
-                                changesLines.push(i18n.getMessage('migrationPreviewRenamedSettingsHeader', [summary.renamedSettings.length.toString()]));
-                                for (var i = 0; i < summary.renamedSettings.length; i++) {
-                                    changesLines.push('  • ' + summary.renamedSettings[i]);
-                                }
-                                changesLines.push('');
-                            }
-                            if (summary.renamedCommands.length > 0) {
-                                changesLines.push(i18n.getMessage('migrationPreviewRenamedCommandsHeader', [summary.renamedCommands.length.toString()]));
-                                for (var i = 0; i < summary.renamedCommands.length; i++) {
-                                    changesLines.push('  • ' + summary.renamedCommands[i]);
-                                }
-                                changesLines.push('');
-                            }
-                            if (summary.valueReplacements.length > 0) {
-                                changesLines.push(i18n.getMessage('migrationPreviewValueReplacementsHeader', [summary.valueReplacements.length.toString()]));
-                                for (var i = 0; i < summary.valueReplacements.length; i++) {
-                                    changesLines.push('  • ' + summary.valueReplacements[i]);
-                                }
-                                changesLines.push('');
-                            }
-                            if (summary.settingRemappings.length > 0) {
-                                changesLines.push(i18n.getMessage('migrationPreviewSettingRemappingsHeader', [summary.settingRemappings.length.toString()]));
-                                for (var i = 0; i < summary.settingRemappings.length; i++) {
-                                    changesLines.push('  • ' + summary.settingRemappings[i]);
-                                }
-                            }
-                            $changes.text(changesLines.join('\n'));
-
-                            // Build warnings text
-                            if (summary.warnings.length > 0) {
-                                var warnLines = [];
-                                for (var i = 0; i < summary.warnings.length; i++) {
-                                    warnLines.push('⚠ ' + summary.warnings[i]);
-                                }
-                                $warnings.text(warnLines.join('\n'));
-                            } else {
-                                $warnings.text('');
-                            }
-
-                            $preview.removeClass('is-hidden');
-                            i18n.localize($preview);
-
-                            function cleanup() {
-                                $continueBtn.off('click.migPreview');
-                                $cancelBtn.off('click.migPreview');
-                                $preview.addClass('is-hidden');
-                            }
-
-                            $cancelBtn.on('click.migPreview', function(e) {
-                                e.preventDefault();
-                                cleanup();
-                                onCancel();
-                            });
-
-                            $continueBtn.on('click.migPreview', function(e) {
-                                e.preventDefault();
-                                cleanup();
-                                onContinue();
-                            });
                         }
 
                         // Start port polling and auto-restore with given data
@@ -1150,21 +1108,7 @@ TABS.firmware_flasher.initialize = function (callback) {
             if (missingProfiles) {
                 if (!migrationResult) {
                     var backupVer = MigrationHandler.extractBackupVersion(fileResponse.data) || 'unknown';
-                    migrationResult = {
-                        migratedContent: fileData,
-                        summary: {
-                            fromVersion: backupVer,
-                            toVersion: currentFcVersion,
-                            profilesApplied: [],
-                            totalChanges: 0,
-                            removedSettings: [],
-                            renamedSettings: [],
-                            renamedCommands: [],
-                            valueReplacements: [],
-                            settingRemappings: [],
-                            warnings: [],
-                        },
-                    };
+                    migrationResult = MigrationHandler.createEmptyResult(backupVer, currentFcVersion, fileData);
                 }
                 migrationResult.summary.warnings.push(
                     i18n.getMessage('migrationMissingProfileWarning', [
@@ -1177,7 +1121,7 @@ TABS.firmware_flasher.initialize = function (callback) {
             // If migration has changes or warnings, show preview overlay and wait for user decision
             if (migrationResult && (migrationResult.summary.totalChanges > 0 || migrationResult.summary.warnings.length > 0)) {
                 await new Promise(function(resolve) {
-                    showManualMigrationPreview(migrationResult.summary, function onContinue() {
+                    showMigrationPreview(migrationResult.summary, function onContinue() {
                         GUI.log(i18n.getMessage('backupRestoreMigrationApplied', [
                             migrationResult.summary.fromVersion,
                             migrationResult.summary.toVersion,
@@ -1210,86 +1154,6 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             var rebootBaud = parseInt($('div#port-picker #baud').val());
             GUI.connect_lock = true;
-
-            // Show migration preview for manual restore
-            function showManualMigrationPreview(summary, onContinue, onCancel) {
-                var $preview = $('#migration-preview-overlay');
-                var $subtitle = $preview.find('.migration-preview__subtitle');
-                var $changes = $preview.find('.migration-preview__changes');
-                var $warnings = $preview.find('.migration-preview__warnings');
-                var $continueBtn = $preview.find('.migration-preview__btn--continue');
-                var $cancelBtn = $preview.find('.migration-preview__btn--cancel');
-
-                $subtitle.text(i18n.getMessage('migrationPreviewSubtitle', [summary.fromVersion, summary.toVersion]));
-
-                var changesLines = [];
-                if (summary.removedSettings.length > 0) {
-                    changesLines.push(i18n.getMessage('migrationPreviewRemovedHeader', [summary.removedSettings.length.toString()]));
-                    for (var ci = 0; ci < summary.removedSettings.length; ci++) {
-                        changesLines.push('  • ' + summary.removedSettings[ci]);
-                    }
-                    changesLines.push('');
-                }
-                if (summary.renamedSettings.length > 0) {
-                    changesLines.push(i18n.getMessage('migrationPreviewRenamedSettingsHeader', [summary.renamedSettings.length.toString()]));
-                    for (var ci = 0; ci < summary.renamedSettings.length; ci++) {
-                        changesLines.push('  • ' + summary.renamedSettings[ci]);
-                    }
-                    changesLines.push('');
-                }
-                if (summary.renamedCommands.length > 0) {
-                    changesLines.push(i18n.getMessage('migrationPreviewRenamedCommandsHeader', [summary.renamedCommands.length.toString()]));
-                    for (var ci = 0; ci < summary.renamedCommands.length; ci++) {
-                        changesLines.push('  • ' + summary.renamedCommands[ci]);
-                    }
-                    changesLines.push('');
-                }
-                if (summary.valueReplacements.length > 0) {
-                    changesLines.push(i18n.getMessage('migrationPreviewValueReplacementsHeader', [summary.valueReplacements.length.toString()]));
-                    for (var ci = 0; ci < summary.valueReplacements.length; ci++) {
-                        changesLines.push('  • ' + summary.valueReplacements[ci]);
-                    }
-                    changesLines.push('');
-                }
-                if (summary.settingRemappings.length > 0) {
-                    changesLines.push(i18n.getMessage('migrationPreviewSettingRemappingsHeader', [summary.settingRemappings.length.toString()]));
-                    for (var ci = 0; ci < summary.settingRemappings.length; ci++) {
-                        changesLines.push('  • ' + summary.settingRemappings[ci]);
-                    }
-                }
-                $changes.text(changesLines.join('\n'));
-
-                if (summary.warnings.length > 0) {
-                    var warnLines = [];
-                    for (var wi = 0; wi < summary.warnings.length; wi++) {
-                        warnLines.push('⚠ ' + summary.warnings[wi]);
-                    }
-                    $warnings.text(warnLines.join('\n'));
-                } else {
-                    $warnings.text('');
-                }
-
-                $preview.removeClass('is-hidden');
-                i18n.localize($preview);
-
-                function cleanup() {
-                    $continueBtn.off('click.migPreview');
-                    $cancelBtn.off('click.migPreview');
-                    $preview.addClass('is-hidden');
-                }
-
-                $cancelBtn.on('click.migPreview', function(e) {
-                    e.preventDefault();
-                    cleanup();
-                    onCancel();
-                });
-
-                $continueBtn.on('click.migPreview', function(e) {
-                    e.preventDefault();
-                    cleanup();
-                    onContinue();
-                });
-            }
 
             CONFIGURATOR.connection.connect(port, {bitrate: rebootBaud}, function(openInfo) {
                 if (!openInfo) {


### PR DESCRIPTION
### Summary

Adds a complete backup/restore and settings migration system to the firmware flasher tab. The configurator automatically captures the current FC settings before **every** flash (via CLI `diff all`) — regardless of whether chip erase is enabled. When flashing with full chip erase, it offers to restore them after the FC reboots, including automatic migration of settings when crossing major INAV versions. The last 10 auto-backups are retained; older ones are pruned automatically.

### Changes

| File | Lines | Purpose |
|------|-------|---------|
| backup_restore.js | +665 | Core backup/restore module (CLI protocol) |
| migration_handler.js | +362 | Settings migration engine |
| 7_to_8.json | +49 | INAV 7→8 migration profile |
| 8_to_9.json | +25 | INAV 8→9 migration profile |
| firmware_flasher.js | +752 | Flash tab integration |
| firmware_flasher.html | +72 | Overlay HTML (5 overlays) |
| firmware_flasher.css | +443 | Overlay styling |
| messages.json | +147 | i18n keys |
| stm32.js | +48 | `onCliReady` hook for auto-backup |
| main.js | +30 | IPC handlers (backup dir, file ops) |
| preload.js | +3 | electronAPI bridge |
| forge.config.js | +7 | `rebuildConfig` for native modules |

### Architecture

#### Data Flow

```
Flash initiated (any mode)
  → Auto-backup: enter CLI → "diff all" → save to %APPDATA%/inav-configurator/backups/
  → Prune auto-backups to keep only the 10 most recent
  → Flash firmware (existing STM32/DFU flow)
  → onFlashComplete():
      → If full chip erase: offer auto-restore
      → If version upgrade: check migration profiles, show preview
      → If major downgrade: block auto-restore (manual only)
      → Poll COM port for FC reboot (DFU → normal mode)
      → Connect → enter CLI → send commands → save → reboot
```

#### Backup/Restore Module (backup_restore.js)

- **`captureCliDiffAll()`** — Sends `diff all` via CLI, captures output line-by-line via `mspHelper.dataHandler`
- **`performBackup()` / `performBackupToFile()`** — Save CLI diff as timestamped `.txt` files with metadata header (`# Version`, `# Board`, `# Date`)
- **`performRestore(data)`** — Parses backup text, sends each CLI command sequentially, tracks progress via callback
- **`performRestoreWithMigration(data, targetVersion)`** — Runs migration engine on backup data before restore, returns migration summary
- **`_saveAutoBackup()` / `_pruneAutoBackups()`** — Auto-backups use `UPDATE_` prefix; pruned to keep only the **10 most recent** (user-renamed files are preserved and not counted)
- **`saveAndReboot()`** — Sends `save` then `exit` to CLI, triggers FC reboot
- **`getVersionChangeType(from, to)`** — Returns `patch|minor|major` using semver
- **`isAutoRestoreSafe(from, to)`** — Blocks auto-restore on major downgrades

**Auto-backup behavior:** A backup is created before **every** flash operation — chip erase or not. This ensures the user always has a recent backup available. Auto-restore is only *offered* when chip erase is used (since non-erase flashes preserve settings on the FC).

#### Migration Engine (migration_handler.js)

- **JSON-based profiles** in migration: each profile declares `fromVersion` → `toVersion` with transformation rules
- **Transformation types**:
  - `commandRenames` — CLI command name changes (e.g. `profile` → `control_profile`)
  - `settingRenames` — Setting key renames (e.g. `mixer_pid_profile_linking` → `mixer_control_profile_linking`)
  - `valueReplacements` — Enum value changes (e.g. `UBLOX7` → `UBLOX`)
  - `removed` — Settings that no longer exist (filtered out)
  - `settingPatternMappings` — Generic regex-based value remapping for numbered/indexed settings (e.g. OSD custom element type IDs renumbered between versions)
  - `warnings` — Manual review notices for semantic changes
- **`buildMigrationChain(from, to)`** — Chains profiles for multi-version jumps (e.g., 7→8→9)
- **`migrateBackupData(text, targetVersion)`** — Applies all chained profiles line-by-line, returns `{migratedText, summary}`
- **`extractBackupVersion(text)`** — Parses `# Version: X.Y.Z` from backup header

#### `settingPatternMappings` (generic pattern-based remapping)

Instead of hardcoding specific setting patterns in the migration handler, profiles define an array of `{pattern, valueMap, description}` objects. The handler iterates over them and applies the first matching regex pattern. This keeps the engine fully generic — new mappings only require JSON changes, no code changes.

Example from 7_to_8.json:
```json
"settingPatternMappings": [
    {
        "pattern": "^osd_custom_element_\\d+_type$",
        "valueMap": { "4": "9", "5": "16", "6": "7", "7": "10" },
        "description": "OSD custom element type IDs were renumbered"
    }
]
```

#### Flash Tab Integration (firmware_flasher.js)

- **`onFlashComplete()`** — Reworked: version change detection → downgrade block → migration preview → COM port polling → restore
- **`showMigrationPreview(summary, migratedData)`** — Overlay listing all renamed/removed/replaced/warned settings before restore
- **`showManualMigrationPreview(summary, migratedData)`** — Same for manual file restore
- **`startPortPollingAndRestore(data)`** — Extracted: polls `SerialPort.list()` for port reappearance after FC reboot
- **`disconnectSafely(callback)`** — Global function: wraps `disconnect()` with 3s timeout fallback for cases where FC reboots and serial port vanishes before disconnect callback fires (prevents `connect_lock` deadlock)

#### IPC Layer

- **Main process** (main.js): `get-backup-dir`, `list-backups`, `read-backup`, `save-backup`, `delete-backup` handlers
- **Preload** (preload.js): Exposes via `electronAPI`
- **Backup dir**: `app.getPath('userData')/backups/`

#### STM32 Protocol Hook

- **stm32.js**: Added `onCliReady` callback parameter — when provided, enters CLI mode after connect and calls back instead of proceeding to flash. Used by auto-backup to capture `diff all` before the actual flash begins.

### UI Overlays (all in firmware flasher tab)

1. **Restore Confirm Overlay** — "Restore settings from auto-backup?" (after chip-erase flash)
2. **Version Warning Overlay** — Minor/major update warning (chip erase recommended)
3. **Migration Preview Overlay** — Lists all setting changes before restore (renamed, removed, value replacements, pattern remappings, warnings)
4. **Restore Progress Overlay** — Progress bar during CLI command replay
5. **Restore Error Dialog** — Shows failed commands and error details
6. **Missing Migration Profile** — Shows warning if no migration profile is present (flashing INAV 10 with Configurator 9)

### Adding New Migration Profiles

1. Create `js/migration/X_to_Y.json` following the existing schema
2. Import and register in migration_handler.js → `MIGRATION_PROFILES` array
3. The engine auto-chains profiles (e.g., 7→8 + 8→9 for a 7→9 upgrade)

**JSON schema:**
```json
{
  "fromVersion": "8",
  "toVersion": "9",
  "description": "INAV 8.0 → 9.0 migration",
  "commandRenames": { "old_command": "new_command" },
  "settingRenames": { "old_setting": "new_setting" },
  "valueReplacements": { "setting_name": { "OLD_VAL": "NEW_VAL" } },
  "removed": ["removed_setting_1", "removed_setting_2"],
  "settingPatternMappings": [
    {
      "pattern": "^some_indexed_setting_\\d+_type$",
      "valueMap": { "4": "9", "5": "16" },
      "description": "Type IDs were renumbered"
    }
  ],
  "warnings": [
    "some_setting default changed from X to Y — review manually."
  ]
}
```

### Known Limitations

- **Downgrade restore**: Major version downgrades block auto-restore because old firmware may not accept settings from a newer version. Manual restore still possible via file picker.
- **FC reboot race**: After `save`+`exit`, the FC reboots and the serial port vanishes. `disconnectSafely()` handles this with a 3s timeout fallback, but the underlying cause is that the disconnect callback never fires when the port disappears.
- **CLI protocol**: Restore sends commands one-by-one and waits for echo. Large backups may take 10-20 seconds.

### Testing

- Tested with INAV 7.1 → 8.0 upgrade (migration applied)
- Tested with INAV 7.1 → 9.0 upgrade (migration applied)
- Tested with INAV 8.0 → 9.0 upgrade (migration applied)
- Tested migration for manual restore of 8.0 diff to 9.0 diff
- Tested manual backup/restore without version change
- Tested chip-erase flash with auto-backup + auto-restore
- Tested non-erase flash (backup created, no restore offered)
- Tested disconnect robustness (no more hang after save)
- Build verified: `yarn start` runs without errors