### PR TITLE
Fix OSD custom element layout on narrow/HD and wide screens

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1972,6 +1972,15 @@ dialog {
     border-bottom-right-radius: 5px;
 }
 
+@media only screen and (max-width: 1439px) {
+
+    .content_toolbar .btn a {
+        padding: 0 5px;
+        line-height: 22px;
+    }
+
+}
+
 @media only screen and (max-width: 1055px) , only screen and (max-device-width: 1055px) {
 
     .content_wrapper {

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -693,6 +693,12 @@
     padding-bottom: 0 i !important;
 }
 
+@media only screen and (max-width: 1439px) {
+    .tab-osd .content_wrapper {
+        padding: 10px;
+    }
+}
+
 @media only screen and (max-width: 1055px) , only screen and (max-device-width: 1055px) {
     .tab-osd .content_wrapper {
         height: calc(100% - 30px);
@@ -784,6 +790,8 @@
     width: 16px;
     text-align: center;
 }
+
+.osd_group { max-width: 300px; }
 
 .ce-card-body {
     padding: 8px 10px;

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -695,7 +695,7 @@
 
 @media only screen and (max-width: 1439px) {
     .tab-osd .content_wrapper {
-        padding: 10px;
+        padding: 6px;
     }
 }
 

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -765,7 +765,6 @@
 .ce-card-name {
     font-weight: bold;
     font-size: 12px;
-    white-space: nowrap;
 }
 
 .ce-card-preview {
@@ -802,15 +801,6 @@
     margin-bottom: 0;
 }
 
-.ce-source-select {
-    width: auto !important;
-    flex-shrink: 0;
-}
-
-.ce-format-select {
-    width: auto !important;
-    flex-shrink: 0;
-}
 
 .ce-slot-value {
     flex: 1;

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -3891,7 +3891,10 @@ function buildSlotRow(i, ii) {
     for (var fi = 0; fi < OSD.constants.CE_FORMATS.length; fi++) {
         formatHtml += '<option value="' + fi + '">' + OSD.constants.CE_FORMATS[fi].label + '</option>';
     }
-    var $formatSelect = $('<select>').addClass('ce-format-select').html(formatHtml).hide();
+    var $formatSelect = $('<select>').addClass('ce-format-select').html(formatHtml);
+
+    // Format row — shown only when source is GV (5) or LC (6)
+    var $fmtRow = $('<div>').addClass('ce-slot-row').hide().append($formatSelect);
 
     // Forward bridge: visible source/format → hidden type
     function updateHiddenType() {
@@ -3903,9 +3906,9 @@ function buildSlotRow(i, ii) {
     $sourceSelect.on('change', function() {
         var src = parseInt($(this).val());
         if (src === 5 || src === 6) {
-            $formatSelect.show();
+            $fmtRow.show();
         } else {
-            $formatSelect.hide();
+            $fmtRow.hide();
         }
         updateHiddenType();
     });
@@ -3949,9 +3952,10 @@ function buildSlotRow(i, ii) {
         var sf = ceTypeToSourceFormat(type);
         $sourceSelect.val(sf.source);
         if (sf.source === 5 || sf.source === 6) {
-            $formatSelect.show().val(sf.formatIndex);
+            $fmtRow.show();
+            $formatSelect.val(sf.formatIndex);
         } else {
-            $formatSelect.hide();
+            $fmtRow.hide();
         }
         var dataValue = $(this).find(':selected').data('value');
         $valueDiv.find('.value').hide();
@@ -3960,8 +3964,9 @@ function buildSlotRow(i, ii) {
         }
     });
 
-    $row.append($hiddenType).append($sourceSelect).append($valueDiv).append($formatSelect);
-    return $row;
+    $row.append($hiddenType).append($sourceSelect).append($valueDiv);
+    var $wrapper = $('<div>').append($row).append($fmtRow);
+    return $wrapper;
 }
 
 // Build visibility row for a custom element card

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -3891,10 +3891,10 @@ function buildSlotRow(i, ii) {
     for (var fi = 0; fi < OSD.constants.CE_FORMATS.length; fi++) {
         formatHtml += '<option value="' + fi + '">' + OSD.constants.CE_FORMATS[fi].label + '</option>';
     }
-    var $formatSelect = $('<select>').addClass('ce-format-select').html(formatHtml);
+    const $formatSelect = $('<select>').addClass('ce-format-select').html(formatHtml);
 
     // Format row — shown only when source is GV (5) or LC (6)
-    var $fmtRow = $('<div>').addClass('ce-slot-row').hide().append($formatSelect);
+    const $fmtRow = $('<div>').addClass('ce-slot-row').hide().append($formatSelect);
 
     // Forward bridge: visible source/format → hidden type
     function updateHiddenType() {


### PR DESCRIPTION
## Summary

- **Bug 1 (overflow on narrow screens with HD OSD):** Removed `width: auto !important; flex-shrink: 0` from `.ce-source-select` and `.ce-format-select`, which was preventing the slot rows from fitting in the narrow side panels of HD OSD types (HDZero, DJI HD, etc.)
- **Bug 2 (LC condition driver selector missing in HD mode):** Moved the format select into a dedicated sub-row (`$fmtRow`) that appears only when source is GV or LC, freeing the main row to show the LC/GV driver selector at a usable width in all OSD modes
- **Responsive improvement:** Added `@media (max-width: 1439px)` rule reducing `content_wrapper` padding from 20px to 10px, giving each side panel ~10px more width on narrower screens
- **Wide-screen improvement:** Added `max-width: 300px` to `.osd_group` to prevent card content rows from stretching excessively at 1920px+

## Test plan

- [ ] At 1366×768 with HD OSD (HDZero/DJI/Avatar/BFHDCompat): slot rows fit within side panels without overflow
- [ ] HD OSD mode: LC condition driver selector dropdown is visible
- [ ] PAL/NTSC mode: LC condition driver selector still visible (no regression)
- [ ] Selecting GV or LC as source shows the format sub-row; other sources hide it
- [ ] At 1920×1080: card content rows are capped at a reasonable width, not stretching edge-to-edge
- [ ] At <1440px width: side panels are slightly wider due to reduced padding