### PR TITLE
ports: add CRSF Sensor serial port function (bit 24, 420000 baud)

### DIFF
--- a/js/serialPortHelper.js
+++ b/js/serialPortHelper.js
@@ -131,6 +131,13 @@ const serialPortHelper = (function () {
             name: 'HEADTRACKER',
             groups: ['peripherals'],
             defaultBaud: 115200
+        },
+        {
+            name: 'CRSF_SENSOR',
+            groups: ['sensors'],
+            defaultBaud: 420000,
+            lockedBaud: true,
+            isUnique: true
         }
     ];
 
@@ -161,7 +168,8 @@ const serialPortHelper = (function () {
         'SMARTPORT_MASTER': 23,
         'MSP_DISPLAYPORT': 25,
         'GIMBAL': 26,
-        'HEADTRACKER': 27
+        'HEADTRACKER': 27,
+        'CRSF_SENSOR': 24
     };
 
     privateScope.identifierToName = {
@@ -185,7 +193,8 @@ const serialPortHelper = (function () {
             '38400',
             '57600',
             '115200',
-            '230400'
+            '230400',
+            '420000'
         ],
         'MSP': [
             '2400',

--- a/js/serialPortHelper.js
+++ b/js/serialPortHelper.js
@@ -166,10 +166,10 @@ const serialPortHelper = (function () {
         'DJI_FPV': 21,
         'SBUS_OUTPUT': 22,
         'SMARTPORT_MASTER': 23,
+        'CRSF_SENSOR': 24,
         'MSP_DISPLAYPORT': 25,
         'GIMBAL': 26,
-        'HEADTRACKER': 27,
-        'CRSF_SENSOR': 24
+        'HEADTRACKER': 27
     };
 
     privateScope.identifierToName = {
@@ -193,8 +193,7 @@ const serialPortHelper = (function () {
             '38400',
             '57600',
             '115200',
-            '230400',
-            '420000'
+            '230400'
         ],
         'MSP': [
             '2400',

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1496,6 +1496,9 @@
     "portsFunction_HEADTRACKER": {
         "message": "Serial Headtracker"
     },
+    "portsFunction_CRSF_SENSOR": {
+        "message": "CRSF Sensor"
+    },
     "pidTuning_Other": {
         "message": "Other"
     },

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -107,7 +107,7 @@ portsTab.initialize = function (callback) {
                 port_configuration_e.data('port', serialPort);
 
                 for (var columnIndex = 0; columnIndex < columns.length; columnIndex++) {
-                    var column = columns[columnIndex];
+                    let column = columns[columnIndex];
 
                     var functions_e = $(port_configuration_e).find('.functionsCell-' + column);
                     let functions_e_id = "portFunc-" + column + "-" + portIndex;

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -318,7 +318,9 @@ function updateDefaultBaud(baudSelect, column) {
         baudRate = rule.defaultBaud;
     }
 
-    section.find("." + column + "_baudrate").children('[value=' + baudRate + ']').prop('selected', true);
+    const $baudSelect = section.find("." + column + "_baudrate");
+    $baudSelect.children('[value=' + baudRate + ']').prop('selected', true);
+    $baudSelect.prop('disabled', !!(rule && rule.lockedBaud));
 }
 
 portsTab.cleanup = function (callback) {

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -152,6 +152,7 @@ portsTab.initialize = function (callback) {
 
                             if (serialPort.functions.indexOf(functionName) >= 0) {
                                 select_e.val(functionName);
+                                updateDefaultBaud(functions_e_id, column);
                             }
                         }
                     }
@@ -197,7 +198,7 @@ portsTab.initialize = function (callback) {
                 let $element = $(element);
 
                 if ($element.val() != functionName) {
-                    $element.val('');
+                    $element.val('').trigger('change');
                 }
             });
 


### PR DESCRIPTION
## Summary

Adds Configurator UI support for the `FUNCTION_CRSF_SENSOR` serial port function introduced in firmware PR [iNavFlight/inav#11379](https://github.com/iNavFlight/inav/pull/11379). Without this, users must configure the CRSF sensor UART via CLI only.

## Changes

- **`js/serialPortHelper.js`**: Add `CRSF_SENSOR` to the port function rules (sensors group, `isUnique: true`, `defaultBaud: 420000`, `lockedBaud: true`) and to the function ID map at bit 24 (`1 << 24`). Add `420000` to the SENSOR baud list so the option is available in the dropdown.
- **`tabs/ports.js`**: Extend `updateDefaultBaud` to disable the baud rate select when the active function has `lockedBaud: true`, enforcing 420000 baud for CRSF Sensor and preventing misconfiguration.
- **`locale/en/messages.json`**: Add `portsFunction_CRSF_SENSOR` display name ("CRSF Sensor").

## Behaviour

- **Ports tab**: "CRSF Sensor" appears as a selectable option in the sensors function column. It is unique (only one port can be assigned). Selecting it locks the baud rate selector to 420000.
- **Sensor dropdowns** (GPS provider, baro hardware, battery meter type): these are populated from the FC's settings table over MSP, so they will automatically show the CRSF options once firmware PR #11379 is flashed — no additional configurator changes needed.

## Testing

- Built configurator successfully (Vite + Electron Forge, Linux x64)
- Verified `CRSF_SENSOR` appears at bit 24 in `functionsToMask` / `maskToFunctions`
- Hardware testing not performed (requires FC running firmware PR #11379)

## Related

- Firmware PR: iNavFlight/inav#11379