### PR TITLE
osd: fix help link for Use Pilot Logo toggle

### DIFF
--- a/tabs/osd.html
+++ b/tabs/osd.html
@@ -83,11 +83,11 @@
                                 <input type="text" id="pilot_name" data-setting="pilot_name" data-live="true" />
                                 <span data-i18n="osd_pilot_name"></span>
                             </label>
-                            <div for="usePilotLogo" class="helpicon cf_tip osd_use_large_pilot_logo" data-i18n_title="osd_use_large_pilot_logo_help"></div>
                             <label>
                                 <input type="checkbox" id="usePilotLogo" class="toggle update_preview" data-setting="osd_use_pilot_logo" data-live="true">
                                 <span data-i18n="osd_use_pilot_logo"></span>
                             </label>
+                            <div for="usePilotLogo" class="helpicon cf_tip" data-i18n_title="osdElement_PILOT_LOGO_HELP"></div>
                             <label class="craft_name">
                                 <input type="text" id="craft_name" data-setting="name" data-live="true" />
                                 <span data-i18n="osd_craft_name"></span>


### PR DESCRIPTION
Fixes #2523

The `?` help icon next to the **Use Pilot Logo** toggle on the OSD tab did not behave like other help icons. Clicking it toggled the switch instead of opening the linked docs anchor (`Settings.md#osd_use_pilot_logo`), and hovering did not show the right context-sensitive help text.

## Root cause

In `tabs/osd.html` the helpicon for `usePilotLogo` was placed **before** the label that wraps the checkbox toggle. With `.helpicon { float: right; }` and `.tab-osd .settings label { display: block; width: 100% }`, the floated icon ends up inside the same visual click area as the toggle's label, so clicks landed on the label and toggled the input rather than activating the `<a class="helpiconLink">` that `Settings.linkHelpIcons()` wraps it in.

The tooltip key also pointed at `osd_use_large_pilot_logo_help`, which is the help text for a different (large) pilot-logo setting, not for `osd_use_pilot_logo`.

## Fix

Move the helpicon **after** the toggle's `<label>`, matching the pattern used by other working help icons in the configurator — e.g. the Failsafe **Use Minimum Distance** toggle in `tabs/failsafe.html`, where the input/label/helpicon are siblings and the icon comes last.

Also point the tooltip at `osdElement_PILOT_LOGO_HELP` ("Shows your small pilot logo in the OSD..."), which is the help string that actually describes the `osd_use_pilot_logo` setting.

## Behavior after fix

- Clicking the `?` opens `Settings.md#osd_use_pilot_logo` in the default browser (via `Settings.linkHelpIcons()` + Electron `setWindowOpenHandler`).
- Hovering shows the correct small-pilot-logo help text.
- The toggle is no longer flipped by clicks on the icon.

## Test plan

- Open the OSD tab.
- Hover the `?` next to **Use pilot logo** — tooltip describes the small pilot logo setting.
- Click the `?` — default browser opens `Settings.md#osd_use_pilot_logo`, the toggle state does not change.
- The toggle itself still works when clicked directly on the switch or its text label.
