### PR TITLE
GPS: fix hwVersion MSP read from uint32 to uint8

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -278,7 +278,8 @@ var FC = {
             messageDt: 0,
             errors: 0,
             timeouts: 0,
-            packetCount: 0
+            packetCount: 0,
+            hwVersion: 0
         };
         
         this.ADSB_VEHICLES = {

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -198,8 +198,6 @@ var mspHelper = (function () {
                 FC.GPS_DATA.hdop = data.getUint16(14, true);
                 FC.GPS_DATA.eph = data.getUint16(16, true);
                 FC.GPS_DATA.epv = data.getUint16(18, true);
-                // hwVersion: 1-byte field (bits [7:6]=series, bits [5:0]=generation)
-                // Added in maintenance-9.x; absent in older firmware (payload < 21 bytes)
                 if (data.byteLength >= 21) {
                     FC.GPS_DATA.hwVersion = data.getUint8(20);
                 } else {

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -198,11 +198,12 @@ var mspHelper = (function () {
                 FC.GPS_DATA.hdop = data.getUint16(14, true);
                 FC.GPS_DATA.eph = data.getUint16(16, true);
                 FC.GPS_DATA.epv = data.getUint16(18, true);
-                // Check if hwVersion field exists (firmware with extended MSP_GPSSTATISTICS)
-                if (data.byteLength >= 24) {
-                    FC.GPS_DATA.hwVersion = data.getUint32(20, true);
+                // hwVersion: 1-byte field (bits [7:6]=series, bits [5:0]=generation)
+                // Added in maintenance-9.x; absent in older firmware (payload < 21 bytes)
+                if (data.byteLength >= 21) {
+                    FC.GPS_DATA.hwVersion = data.getUint8(20);
                 } else {
-                    FC.GPS_DATA.hwVersion = 0; // Unknown for older firmware
+                    FC.GPS_DATA.hwVersion = 0;
                 }
                 break;
             case MSPCodes.MSP2_ADSB_VEHICLE_LIST:

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -279,9 +279,9 @@ TABS.gps.initialize = function (callback) {
 
         function detectGPSPreset(hwVersion) {
             switch(hwVersion) {
-                case 800:  return 'm8';
-                case 900:  return 'm9-precision';  // Default to precision mode for better accuracy
-                case 1000: return 'm10';
+                case 0x48: return 'm8';
+                case 0x49: return 'm9-precision';
+                case 0x4A: return 'm10';
                 default:   return 'manual';
             }
         }


### PR DESCRIPTION
## Summary

Follow-up to #2526. Updates `MSP_GPSSTATISTICS` handler to match the firmware fix in iNavFlight/inav#11510.

**Changes:**
- `js/msp/MSPHelper.js` — read hwVersion as `getUint8(20)` (was `getUint32(20)`); payload size guard `>= 21` (was `>= 24`)
- `tabs/gps.js` — update `detectGPSPreset()` switch cases to new encoded values: `0x48`=M8, `0x49`=M9, `0x4A`=M10
- `js/fc.js` — add `hwVersion: 0` to `GPS_DATA` initial state

The new encoding uses bits [7:6] for series and bits [5:0] for generation, allowing future expansion to F9 and other manufacturers.

## Test plan

- [x] Tested with M9 receiver — Configurator correctly reads `0x49`, auto-detects M9-precision preset
- [x] Tested with M10 receiver — Configurator correctly reads `0x4A`, auto-detects M10 preset
- [x] Older firmware (pre-#11262, < 21-byte payload) correctly falls back to `hwVersion = 0`
- [x] Companion firmware PR: iNavFlight/inav#11510