### PR TITLE
toolbar: replace float-based layout with flexbox

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1345,7 +1345,7 @@ dialog {
 
 .content_toolbar .btn a {
     /*  common styles for content toolbar buttons */
-    margin: 0;
+    margin: 5px;
     background-color: #37a8db;
     border-radius: 3px;
     border: 1px solid #3394b5;
@@ -1356,7 +1356,7 @@ dialog {
     display: block;
     cursor: pointer;
     transition: all ease 0.2s;
-    padding: 0 9px;
+    padding: 5px 9px;
     line-height: 28px;
 }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1322,24 +1322,34 @@ dialog {
 .content_toolbar {
     /*  content toolbar panel */
     width: 100%;
-    height: 30px;
+    box-sizing: border-box;
     background-color: #EFEFEF;
     box-shadow: rgba(0, 0, 0, 0.10) 0 -3px 8px;
-    padding: 10px 0;
-    overflow: hidden;
+    padding: 6px 10px;
     border-top: 1px solid #F9F9F9;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+.content_toolbar > div {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.content_toolbar .toolbar-left {
+    margin-right: auto;
 }
 
 .content_toolbar .btn a {
     /*  common styles for content toolbar buttons */
-    margin-top: 0;
-    margin-bottom: 0;
-    margin-right: 20px;
+    margin: 0;
     background-color: #37a8db;
     border-radius: 3px;
     border: 1px solid #3394b5;
     color: #fff;
-    float: right;
     font-family: 'open_sansbold', Arial, serif;
     font-size: 12px;
     text-shadow: 0 1px rgba(0, 0, 0, 0.25);

--- a/tabs/cli.html
+++ b/tabs/cli.html
@@ -19,18 +19,18 @@
         </div>
     </div>
     <div class="content_toolbar">
-        <div class="btn save_btn" style="float: left; padding-left: 15px">
+        <div class="btn save_btn toolbar-left">
             <a class="msc" href="#" i18n="cliMscBtn"></a>
             <a class="savecmd" href="#" i18n="cliSaveSettingsBtn"></a>
             <a class="exit" href="#" i18n="cliExitBtn"></a>
         </div>
-        <div class="btn save_btn pull-right">
-            <a class="cliDocsBtn" href="#" i18n="cliDocsBtn" target="_blank"></a>
-            <a class="save" href="#" i18n="cliSaveToFileBtn"></a>
+        <div class="btn save_btn">
+            <a class="diffall" href="#" i18n="cliDiffAllBtn"></a>
+            <a class="clear" href="#" i18n="cliClearOutputHistoryBtn"></a>
+            <a class="copy" href="#" i18n="cliCopyToClipboardBtn"></a>
             <a class="load" href="#" i18n="cliLoadFromFileBtn"></a>
-            <a class="copy" href="#" i18n="cliCopyToClipboardBtn"></a>            
-            <a class="clear" href="#" i18n="cliClearOutputHistoryBtn"></a>     
-            <a class="diffall" href="#" i18n="cliDiffAllBtn"></a>  
+            <a class="save" href="#" i18n="cliSaveToFileBtn"></a>
+            <a class="cliDocsBtn" href="#" i18n="cliDocsBtn" target="_blank"></a>
         </div>
     </div>
 

--- a/tabs/firmware_flasher.html
+++ b/tabs/firmware_flasher.html
@@ -181,23 +181,30 @@
         </div>
     </div>
     <div class="content_toolbar">
-        <div class="btn">
-            <a class="load_file" href="#" i18n="firmwareFlasherButtonLoadLocal"></a>
+
+        <div class="toolbar-left">
+          <div class="btn">
+              <a class="backup_config" href="#" i18n="backupRestoreButtonBackup"></a>
+          </div>
+          <div class="btn">
+              <a class="restore_config" href="#" i18n="backupRestoreButtonRestore"></a>
+          </div>
+          <div class="btn">
+              <a class="open_backups_folder" href="#" i18n="backupRestoreOpenBackupsFolder"></a>
+          </div>
         </div>
-        <div class="btn">
-            <a class="load_remote_file disabled" href="#" i18n="firmwareFlasherButtonLoadOnline"></a>
+
+        <div>
+          <div class="btn">
+              <a class="load_file" href="#" i18n="firmwareFlasherButtonLoadLocal"></a>
+          </div>
+          <div class="btn">
+              <a class="load_remote_file disabled" href="#" i18n="firmwareFlasherButtonLoadOnline"></a>
+          </div>
+          <div class="btn">
+              <a class="flash_firmware disabled" href="#progressbar" i18n="firmwareFlasherFlashFirmware"></a>
+          </div>
         </div>
-        <div class="btn">
-            <a class="flash_firmware disabled" href="#progressbar" i18n="firmwareFlasherFlashFirmware"></a>
-        </div>
-        <div class="btn">
-            <a class="backup_config" href="#" i18n="backupRestoreButtonBackup"></a>
-        </div>
-        <div class="btn">
-            <a class="restore_config" href="#" i18n="backupRestoreButtonRestore"></a>
-        </div>
-        <div class="btn">
-            <a class="open_backups_folder" href="#" i18n="backupRestoreOpenBackupsFolder"></a>
-        </div>
+
     </div>
 </div>


### PR DESCRIPTION
## Summary

- Converts `.content_toolbar` from a float-based layout to flexbox, with `justify-content: flex-end` so single button groups stay right-aligned
- Adds `.content_toolbar > div { display: flex; gap: 8px }` so button groups lay out horizontally without floats
- Adds `.toolbar-left` utility class using `margin-right: auto` to push a sibling group to the far right
- Fixes `firmware_flasher` toolbar: flash buttons (Load Local, Load Online, Flash) now left-aligned; backup buttons (Backup, Restore, Open Folder) now right-aligned
- Cleans up `cli.html`: removes `style="float: left"` inline style and undefined `pull-right` class, replaces with `toolbar-left`
- Adds `box-sizing: border-box` and removes fixed `height: 30px` (replaced with `padding: 6px 10px`) so buttons have proper vertical breathing room and right-edge padding is not clipped

Old:

<img width="909" height="100" alt="image" src="https://github.com/user-attachments/assets/1c0ac964-4640-42a7-9cda-90c5c6306d14" />



New:

<img width="1470" height="179" alt="image" src="https://github.com/user-attachments/assets/2f807125-7470-4fef-aa50-75f459c1b033" />
