### PR TITLE
Fix OSM 403: inject Referer and User-Agent for tile requests

### DIFF
--- a/js/main/main.js
+++ b/js/main/main.js
@@ -1,5 +1,5 @@
 import { chmod, rm, mkdirSync, existsSync } from 'node:fs';
-import { app, BrowserWindow, ipcMain, Menu, MenuItem, shell, dialog } from 'electron';
+import { app, BrowserWindow, ipcMain, Menu, MenuItem, shell, dialog, session } from 'electron';
 import windowStateKeeper from 'electron-window-state';
 import Store from "electron-store";
 import path from 'path';
@@ -97,6 +97,18 @@ function createDeviceChooser() {
 }
 
 app.on('ready', () => {
+  // Electron provides no valid Referer for OSM tiles (file:// in prod, localhost in dev).
+  // OSM CDN rejects both with 403, so inject the required headers unconditionally.
+  const PROJECT_URL = 'https://github.com/iNavFlight/inav-configurator';
+  session.defaultSession.webRequest.onBeforeSendHeaders(
+    { urls: ['https://tile.openstreetmap.org/*', 'https://*.tile.openstreetmap.org/*'] },
+    (details, callback) => {
+      details.requestHeaders['Referer'] = PROJECT_URL;
+      details.requestHeaders['User-Agent'] = `INAV-Configurator/${app.getVersion()} (${PROJECT_URL})`;
+      callback({ requestHeaders: details.requestHeaders });
+    }
+  );
+
   createWindow();
 });
 


### PR DESCRIPTION
## Summary

Fixes 403 errors from the OSM tile CDN when loading the map tab.

Electron provides no valid `Referer` for outgoing tile requests — packaged builds load pages from `file://`, and dev builds load from `http://localhost`. OSM's CDN rejects both with 403. The fix registers a `webRequest.onBeforeSendHeaders` hook on the default session at app startup that injects the required `Referer` and `User-Agent` headers on all requests to `tile.openstreetmap.org`.

## Changes

- `js/main/main.js`: import `session` from electron; register `onBeforeSendHeaders` hook in `app.on('ready', ...)` (not inside `createWindow()`, to prevent double-registration) that injects `Referer` and a policy-compliant `User-Agent` for OSM tile requests
- URL filter covers both `https://tile.openstreetmap.org/*` (the URL OpenLayers actually uses) and `https://*.tile.openstreetmap.org/*` (CDN subdomain form)
- `User-Agent` uses `app.getVersion()` so it tracks the package version dynamically rather than a hardcoded string

## Testing

- Launched configurator in dev mode, opened map tab — OSM tiles load without 403 errors
- Confirmed tiles were previously failing before this change

## Notes

Cherry-picked and amended from MartinovEm's PR #2599 (`dff32ce`). The original commit hardcoded the version string and used only the subdomain wildcard pattern; both issues are fixed here.