### PR TITLE
Rename smix max to fixed

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -941,7 +941,7 @@ var FC = {
             'Stabilized Pitch-',    // 26
             'Stabilized Yaw+',      // 27
             'Stabilized Yaw-',      // 28,
-            'MAX',                  // 29,
+            'Fixed Value',          // 29,
             'GVAR 0',               // 30
             'GVAR 1',               // 31
             'GVAR 2',               // 32

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -408,9 +408,9 @@ mixerTab.initialize = function (callback, scrollPosition) {
 
     function updateFixedValueVisibility(row, $mixRuleInput) {
 
-        // Show the fixed value input box if "MAX" input was selected for this servo
+        // Show the fixed value input box if "Fixed Value" input was selected for this servo
         const $fixedValueCalcInput = row.find(".mix-rule-fixed-value");
-        if (FC.getServoMixInputNames()[$mixRuleInput.val()] === 'MAX') {
+        if (FC.getServoMixInputNames()[$mixRuleInput.val()] === 'Fixed Value') {
             $fixedValueCalcInput.show();
         } else {
             $fixedValueCalcInput.hide();
@@ -422,7 +422,7 @@ mixerTab.initialize = function (callback, scrollPosition) {
         const rules = FC.SERVO_RULES.get();
         for (let servoRuleIndex in rules) {
             if (rules.hasOwnProperty(servoRuleIndex)) {
-                if (FC.getServoMixInputNames()[rules[servoRuleIndex].getInput()] === 'MAX') {
+                if (FC.getServoMixInputNames()[rules[servoRuleIndex].getInput()] === 'Fixed Value') {
                     $fixedValueCol.show();
                     return;
                 }


### PR DESCRIPTION
To set a fixed value in the servo mixer, previously one had to choose "MAX" as the source. That's misleading because it's not always the max value. This PR renames it to "fixed value".
