### PR TITLE
fix(advanced-tuning): load mixer config before rendering tab

### DIFF
--- a/tabs/advanced_tuning.js
+++ b/tabs/advanced_tuning.js
@@ -17,7 +17,7 @@ advancedTuningTab.initialize = function (callback) {
         GUI.active_tab = this;
     }
 
-    var loadChainer = new MSPChainerClass();
+    const loadChainer = new MSPChainerClass();
     loadChainer.setChain([mspHelper.loadMixerConfig]);
     loadChainer.setExitPoint(load_html);
     loadChainer.execute();

--- a/tabs/advanced_tuning.js
+++ b/tabs/advanced_tuning.js
@@ -67,7 +67,7 @@ advancedTuningTab.initialize = function (callback) {
 
         GUI.simpleBind();
 
-        i18n.localize();;
+        i18n.localize();
         
         // Set up required field warnings
         $('#launchIdleThr').on('keyup', () => {

--- a/tabs/advanced_tuning.js
+++ b/tabs/advanced_tuning.js
@@ -2,6 +2,8 @@
 
 import MSPCodes from './../js/msp/MSPCodes';
 import MSP from './../js/msp';
+import MSPChainerClass from './../js/msp/MSPchainer';
+import mspHelper from './../js/msp/MSPHelper';
 import GUI from './../js/gui';
 import FC from './../js/fc';
 import Settings from './../js/settings';
@@ -15,7 +17,14 @@ advancedTuningTab.initialize = function (callback) {
         GUI.active_tab = this;
     }
 
-    import('./advanced_tuning.html?raw').then(({default: html}) => GUI.load(html, Settings.processHtml(processHtml)));
+    var loadChainer = new MSPChainerClass();
+    loadChainer.setChain([mspHelper.loadMixerConfig]);
+    loadChainer.setExitPoint(load_html);
+    loadChainer.execute();
+
+    function load_html() {
+        import('./advanced_tuning.html?raw').then(({default: html}) => GUI.load(html, Settings.processHtml(processHtml)));
+    }
 
     function save_to_eeprom() {
         console.log('save_to_eeprom');


### PR DESCRIPTION
## Summary

Fixes a regression introduced alongside progressive settings loading (PR #2625): the Advanced Tuning tab shows both fixed-wing and multirotor sections simultaneously, regardless of craft type.

## Root Cause

`processHtml()` calls `FC.isAirplane()` / `FC.isMultirotor()`, both of which read `FC.MIXER_CONFIG.platformType`. The tab never fetched MIXER_CONFIG itself — it relied on it being pre-loaded by another tab. If `platformType` was still `-1` (the `resetState()` default), both methods return false and the `else` branch renders both sections at once.

## Changes

- `tabs/advanced_tuning.js`: Add MSPChainer to fetch `loadMixerConfig` before calling `load_html()`, ensuring `platformType` holds the real FC value when `processHtml()` applies show/hide logic. Matches the established pattern in `pid_tuning.js` and `mixer.js`.
- `tabs/advanced_tuning.js`: Remove pre-existing duplicate semicolon (`i18n.localize();;`).

## Testing

- Connected to SITL (multirotor, platformType = 0)
- Advanced Tuning tab: multirotor section visible, airplane section hidden — correct
- No JavaScript errors in console
- Code reviewed with inav-code-review agent — no critical issues found

## Related

Complements PR #2625 (progressive settings loading)