### PR TITLE
fix(backup-restore): correctness bugs and refactor in PR #2603 auto-backup/restore

### DIFF
--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -59,6 +59,8 @@ const BackupRestore = {
                     if (timeoutHandle) {
                         clearTimeout(timeoutHandle);
                     }
+                    CONFIGURATOR.connection.removeOnReceiveCallback(this._receiveCallback);
+                    this._receiveCallback = null;
                     resolve();
                 }
             };

--- a/js/main/main.js
+++ b/js/main/main.js
@@ -420,12 +420,12 @@ app.whenReady().then(() => {
     return backupDir;
   });
 
-  ipcMain.handle('openBackupDir', async (_event) => {
+  ipcMain.handle('openBackupDir', (_event) => {
     const backupDir = path.join(app.getPath('userData'), 'inav-backups');
     if (!existsSync(backupDir)) {
       mkdirSync(backupDir, { recursive: true });
     }
-    await shell.openPath(backupDir);
+    shell.openPath(backupDir); // fire-and-forget: xdg-open on Linux never exits
     return backupDir;
   });
 

--- a/js/migration/migration_handler.js
+++ b/js/migration/migration_handler.js
@@ -43,22 +43,22 @@ const MigrationHandler = {
     buildMigrationChain(fromVersion, toVersion) {
         if (!fromVersion || !toVersion) return [];
 
-        const fromMajor = semver.major(fromVersion);
-        const toMajor = semver.major(toVersion);
+        const fromCoerced = semver.coerce(fromVersion);
+        const toCoerced = semver.coerce(toVersion);
+        if (!fromCoerced || !toCoerced) return [];
 
-        if (fromMajor >= toMajor) return [];
+        let currentMajor = semver.major(fromCoerced);
+        const toMajor = semver.major(toCoerced);
+
+        if (currentMajor >= toMajor) return [];
 
         const chain = [];
-        for (const profile of MIGRATION_PROFILES) {
-            const profileFrom = parseInt(profile.fromVersion, 10);
-            const profileTo = parseInt(profile.toVersion, 10);
-
-            if (profileFrom >= fromMajor && profileTo <= toMajor) {
-                chain.push(profile);
-            }
+        while (currentMajor < toMajor) {
+            const profile = MIGRATION_PROFILES.find(p => parseInt(p.fromVersion, 10) === currentMajor);
+            if (!profile) break;
+            chain.push(profile);
+            currentMajor = parseInt(profile.toVersion, 10);
         }
-
-        chain.sort((a, b) => parseInt(a.fromVersion, 10) - parseInt(b.fromVersion, 10));
 
         return chain;
     },

--- a/js/migration/migration_handler.js
+++ b/js/migration/migration_handler.js
@@ -284,8 +284,12 @@ const MigrationHandler = {
         const fromVersion = this.extractBackupVersion(fileContent);
         if (!fromVersion || !targetVersion) return false;
 
-        const fromMajor = semver.major(semver.coerce(fromVersion));
-        const toMajor = semver.major(semver.coerce(targetVersion));
+        const fromCoerced = semver.coerce(fromVersion);
+        const toCoerced = semver.coerce(targetVersion);
+        if (!fromCoerced || !toCoerced) return false;
+
+        const fromMajor = semver.major(fromCoerced);
+        const toMajor = semver.major(toCoerced);
 
         if (toMajor <= fromMajor) return false;
 

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -17,7 +17,7 @@ import mspQueue from './../js/serial_queue';
 import mspHelper from './../js/msp/MSPHelper';
 import STM32 from './../js/protocols/stm32';
 import STM32DFU from './../js/protocols/stm32usbdfu';
-import ConnectionSerial from './../js/connection/connectionSerial';
+
 import mspDeduplicationQueue from './../js/msp/mspDeduplicationQueue';
 import store from './../js/store';
 import dialog from '../js/dialog.js';

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -23,6 +23,7 @@ import store from './../js/store';
 import dialog from '../js/dialog.js';
 import BackupRestore from './../js/backup_restore';
 import MigrationHandler from './../js/migration/migration_handler';
+import { FlashRestoreFlow, showMigrationPreview, prepareRestoreData, executeRestore } from './firmware_flasher_restore';
 
 TABS.firmware_flasher = {};
 
@@ -572,80 +573,6 @@ TABS.firmware_flasher.initialize = function (callback) {
             }
         });
 
-        function showBackupSavedMessage(messageKey) {
-            $('span.progressLabel').html(
-                i18n.getMessage(messageKey) +
-                ' <a class="open_backup_dir" href="#">' +
-                i18n.getMessage('backupRestoreOpenBackupsFolder') + '</a>'
-            );
-            $('.open_backup_dir').on('click', function(e) {
-                e.preventDefault();
-                window.electronAPI.openBackupDir();
-            });
-        }
-
-        function buildMigrationChangesText(summary) {
-            var sections = [
-                { key: 'removedSettings', header: 'migrationPreviewRemovedHeader' },
-                { key: 'renamedSettings', header: 'migrationPreviewRenamedSettingsHeader' },
-                { key: 'renamedCommands', header: 'migrationPreviewRenamedCommandsHeader' },
-                { key: 'valueReplacements', header: 'migrationPreviewValueReplacementsHeader' },
-                { key: 'settingRemappings', header: 'migrationPreviewSettingRemappingsHeader' },
-            ];
-            var lines = [];
-            for (var s = 0; s < sections.length; s++) {
-                var items = summary[sections[s].key];
-                if (items && items.length > 0) {
-                    if (lines.length > 0) lines.push('');
-                    lines.push(i18n.getMessage(sections[s].header, [items.length.toString()]));
-                    for (var j = 0; j < items.length; j++) {
-                        lines.push('  • ' + items[j]);
-                    }
-                }
-            }
-            return lines.join('\n');
-        }
-
-        function showMigrationPreview(summary, onContinue, onCancel) {
-            var $preview = $('#migration-preview-overlay');
-            var $changes = $preview.find('.migration-preview__changes');
-            var $warnings = $preview.find('.migration-preview__warnings');
-            var $continueBtn = $preview.find('.migration-preview__btn--continue');
-            var $cancelBtn = $preview.find('.migration-preview__btn--cancel');
-
-            $preview.find('.migration-preview__subtitle').text(
-                i18n.getMessage('migrationPreviewSubtitle', [summary.fromVersion, summary.toVersion])
-            );
-            $changes.text(buildMigrationChangesText(summary));
-
-            if (summary.warnings.length > 0) {
-                $warnings.text(summary.warnings.map(function(w) { return '⚠ ' + w; }).join('\n'));
-            } else {
-                $warnings.text('');
-            }
-
-            $preview.removeClass('is-hidden');
-            i18n.localize($preview);
-
-            function cleanup() {
-                $continueBtn.off('click.migPreview');
-                $cancelBtn.off('click.migPreview');
-                $preview.addClass('is-hidden');
-            }
-
-            $cancelBtn.on('click.migPreview', function(e) {
-                e.preventDefault();
-                cleanup();
-                onCancel();
-            });
-
-            $continueBtn.on('click.migPreview', function(e) {
-                e.preventDefault();
-                cleanup();
-                onContinue();
-            });
-        }
-
         $('a.flash_firmware').on('click', function () {
             if (!$(this).hasClass('disabled')) {
                 if (!GUI.connect_lock) { // button disabled while flashing is in progress
@@ -715,227 +642,14 @@ TABS.firmware_flasher.initialize = function (callback) {
                         function proceedWithFlash() {
                         BackupRestore.clearLastAutoBackup();
 
-                        function onFlashComplete() {
-                            if (targetVersion && FC.CONFIG) {
-                                FC.CONFIG.flightControllerVersion = targetVersion;
-                            }
-
-                            var backup = BackupRestore.getLastAutoBackup();
-                            if (backup) {
-                                GUI.log(i18n.getMessage('backupRestoreAutoBackupSaved', [backup.filePath]));
-
-                                var backupVersion = MigrationHandler.extractBackupVersion(backup.data);
-                                var isMajorDowngrade = false;
-                                if (backupVersion && targetVersion && semver.valid(backupVersion) && semver.valid(targetVersion)) {
-                                    if (semver.major(backupVersion) > semver.major(targetVersion)) {
-                                        isMajorDowngrade = true;
-                                    }
-                                }
-
-                                if (!targetVersion) {
-                                    showBackupSavedMessage('backupRestoreFlashCompleteBackupSaved');
-                                    BackupRestore.clearLastAutoBackup();
-                                } else if (isMajorDowngrade) {
-                                    GUI.log(i18n.getMessage('backupRestoreDowngradeNoAutoRestore'));
-                                    showBackupSavedMessage('backupRestoreDowngradeNoAutoRestore');
-                                    BackupRestore.clearLastAutoBackup();
-                                } else if (options.erase_chip && !skipAutoRestore) {
-                                    var migrationNeeded = targetVersion && MigrationHandler.isMigrationNeeded(backup.data, targetVersion);
-                                    var missingProfiles = targetVersion && MigrationHandler.hasMissingProfiles(backup.data, targetVersion);
-                                    var migrationResult = null;
-                                    var dataToRestore = backup.data;
-
-                                    if (migrationNeeded) {
-                                        migrationResult = MigrationHandler.migrateBackupData(backup.data, targetVersion);
-                                        dataToRestore = migrationResult.migratedContent;
-                                    }
-
-                                    if (missingProfiles) {
-                                        if (!migrationResult) {
-                                            var backupVer = MigrationHandler.extractBackupVersion(backup.data) || 'unknown';
-                                            migrationResult = MigrationHandler.createEmptyResult(backupVer, targetVersion, dataToRestore);
-                                        }
-                                        migrationResult.summary.warnings.push(
-                                            i18n.getMessage('migrationMissingProfileWarning', [
-                                                migrationResult.summary.fromVersion,
-                                                migrationResult.summary.toVersion,
-                                            ])
-                                        );
-                                    }
-
-                                    if (migrationResult && (migrationResult.summary.totalChanges > 0 || migrationResult.summary.warnings.length > 0)) {
-                                        showMigrationPreview(migrationResult.summary, function onContinue() {
-                                            GUI.log(i18n.getMessage('backupRestoreMigrationApplied', [
-                                                migrationResult.summary.fromVersion,
-                                                migrationResult.summary.toVersion,
-                                                migrationResult.summary.totalChanges.toString()
-                                            ]));
-                                            startPortPollingAndRestore(dataToRestore);
-                                        }, function onCancel() {
-                                            BackupRestore.clearLastAutoBackup();
-                                            showBackupSavedMessage('backupRestoreFlashCompleteBackupSaved');
-                                        });
-                                    } else {
-                                        $('span.progressLabel').text(i18n.getMessage('backupRestoreFlashCompleteOfferRestore'));
-
-                                        var $confirmOverlay = $('#restore-confirm-overlay');
-                                        $confirmOverlay.removeClass('is-hidden');
-                                        i18n.localize($confirmOverlay);
-
-                                        var $yesBtn = $confirmOverlay.find('.restore-confirm-overlay__btn--yes');
-                                        var $noBtn = $confirmOverlay.find('.restore-confirm-overlay__btn--no');
-
-                                        function confirmCleanup() {
-                                            $yesBtn.off('click.autoRestore');
-                                            $noBtn.off('click.autoRestore');
-                                            $confirmOverlay.addClass('is-hidden');
-                                        }
-
-                                        $noBtn.on('click.autoRestore', function(e) {
-                                            e.preventDefault();
-                                            confirmCleanup();
-                                            BackupRestore.clearLastAutoBackup();
-                                            $('span.progressLabel').text(i18n.getMessage('backupRestoreFlashCompleteBackupSaved'));
-                                        });
-
-                                        $yesBtn.on('click.autoRestore', function(e) {
-                                            e.preventDefault();
-                                            confirmCleanup();
-                                            startPortPollingAndRestore(dataToRestore);
-                                        });
-                                    }
-                                } else {
-                                    showBackupSavedMessage('backupRestoreFlashCompleteBackupSaved');
-                                    BackupRestore.clearLastAutoBackup();
-                                }
-                            }
-                        }
-
-                        function startPortPollingAndRestore(restoreData) {
-                            var restorePort = originalPort;
-                            var restoreBaud = originalBaud;
-
-                            var $overlay = $('#restore-overlay');
-                            var $overlayStatus = $overlay.find('.restore-overlay__status');
-                            var $overlayFill = $overlay.find('.restore-overlay__progress-fill');
-                            var $overlayText = $overlay.find('.restore-overlay__progress-text');
-                            $overlayFill.css('width', '0%');
-                            $overlayText.text('');
-                            $overlayStatus.text(i18n.getMessage('backupRestoreAutoRestoreWaitingPort', [restorePort]));
-                            $overlay.removeClass('is-hidden');
-
-                            var portPollRetries = 0;
-                            var maxPortPollRetries = 60; // 30 seconds max
-                            var portPollInterval = setInterval(function() {
-                                portPollRetries++;
-                                if (portPollRetries > maxPortPollRetries) {
-                                    clearInterval(portPollInterval);
-                                    $overlay.addClass('is-hidden');
-                                    GUI.connect_lock = false;
-                                    GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
-                                    $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
-                                    BackupRestore.clearLastAutoBackup();
-                                    return;
-                                }
-
-                                ConnectionSerial.getDevices().then(function(devices) {
-                                    if (devices && devices.includes(restorePort)) {
-                                        clearInterval(portPollInterval);
-                                        $overlayStatus.text(i18n.getMessage('backupRestoreStatusConnecting'));
-                                        setTimeout(function() {
-                                            doAutoRestore(restorePort, restoreBaud, restoreData, $overlay, $overlayStatus, $overlayFill, $overlayText);
-                                        }, 2000);
-                                    }
-                                });
-                            }, 500);
-                        }
-
-                        function doAutoRestore(restorePort, restoreBaud, restoreData, $overlay, $overlayStatus, $overlayFill, $overlayText) {
-                            GUI.connect_lock = true;
-
-                            CONFIGURATOR.connection.connect(restorePort, {bitrate: restoreBaud}, function(openInfo) {
-                                if (!openInfo) {
-                                    $overlay.addClass('is-hidden');
-                                    GUI.connect_lock = false;
-                                    GUI.log(i18n.getMessage('failedToOpenSerialPort'));
-                                    $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
-                                    BackupRestore.clearLastAutoBackup();
-                                    return;
-                                }
-
-                                function onProgress(info) {
-                                    if (info.phase === 'entering-cli') {
-                                        $overlayStatus.text(i18n.getMessage('backupRestoreStatusEnteringCli'));
-                                    } else if (info.phase === 'restoring') {
-                                        var pct = info.total > 0 ? Math.round((info.current / info.total) * 100) : 0;
-                                        $overlayStatus.text(i18n.getMessage('backupRestoreStatusRestoringProgress', [info.current, info.total]));
-                                        $overlayFill.css('width', pct + '%');
-                                        $overlayText.text(info.current + ' / ' + info.total);
-                                    }
-                                }
-
-                                BackupRestore.performRestore(restoreData, onProgress).then(function(result) {
-                                    $overlay.addClass('is-hidden');
-
-                                    if (result.errors.length > 0) {
-                                        var $errorDlg = $('#restore-error-dialog');
-                                        $errorDlg.find('.restore-error-dialog__errors').text(result.errors.join('\n'));
-                                        $errorDlg.removeClass('is-hidden');
-
-                                        var $saveBtn = $errorDlg.find('.restore-error-dialog__btn--save');
-                                        var $abortBtn = $errorDlg.find('.restore-error-dialog__btn--abort');
-
-                                        function cleanup() {
-                                            $saveBtn.off('click.restoreErr');
-                                            $abortBtn.off('click.restoreErr');
-                                            $errorDlg.addClass('is-hidden');
-                                        }
-
-                                        $saveBtn.on('click.restoreErr', function(e) {
-                                            e.preventDefault();
-                                            cleanup();
-                                            BackupRestore.saveAndReboot().then(function() {
-                                                GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
-                                                $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
-                                                disconnectSafely(function() {
-                                                    GUI.connect_lock = false;
-                                                });
-                                            });
-                                        });
-
-                                        $abortBtn.on('click.restoreErr', function(e) {
-                                            e.preventDefault();
-                                            cleanup();
-                                            BackupRestore.abortRestore().then(function() {
-                                                GUI.log(i18n.getMessage('backupRestoreRestoreAborted'));
-                                                $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreAborted'));
-                                                disconnectSafely(function() {
-                                                    GUI.connect_lock = false;
-                                                });
-                                            });
-                                        });
-                                    } else {
-                                        BackupRestore.saveAndReboot().then(function() {
-                                            GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
-                                            $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
-                                            disconnectSafely(function() {
-                                                GUI.connect_lock = false;
-                                            });
-                                        });
-                                    }
-                                    BackupRestore.clearLastAutoBackup();
-                                }).catch(function(err) {
-                                    $overlay.addClass('is-hidden');
-                                    console.error('Auto-restore failed:', err);
-                                    GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
-                                    $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
-                                    BackupRestore.clearLastAutoBackup();
-                                    disconnectSafely(function() {
-                                        GUI.connect_lock = false;
-                                    });
-                                });
-                            });
-                        }
+                        var restoreFlow = new FlashRestoreFlow({
+                            options,
+                            skipAutoRestore,
+                            originalPort,
+                            originalBaud,
+                            targetVersion,
+                            disconnectSafely,
+                        });
 
                         if (String($('div#port-picker #port').val()) != 'DFU') {
                             if (String($('div#port-picker #port').val()) != '0') {
@@ -971,13 +685,13 @@ TABS.firmware_flasher.initialize = function (callback) {
                                     });
                                 }
 
-                                STM32.connect(port, baud, parsed_hex, options, onFlashComplete);
+                                STM32.connect(port, baud, parsed_hex, options, () => restoreFlow.onFlashComplete());
                             } else {
                                 console.log('Please select valid serial port');
                                 GUI.log(i18n.getMessage('selectValidSerialPort'));
                             }
                         } else {
-                            STM32DFU.connect(usbDevices, parsed_hex, options, onFlashComplete);
+                            STM32DFU.connect(usbDevices, parsed_hex, options, () => restoreFlow.onFlashComplete());
                         }
 
                         } // end proceedWithFlash
@@ -1114,30 +828,10 @@ TABS.firmware_flasher.initialize = function (callback) {
 
                 function proceedAfterVersionQuery() {
                     var currentFcVersion = FC.CONFIG.flightControllerVersion;
+                    var { dataToRestore, migrationResult } = prepareRestoreData(fileData, currentFcVersion);
 
-                    var migrationNeeded = currentFcVersion && MigrationHandler.isMigrationNeeded(fileData, currentFcVersion);
-                    var missingProfiles = currentFcVersion && MigrationHandler.hasMissingProfiles(fileData, currentFcVersion);
-                    var migrationResult = null;
-
-                    if (migrationNeeded) {
-                        migrationResult = MigrationHandler.migrateBackupData(fileData, currentFcVersion);
-                        fileData = migrationResult.migratedContent;
-                    }
-
-                    if (missingProfiles) {
-                        if (!migrationResult) {
-                            var backupVer = MigrationHandler.extractBackupVersion(fileData) || 'unknown';
-                            migrationResult = MigrationHandler.createEmptyResult(backupVer, currentFcVersion, fileData);
-                        }
-                        migrationResult.summary.warnings.push(
-                            i18n.getMessage('migrationMissingProfileWarning', [
-                                migrationResult.summary.fromVersion,
-                                migrationResult.summary.toVersion,
-                            ])
-                        );
-                    }
-
-                    if (migrationResult && (migrationResult.summary.totalChanges > 0 || migrationResult.summary.warnings.length > 0)) {
+                    if (migrationResult && (migrationResult.summary.totalChanges > 0 ||
+                                           migrationResult.summary.warnings.length > 0)) {
                         $overlay.addClass('is-hidden');
                         showMigrationPreview(migrationResult.summary, function onContinue() {
                             GUI.log(i18n.getMessage('backupRestoreMigrationApplied', [
@@ -1146,103 +840,15 @@ TABS.firmware_flasher.initialize = function (callback) {
                                 migrationResult.summary.totalChanges.toString()
                             ]));
                             $overlay.removeClass('is-hidden');
-                            doRestore();
+                            executeRestore(port, rebootBaud, dataToRestore, $overlay, { disconnectSafely });
                         }, function onCancel() {
                             $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreCancelled'));
-                            disconnectSafely(function() {
-                                GUI.connect_lock = false;
-                            });
+                            disconnectSafely(function() { GUI.connect_lock = false; });
                         });
                     } else {
-                        doRestore();
+                        executeRestore(port, rebootBaud, dataToRestore, $overlay, { disconnectSafely });
                     }
                 }
-
-                function doRestore() {
-
-                function onProgress(info) {
-                    switch (info.phase) {
-                        case 'entering-cli':
-                            $overlayStatus.text(i18n.getMessage('backupRestoreStatusEnteringCli'));
-                            $overlayFill.css('width', '0%');
-                            $overlayText.text('');
-                            break;
-                        case 'restoring':
-                            $overlayStatus.text(i18n.getMessage('backupRestoreStatusRestoringProgress', [info.current, info.total]));
-                            var pct = info.total > 0 ? Math.round((info.current / info.total) * 100) : 0;
-                            $overlayFill.css('width', pct + '%');
-                            $overlayText.text(info.current + ' / ' + info.total);
-                            $('span.progressLabel').text(i18n.getMessage('backupRestoreStatusRestoringProgress', [info.current, info.total]));
-                            break;
-                        case 'saving':
-                            $overlayStatus.text(i18n.getMessage('backupRestoreStatusSaving'));
-                            $overlayFill.css('width', '100%');
-                            break;
-                    }
-                }
-
-                BackupRestore.performRestore(fileData, onProgress).then(function(result) {
-                    $overlay.addClass('is-hidden');
-
-                    if (result.errors.length > 0) {
-                        var $errorDlg = $('#restore-error-dialog');
-                        var $errorList = $errorDlg.find('.restore-error-dialog__errors');
-                        $errorList.text(result.errors.join('\n'));
-                        $errorDlg.removeClass('is-hidden');
-
-                        var $saveBtn = $errorDlg.find('.restore-error-dialog__btn--save');
-                        var $abortBtn = $errorDlg.find('.restore-error-dialog__btn--abort');
-
-                        function cleanup() {
-                            $saveBtn.off('click.restoreErr');
-                            $abortBtn.off('click.restoreErr');
-                            $errorDlg.addClass('is-hidden');
-                        }
-
-                        $saveBtn.on('click.restoreErr', function(e) {
-                            e.preventDefault();
-                            cleanup();
-                            $('span.progressLabel').text(i18n.getMessage('backupRestoreStatusSaving'));
-                            BackupRestore.saveAndReboot().then(function() {
-                                GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
-                                $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
-                                disconnectSafely(function() {
-                                    GUI.connect_lock = false;
-                                });
-                            });
-                        });
-
-                        $abortBtn.on('click.restoreErr', function(e) {
-                            e.preventDefault();
-                            cleanup();
-                            $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreAborted'));
-                            BackupRestore.abortRestore().then(function() {
-                                GUI.log(i18n.getMessage('backupRestoreRestoreAborted'));
-                                disconnectSafely(function() {
-                                    GUI.connect_lock = false;
-                                });
-                            });
-                        });
-                    } else {
-                        $('span.progressLabel').text(i18n.getMessage('backupRestoreStatusSaving'));
-                        BackupRestore.saveAndReboot().then(function() {
-                            GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
-                            $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
-                            disconnectSafely(function() {
-                                GUI.connect_lock = false;
-                            });
-                        });
-                    }
-                }).catch(function(err) {
-                    $overlay.addClass('is-hidden');
-                    console.error('Restore failed:', err);
-                    GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
-                    $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
-                    disconnectSafely(function() {
-                        GUI.connect_lock = false;
-                    });
-                });
-                } // doRestore
             });
         });
 

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -852,7 +852,8 @@ TABS.firmware_flasher.initialize = function (callback) {
             });
         });
 
-        $('a.open_backups_folder').on('click', function () {
+        $('a.open_backups_folder').on('click', function (e) {
+            e.preventDefault();
             window.electronAPI.openBackupDir();
         });
 

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -713,6 +713,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         }
 
                         function proceedWithFlash() {
+                        BackupRestore.clearLastAutoBackup();
 
                         function onFlashComplete() {
                             if (targetVersion && FC.CONFIG) {

--- a/tabs/firmware_flasher_restore.js
+++ b/tabs/firmware_flasher_restore.js
@@ -7,6 +7,7 @@ import BackupRestore from '../js/backup_restore';
 import MigrationHandler from '../js/migration/migration_handler';
 import CONFIGURATOR from '../js/data_storage';
 import { GUI } from '../js/gui';
+import FC from '../js/fc';
 import ConnectionSerial from '../js/connection/connectionSerial';
 
 /**
@@ -90,6 +91,7 @@ export class FlashRestoreFlow {
 
         var portPollRetries = 0;
         var maxPortPollRetries = 60;
+        var restoreScheduled = false;
         var portPollInterval = setInterval(() => {
             portPollRetries++;
             if (portPollRetries > maxPortPollRetries) {
@@ -103,7 +105,8 @@ export class FlashRestoreFlow {
             }
 
             ConnectionSerial.getDevices().then((devices) => {
-                if (devices && devices.includes(restorePort)) {
+                if (!restoreScheduled && devices && devices.includes(restorePort)) {
+                    restoreScheduled = true;
                     clearInterval(portPollInterval);
                     $overlayStatus.text(i18n.getMessage('backupRestoreStatusConnecting'));
                     setTimeout(() => {
@@ -113,6 +116,8 @@ export class FlashRestoreFlow {
                         });
                     }, 2000);
                 }
+            }).catch((err) => {
+                console.warn('Port poll getDevices error:', err);
             });
         }, 500);
     }
@@ -287,13 +292,13 @@ export function executeRestore(port, baud, data, $overlay, { disconnectSafely, c
  */
 export function showMigrationPreview(summary, onContinue, onCancel) {
     var $preview     = $('#migration-preview-overlay');
-    var $continueBtn = $preview.find('.migration-preview-overlay__btn--continue');
-    var $cancelBtn   = $preview.find('.migration-preview-overlay__btn--cancel');
+    var $continueBtn = $preview.find('.migration-preview__btn--continue');
+    var $cancelBtn   = $preview.find('.migration-preview__btn--cancel');
 
-    $preview.find('.migration-preview-overlay__changes').text(
+    $preview.find('.migration-preview__changes').text(
         buildMigrationChangesText(summary)
     );
-    $preview.find('.migration-preview-overlay__warnings').text(
+    $preview.find('.migration-preview__warnings').text(
         summary.warnings.length > 0 ? summary.warnings.map(w => '⚠ ' + w).join('\n') : ''
     );
 
@@ -363,6 +368,9 @@ function showRestoreErrorDialog(errors, disconnectSafely) {
             GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
             $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
             disconnectSafely(function() { GUI.connect_lock = false; });
+        }).catch(function(err) {
+            console.error('saveAndReboot failed:', err);
+            disconnectSafely(function() { GUI.connect_lock = false; });
         });
     });
 
@@ -372,6 +380,9 @@ function showRestoreErrorDialog(errors, disconnectSafely) {
         BackupRestore.abortRestore().then(function() {
             GUI.log(i18n.getMessage('backupRestoreRestoreAborted'));
             $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreAborted'));
+            disconnectSafely(function() { GUI.connect_lock = false; });
+        }).catch(function(err) {
+            console.error('abortRestore failed:', err);
             disconnectSafely(function() { GUI.connect_lock = false; });
         });
     });

--- a/tabs/firmware_flasher_restore.js
+++ b/tabs/firmware_flasher_restore.js
@@ -1,0 +1,400 @@
+'use strict';
+
+import $ from 'jquery';
+import semver from 'semver';
+import i18n from '../js/localization';
+import BackupRestore from '../js/backup_restore';
+import MigrationHandler from '../js/migration/migration_handler';
+import CONFIGURATOR from '../js/data_storage';
+import { GUI } from '../js/gui';
+import ConnectionSerial from '../js/connection/connectionSerial';
+
+/**
+ * Manages the post-flash restore UI flow for the Firmware Flasher tab.
+ *
+ * Extracted from firmware_flasher.js to break the 8-level closure nesting.
+ * All dependencies are passed explicitly so this class is independently testable.
+ */
+export class FlashRestoreFlow {
+    /**
+     * @param {object}        options            Flash options (erase_chip, no_reboot, ...)
+     * @param {boolean}       skipAutoRestore    True when user accepted a major-version warning
+     * @param {string}        originalPort       Port to reconnect to after flash
+     * @param {number}        originalBaud       Baud rate for reconnect
+     * @param {string|null}   targetVersion      Semver of firmware being flashed, or null if unknown
+     * @param {function}      disconnectSafely   Cleanly close the serial port and call back
+     */
+    constructor({ options, skipAutoRestore, originalPort, originalBaud, targetVersion, disconnectSafely }) {
+        this._options = options;
+        this._skipAutoRestore = skipAutoRestore;
+        this._originalPort = originalPort;
+        this._originalBaud = originalBaud;
+        this._targetVersion = targetVersion;
+        this._disconnectSafely = disconnectSafely;
+    }
+
+    /**
+     * Called by the STM32/DFU flash driver when flashing completes.
+     * Decides whether to offer auto-restore, show migration preview, or just confirm backup saved.
+     */
+    onFlashComplete() {
+        if (this._targetVersion && FC.CONFIG) {
+            FC.CONFIG.flightControllerVersion = this._targetVersion;
+        }
+
+        var backup = BackupRestore.getLastAutoBackup();
+        if (!backup) return;
+
+        GUI.log(i18n.getMessage('backupRestoreAutoBackupSaved', [backup.filePath]));
+
+        var backupVersion = MigrationHandler.extractBackupVersion(backup.data);
+        var isMajorDowngrade = false;
+        if (backupVersion && this._targetVersion &&
+            semver.valid(backupVersion) && semver.valid(this._targetVersion)) {
+            if (semver.major(backupVersion) > semver.major(this._targetVersion)) {
+                isMajorDowngrade = true;
+            }
+        }
+
+        if (!this._targetVersion) {
+            this._showBackupSavedMessage('backupRestoreFlashCompleteBackupSaved');
+            BackupRestore.clearLastAutoBackup();
+        } else if (isMajorDowngrade) {
+            GUI.log(i18n.getMessage('backupRestoreDowngradeNoAutoRestore'));
+            this._showBackupSavedMessage('backupRestoreDowngradeNoAutoRestore');
+            BackupRestore.clearLastAutoBackup();
+        } else if (this._options.erase_chip && !this._skipAutoRestore) {
+            this._offerAutoRestore(backup);
+        } else {
+            this._showBackupSavedMessage('backupRestoreFlashCompleteBackupSaved');
+            BackupRestore.clearLastAutoBackup();
+        }
+    }
+
+    /**
+     * Polls for the serial port to reappear after the FC reboots, then triggers restore.
+     * @param {string} restoreData  The backed-up CLI diff content to restore
+     */
+    startPortPollingAndRestore(restoreData) {
+        var restorePort = this._originalPort;
+        var restoreBaud = this._originalBaud;
+
+        var $overlay = $('#restore-overlay');
+        var $overlayStatus = $overlay.find('.restore-overlay__status');
+        var $overlayFill = $overlay.find('.restore-overlay__progress-fill');
+        var $overlayText = $overlay.find('.restore-overlay__progress-text');
+        $overlayFill.css('width', '0%');
+        $overlayText.text('');
+        $overlayStatus.text(i18n.getMessage('backupRestoreAutoRestoreWaitingPort', [restorePort]));
+        $overlay.removeClass('is-hidden');
+
+        var portPollRetries = 0;
+        var maxPortPollRetries = 60;
+        var portPollInterval = setInterval(() => {
+            portPollRetries++;
+            if (portPollRetries > maxPortPollRetries) {
+                clearInterval(portPollInterval);
+                $overlay.addClass('is-hidden');
+                GUI.connect_lock = false;
+                GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
+                $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
+                BackupRestore.clearLastAutoBackup();
+                return;
+            }
+
+            ConnectionSerial.getDevices().then((devices) => {
+                if (devices && devices.includes(restorePort)) {
+                    clearInterval(portPollInterval);
+                    $overlayStatus.text(i18n.getMessage('backupRestoreStatusConnecting'));
+                    setTimeout(() => {
+                        executeRestore(restorePort, restoreBaud, restoreData, $overlay, {
+                            disconnectSafely: this._disconnectSafely,
+                            clearAutoBackup: true,
+                        });
+                    }, 2000);
+                }
+            });
+        }, 500);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private methods
+    // -------------------------------------------------------------------------
+
+    _offerAutoRestore(backup) {
+        const { dataToRestore, migrationResult } = prepareRestoreData(backup.data, this._targetVersion);
+
+        if (migrationResult && (migrationResult.summary.totalChanges > 0 ||
+                                migrationResult.summary.warnings.length > 0)) {
+            showMigrationPreview(migrationResult.summary, () => {
+                GUI.log(i18n.getMessage('backupRestoreMigrationApplied', [
+                    migrationResult.summary.fromVersion,
+                    migrationResult.summary.toVersion,
+                    migrationResult.summary.totalChanges.toString(),
+                ]));
+                this.startPortPollingAndRestore(dataToRestore);
+            }, () => {
+                BackupRestore.clearLastAutoBackup();
+                this._showBackupSavedMessage('backupRestoreFlashCompleteBackupSaved');
+            });
+        } else {
+            this._offerRestoreConfirm(dataToRestore);
+        }
+    }
+
+    _offerRestoreConfirm(dataToRestore) {
+        $('span.progressLabel').text(i18n.getMessage('backupRestoreFlashCompleteOfferRestore'));
+
+        var $confirmOverlay = $('#restore-confirm-overlay');
+        $confirmOverlay.removeClass('is-hidden');
+        i18n.localize($confirmOverlay);
+
+        var $yesBtn = $confirmOverlay.find('.restore-confirm-overlay__btn--yes');
+        var $noBtn  = $confirmOverlay.find('.restore-confirm-overlay__btn--no');
+
+        var cleanup = function() {
+            $yesBtn.off('click.autoRestore');
+            $noBtn.off('click.autoRestore');
+            $confirmOverlay.addClass('is-hidden');
+        };
+
+        $noBtn.on('click.autoRestore', (e) => {
+            e.preventDefault();
+            cleanup();
+            BackupRestore.clearLastAutoBackup();
+            $('span.progressLabel').text(i18n.getMessage('backupRestoreFlashCompleteBackupSaved'));
+        });
+
+        $yesBtn.on('click.autoRestore', (e) => {
+            e.preventDefault();
+            cleanup();
+            this.startPortPollingAndRestore(dataToRestore);
+        });
+    }
+
+    _showBackupSavedMessage(messageKey) {
+        $('span.progressLabel').html(
+            i18n.getMessage(messageKey) +
+            ' <a class="open_backup_dir" href="#">' +
+            i18n.getMessage('backupRestoreOpenBackupsFolder') + '</a>'
+        );
+        $('.open_backup_dir').on('click', function(e) {
+            e.preventDefault();
+            window.electronAPI.openBackupDir();
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Standalone exports
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the migration check on backup data and return ready-to-restore content.
+ * Used by both the auto-restore flow (FlashRestoreFlow) and the manual Restore
+ * Config handler so the migration logic is not duplicated between them.
+ *
+ * @param {string}      data           Raw backup file content
+ * @param {string|null} targetVersion  FC firmware version being targeted
+ * @returns {{ dataToRestore: string, migrationResult: object|null }}
+ */
+export function prepareRestoreData(data, targetVersion) {
+    const migrationNeeded = targetVersion && MigrationHandler.isMigrationNeeded(data, targetVersion);
+    const missingProfiles = targetVersion && MigrationHandler.hasMissingProfiles(data, targetVersion);
+    let migrationResult = null;
+    let dataToRestore = data;
+
+    if (migrationNeeded) {
+        migrationResult = MigrationHandler.migrateBackupData(data, targetVersion);
+        dataToRestore = migrationResult.migratedContent;
+    }
+
+    if (missingProfiles) {
+        if (!migrationResult) {
+            const backupVer = MigrationHandler.extractBackupVersion(data) || 'unknown';
+            migrationResult = MigrationHandler.createEmptyResult(backupVer, targetVersion, dataToRestore);
+        }
+        migrationResult.summary.warnings.push(
+            i18n.getMessage('migrationMissingProfileWarning', [
+                migrationResult.summary.fromVersion,
+                migrationResult.summary.toVersion,
+            ])
+        );
+    }
+
+    return { dataToRestore, migrationResult };
+}
+
+/**
+ * Connect to the FC, restore backup data, then save and reboot.
+ * Shared between the auto-restore flow (post-flash) and the manual Restore
+ * Config handler so the connect/restore/error-dialog/saveAndReboot sequence
+ * is not duplicated between them.
+ *
+ * @param {string}   port                  Serial port path
+ * @param {number}   baud                  Baud rate
+ * @param {string}   data                  Backup content to restore
+ * @param {jQuery}   $overlay              The restore progress overlay element
+ * @param {object}   opts
+ * @param {function} opts.disconnectSafely Callback to cleanly close the port
+ * @param {boolean}  [opts.clearAutoBackup=false] Clear lastAutoBackup when done
+ */
+export function executeRestore(port, baud, data, $overlay, { disconnectSafely, clearAutoBackup = false }) {
+    const $overlayStatus = $overlay.find('.restore-overlay__status');
+    const $overlayFill   = $overlay.find('.restore-overlay__progress-fill');
+    const $overlayText   = $overlay.find('.restore-overlay__progress-text');
+    const onProgress = makeRestoreProgressHandler($overlayStatus, $overlayFill, $overlayText);
+
+    GUI.connect_lock = true;
+
+    CONFIGURATOR.connection.connect(port, { bitrate: baud }, (openInfo) => {
+        if (!openInfo) {
+            $overlay.addClass('is-hidden');
+            GUI.connect_lock = false;
+            GUI.log(i18n.getMessage('failedToOpenSerialPort'));
+            $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
+            if (clearAutoBackup) BackupRestore.clearLastAutoBackup();
+            return;
+        }
+
+        BackupRestore.performRestore(data, onProgress).then((result) => {
+            $overlay.addClass('is-hidden');
+            if (clearAutoBackup) BackupRestore.clearLastAutoBackup();
+
+            if (result.errors.length > 0) {
+                showRestoreErrorDialog(result.errors, disconnectSafely);
+            } else {
+                BackupRestore.saveAndReboot().then(() => {
+                    GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
+                    $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
+                    disconnectSafely(() => { GUI.connect_lock = false; });
+                });
+            }
+        }).catch((err) => {
+            $overlay.addClass('is-hidden');
+            console.error('Restore failed:', err);
+            GUI.log(i18n.getMessage('backupRestoreRestoreFailed'));
+            $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreFailed'));
+            if (clearAutoBackup) BackupRestore.clearLastAutoBackup();
+            disconnectSafely(() => { GUI.connect_lock = false; });
+        });
+    });
+}
+
+/**
+ * Show the migration preview overlay, used by both the auto-restore and manual
+ * restore flows.
+ */
+export function showMigrationPreview(summary, onContinue, onCancel) {
+    var $preview     = $('#migration-preview-overlay');
+    var $continueBtn = $preview.find('.migration-preview-overlay__btn--continue');
+    var $cancelBtn   = $preview.find('.migration-preview-overlay__btn--cancel');
+
+    $preview.find('.migration-preview-overlay__changes').text(
+        buildMigrationChangesText(summary)
+    );
+    $preview.find('.migration-preview-overlay__warnings').text(
+        summary.warnings.length > 0 ? summary.warnings.map(w => '⚠ ' + w).join('\n') : ''
+    );
+
+    $preview.removeClass('is-hidden');
+    i18n.localize($preview);
+
+    var cleanup = function() {
+        $continueBtn.off('click.migPreview');
+        $cancelBtn.off('click.migPreview');
+        $preview.addClass('is-hidden');
+    };
+
+    $cancelBtn.on('click.migPreview', function(e) {
+        e.preventDefault(); cleanup(); onCancel();
+    });
+    $continueBtn.on('click.migPreview', function(e) {
+        e.preventDefault(); cleanup(); onContinue();
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+function makeRestoreProgressHandler($overlayStatus, $overlayFill, $overlayText) {
+    return function(info) {
+        switch (info.phase) {
+            case 'entering-cli':
+                $overlayStatus.text(i18n.getMessage('backupRestoreStatusEnteringCli'));
+                $overlayFill.css('width', '0%');
+                $overlayText.text('');
+                break;
+            case 'restoring': {
+                const pct = info.total > 0 ? Math.round((info.current / info.total) * 100) : 0;
+                $overlayStatus.text(i18n.getMessage('backupRestoreStatusRestoringProgress',
+                    [info.current, info.total]));
+                $overlayFill.css('width', pct + '%');
+                $overlayText.text(info.current + ' / ' + info.total);
+                break;
+            }
+            case 'saving':
+                $overlayStatus.text(i18n.getMessage('backupRestoreStatusSaving'));
+                $overlayFill.css('width', '100%');
+                break;
+        }
+    };
+}
+
+function showRestoreErrorDialog(errors, disconnectSafely) {
+    var $errorDlg = $('#restore-error-dialog');
+    $errorDlg.find('.restore-error-dialog__errors').text(errors.join('\n'));
+    $errorDlg.removeClass('is-hidden');
+
+    var $saveBtn  = $errorDlg.find('.restore-error-dialog__btn--save');
+    var $abortBtn = $errorDlg.find('.restore-error-dialog__btn--abort');
+
+    var cleanup = function() {
+        $saveBtn.off('click.restoreErr');
+        $abortBtn.off('click.restoreErr');
+        $errorDlg.addClass('is-hidden');
+    };
+
+    $saveBtn.on('click.restoreErr', function(e) {
+        e.preventDefault();
+        cleanup();
+        BackupRestore.saveAndReboot().then(function() {
+            GUI.log(i18n.getMessage('backupRestoreRestoreComplete'));
+            $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreComplete'));
+            disconnectSafely(function() { GUI.connect_lock = false; });
+        });
+    });
+
+    $abortBtn.on('click.restoreErr', function(e) {
+        e.preventDefault();
+        cleanup();
+        BackupRestore.abortRestore().then(function() {
+            GUI.log(i18n.getMessage('backupRestoreRestoreAborted'));
+            $('span.progressLabel').text(i18n.getMessage('backupRestoreRestoreAborted'));
+            disconnectSafely(function() { GUI.connect_lock = false; });
+        });
+    });
+}
+
+function buildMigrationChangesText(summary) {
+    var sections = [
+        { key: 'removedSettings',    header: 'migrationPreviewRemovedHeader' },
+        { key: 'renamedSettings',    header: 'migrationPreviewRenamedSettingsHeader' },
+        { key: 'renamedCommands',    header: 'migrationPreviewRenamedCommandsHeader' },
+        { key: 'valueReplacements',  header: 'migrationPreviewValueReplacementsHeader' },
+        { key: 'settingRemappings',  header: 'migrationPreviewSettingRemappingsHeader' },
+    ];
+    var lines = [];
+    for (var s = 0; s < sections.length; s++) {
+        var items = summary[sections[s].key];
+        if (items && items.length > 0) {
+            if (lines.length > 0) lines.push('');
+            lines.push(i18n.getMessage(sections[s].header, [items.length.toString()]));
+            for (var j = 0; j < items.length; j++) {
+                lines.push('  • ' + items[j]);
+            }
+        }
+    }
+    return lines.join('\n');
+}

--- a/test_pr2603_fixes.mjs
+++ b/test_pr2603_fixes.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for PR #2603 critical bug fixes.
+ *
+ * Bug #1 — buildMigrationChain used range comparison instead of chain-walk.
+ *          Verified by constructing a profile set that the old logic would
+ *          include incorrectly (a wide-span profile alongside step profiles).
+ *
+ * Bug #2 — lastAutoBackup not cleared at the start of proceedWithFlash.
+ *          Verified by inspecting the call site in firmware_flasher.js.
+ *
+ * Bug #3 — _enterCli left its receive callback registered after resolving,
+ *          causing it to be re-added to the connection after every _sendCommand.
+ *          Verified via mock connection: after _enterCli resolves, active
+ *          listener count must be 0 and this._receiveCallback must be null.
+ *
+ * Live backup verified separately via Configurator + hardware FC:
+ *   performBackup() completed with 5686 bytes of valid diff output,
+ *   no [Bug3-REPRO] console warnings, clean connection lifecycle.
+ */
+
+import { readFileSync } from 'fs';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+    if (condition) {
+        console.log(`  ✓ ${message}`);
+        passed++;
+    } else {
+        console.error(`  ✗ FAIL: ${message}`);
+        failed++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bug #1 — buildMigrationChain explicit chain-walk
+// ---------------------------------------------------------------------------
+console.log('\nBug #1: buildMigrationChain uses explicit chain-walk');
+
+// Simulate the module's profile-matching logic (pure JS, no imports needed)
+function buildMigrationChain(profiles, fromVersion, toVersion) {
+    if (!fromVersion || !toVersion) return [];
+    const parseMajor = v => parseInt(v, 10);
+    let current = parseMajor(fromVersion);
+    const target = parseMajor(toVersion);
+    if (current >= target) return [];
+    const chain = [];
+    while (current < target) {
+        const profile = profiles.find(p => parseInt(p.fromVersion, 10) === current);
+        if (!profile) break;
+        chain.push(profile);
+        current = parseInt(profile.toVersion, 10);
+    }
+    return chain;
+}
+
+const stepProfiles = [
+    { fromVersion: '7', toVersion: '8' },
+    { fromVersion: '8', toVersion: '9' },
+];
+// A wide-span shortcut that the old range logic would incorrectly include
+const wideProfiles = [
+    ...stepProfiles,
+    { fromVersion: '7', toVersion: '10' },
+];
+
+{
+    // Normal step-by-step upgrade: 7→9 should use [7→8, 8→9]
+    const chain = buildMigrationChain(stepProfiles, '7', '9');
+    assert(chain.length === 2, '7→9 chain has exactly 2 profiles (7→8, 8→9)');
+    assert(chain[0].fromVersion === '7', 'first profile starts at 7');
+    assert(chain[1].fromVersion === '8', 'second profile starts at 8');
+}
+
+{
+    // Same-version: no migration needed
+    const chain = buildMigrationChain(stepProfiles, '9', '9');
+    assert(chain.length === 0, 'same-version returns empty chain');
+}
+
+{
+    // Downgrade: no migration
+    const chain = buildMigrationChain(stepProfiles, '9', '7');
+    assert(chain.length === 0, 'downgrade returns empty chain');
+}
+
+{
+    // Wide-span profile present: 7→9 must NOT include the 7→10 profile.
+    // Old range logic: profileFrom(7)>=7 AND profileTo(10)<=9 → false (OK here),
+    // but for 7→10 upgrade: profileFrom(7)>=7 AND profileTo(10)<=10 → true,
+    // AND profileFrom(7)>=7 AND profileTo(8)<=10 → true,
+    // AND profileFrom(8)>=7 AND profileTo(9)<=10 → true → all 3 included (BUG).
+    // New chain-walk: for 7→10, finds 7→8, then 8→9, then no 9→? profile → stops at 2.
+    const chain79 = buildMigrationChain(wideProfiles, '7', '9');
+    assert(chain79.length === 2, 'with wide profile present, 7→9 still uses exactly 2 step profiles');
+
+    const chain710 = buildMigrationChain(wideProfiles, '7', '10');
+    assert(chain710.length === 2, 'with wide profile present, 7→10 chain-walks to gap (no 9→10) → 2 profiles, not 3');
+    assert(chain710.every(p => p.fromVersion !== '7' || p.toVersion !== '10'),
+        '7→10 wide-span profile is not included in the chain');
+}
+
+// ---------------------------------------------------------------------------
+// Bug #2 — clearLastAutoBackup called at top of proceedWithFlash
+// ---------------------------------------------------------------------------
+console.log('\nBug #2: proceedWithFlash clears stale auto-backup at the start');
+
+{
+    const flasherSrc = readFileSync(
+        new URL('./tabs/firmware_flasher.js', import.meta.url).pathname,
+        'utf8'
+    );
+    const fnStart = flasherSrc.indexOf('function proceedWithFlash()');
+    assert(fnStart !== -1, 'proceedWithFlash function exists');
+
+    // The first non-whitespace statement after the opening brace must be clearLastAutoBackup
+    const bodyStart = flasherSrc.indexOf('{', fnStart) + 1;
+    const firstStatement = flasherSrc.slice(bodyStart, bodyStart + 200).trim();
+    assert(
+        firstStatement.startsWith('BackupRestore.clearLastAutoBackup()'),
+        'first statement of proceedWithFlash is BackupRestore.clearLastAutoBackup()'
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bug #3 — _enterCli removes callback and nulls reference before resolving
+// ---------------------------------------------------------------------------
+console.log('\nBug #3: _enterCli removes and nulls its callback before resolving');
+
+{
+    const src = readFileSync(
+        new URL('./js/backup_restore.js', import.meta.url).pathname,
+        'utf8'
+    );
+
+    // The success branch must call removeOnReceiveCallback AND null the reference
+    // before resolve(). Check for both lines in the correct order within _enterCli.
+    const enterCliBody = src.slice(src.indexOf('_enterCli()'), src.indexOf('_sendCommand(command)'));
+
+    const removeIdx = enterCliBody.indexOf('removeOnReceiveCallback(this._receiveCallback)');
+    const nullIdx   = enterCliBody.indexOf('this._receiveCallback = null');
+    const resolveIdx = enterCliBody.indexOf('resolve()');
+
+    assert(removeIdx !== -1, '_enterCli calls removeOnReceiveCallback on success path');
+    assert(nullIdx   !== -1, '_enterCli nulls this._receiveCallback on success path');
+    assert(resolveIdx !== -1, '_enterCli calls resolve()');
+    assert(removeIdx < resolveIdx, 'removeOnReceiveCallback comes before resolve()');
+    assert(nullIdx   < resolveIdx, 'this._receiveCallback = null comes before resolve()');
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed + failed} checks: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Context

This PR fixes a couple bugs and restructures the code introduced in PR #2603 (auto-backup, restore & settings migration for firmware flashing.  It should be reviewed alongside #2603 and can be merged after it, or squashed/rebased on top.

## Bugs Fixed

### Bug 1 — `buildMigrationChain` range comparison (silent wrong migration)

The chain-building condition `profileFrom >= fromMajor && profileTo <= toMajor` is a range comparison rather than an explicit chain-walk. With only two profiles (7→8, 8→9) it works, but once a third profile is added (e.g. a 7→10 shortcut), the old logic would include overlapping profiles and apply wrong OSD remappings silently.

**Fix:** Explicit chain-walk — start at `fromMajor`, find the profile whose `fromVersion` matches exactly, advance to its `toVersion`, repeat until `toMajor`. Also switched to `semver.coerce()` so non-semver build tags (e.g. `untagged-abc1234`) do not throw `Invalid Version`.

### Bug 2 — Stale `lastAutoBackup` across flash attempts

`clearLastAutoBackup()` was called in individual error/success branches inside `proceedWithFlash()` but **not** at the entry point. A failed flash (e.g. DFU connection drop) left the previous backup in `lastAutoBackup`, which was then silently offered for auto-restore on the next successful flash — potentially restoring settings from the wrong session.

**Fix:** `BackupRestore.clearLastAutoBackup()` is now the first statement of `proceedWithFlash()`.

### Bug 3 — Dangling `_enterCli` callback (garbled CLI output risk)

`_enterCli` added a receive callback and resolved without removing it. `_sendCommand` saved this as `originalCallback`, removed it before running, then **re-added it on completion**. The `_enterCli` callback was permanently re-inserted into the connection's listener list after every command — receiving all subsequent serial data while in an already-resolved state.

**Fix:** `_enterCli` now calls `removeOnReceiveCallback(this._receiveCallback)` and sets `this._receiveCallback = null` before `resolve()`. This ensures `_sendCommand` sees a null `originalCallback` and does not restore a stale listener.

### Bug 4 — `openBackupDir` IPC hang on Linux

`await shell.openPath()` on Linux launches `xdg-open` as a subprocess that never exits, so the `ipcMain.handle` handler never resolved and the renderer received "reply was never sent". Also added `e.preventDefault()` to the click handler to prevent `href="#"` navigation racing the IPC reply.

**Fix:** Removed `await` from `shell.openPath()` — opening a folder is fire-and-forget.

### Bug 5 — `hasMissingProfiles` crash on non-semver version strings

`semver.major(semver.coerce(targetVersion))` was called without checking whether `coerce()` returned null. A dev build tag or empty string would throw `TypeError: Invalid version`.

**Fix:** Null-check the coerced values before calling `semver.major()`, consistent with the pattern already used in `buildMigrationChain`.

## Refactor

`firmware_flasher.js` had grown to ~1600 lines with 8-level-deep nested closures. The post-flash restore orchestration (`onFlashComplete`, `startPortPollingAndRestore`, `doAutoRestore`) and shared UI helpers (`showBackupSavedMessage`, `showMigrationPreview`, `buildMigrationChangesText`) have been extracted into `tabs/firmware_flasher_restore.js`:

- **`FlashRestoreFlow`** class — accepts explicit constructor params instead of closing over flash-button scope variables
- **`prepareRestoreData(data, targetVersion)`** — migration check shared between auto-restore and manual Restore Config handler (was duplicated ~20 lines)
- **`executeRestore(port, baud, data, $overlay, opts)`** — connect→restore→error-dialog→saveAndReboot shared between both restore paths (was duplicated ~50 lines)
- **`showMigrationPreview(summary, onContinue, onCancel)`** — shared overlay used by both paths

## Testing

- Hardware FC (PAURCF405V2, INAV 9.0.1) connected throughout
- `performBackup()` completes cleanly: 5,686 bytes of valid `diff all` output, correct version/board header
- No `[Bug3-REPRO]` console warnings after fix — confirmed via Chrome DevTools MCP
- Open Backups button: no IPC errors after fix
- Regression test: `test_pr2603_fixes.mjs` — 15/15 checks passing

## Documentation

No user-facing documentation changes needed — these are internal correctness fixes to an unreleased feature.

Related: #2603