### PR TITLE
Revert "Mixer output mapping: prioritize dedicated timer outputs" (#2596)

### DIFF
--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -86,31 +86,18 @@ var OutputMappingCollection = function () {
 
         for (let i = 0; i < data.length; i++) {
             timerMap[i] = null;
-        }
 
-        // Two priority passes: dedicated outputs first, then auto.
-        // Matches firmware pwmBuildTimerOutputList() behavior.
-        for (let priority = 0; priority < 2; priority++) {
-            let isDedicated = (priority === 0);
-
-            for (let i = 0; i < data.length; i++) {
-                if (timerMap[i] !== null) continue;
-
-                let flags = data[i]['usageFlags'];
-                let timerId = data[i]['timerId'];
-                let mode = timerOverrides[timerId] || self.TIMER_OUTPUT_MODE_AUTO;
-
-                if (motorsToGo > 0 && BitHelper.bit_check(flags, TIM_USE_MOTOR)
-                        && (isDedicated ? mode === self.TIMER_OUTPUT_MODE_MOTORS : mode !== self.TIMER_OUTPUT_MODE_MOTORS)) {
-                    timerMap[i] = OUTPUT_TYPE_MOTOR;
-                    motorsToGo--;
-                } else if (servosToGo > 0 && BitHelper.bit_check(flags, TIM_USE_SERVO)
-                        && (isDedicated ? mode === self.TIMER_OUTPUT_MODE_SERVOS : mode !== self.TIMER_OUTPUT_MODE_SERVOS)) {
-                    timerMap[i] = OUTPUT_TYPE_SERVO;
-                    servosToGo--;
-                } else if (!isDedicated && BitHelper.bit_check(flags, TIM_USE_LED)) {
-                    timerMap[i] = OUTPUT_TYPE_LED;
-                }
+            if (servosToGo > 0 && BitHelper.bit_check(data[i]['usageFlags'], TIM_USE_LED)) {
+                console.log(i + ": LED");
+                timerMap[i] = OUTPUT_TYPE_LED;
+            } else if (servosToGo > 0 && BitHelper.bit_check(data[i]['usageFlags'], TIM_USE_SERVO)) {
+                console.log(i + ": SERVO");
+                servosToGo--;
+                timerMap[i] = OUTPUT_TYPE_SERVO;
+            } else if (motorsToGo > 0 && BitHelper.bit_check(data[i]['usageFlags'], TIM_USE_MOTOR)) {
+                console.log(i + ": MOTOR");
+                motorsToGo--;
+                timerMap[i] = OUTPUT_TYPE_MOTOR;
             }
         }
 


### PR DESCRIPTION
## Summary

Reverts #2596 from `maintenance-9.x` for backward compatibility with Configurator 9.0.1.

**The problem:** #2596 updated `outputMapping.js` to use a two-pass priority algorithm matching the firmware change in iNavFlight/inav#11445. The Configurator re-implements the firmware assignment algorithm in JavaScript. When firmware and Configurator versions are mismatched, users with targets that have explicit `timerOverrides` see wrong pin assignment previews in the Outputs tab.

- **Old Configurator 9.0.1 + new firmware 9.1:** Configurator shows wrong assignments (single-pass JS, firmware uses two-pass)
- **New Configurator + old firmware 9.0:** Configurator predicts two-pass result, firmware still assigns single-pass

Paired firmware revert: iNavFlight/inav#11559

## Plan for 10.x

This will be re-implemented in `maintenance-10.x` alongside new MSP messages (`MSP2_INAV_OUTPUT_ASSIGNMENT` / `MSP2_INAV_QUERY_OUTPUT_ASSIGNMENT`) so the firmware reports actual assignments directly and the Configurator never needs to re-implement the algorithm in JS.

## Merge note

After merging, merge this revert into `maintenance-10.x` **before** re-implementing the two-pass algorithm there. This ensures the revert is the common ancestor, preventing future `maintenance-9.x` → `maintenance-10.x` merges from silently undoing the 10.x re-implementation.