### PR TITLE
fix(mixer): remove phantom servo from output mapping

### DIFF
--- a/js/servoMixerRuleCollection.js
+++ b/js/servoMixerRuleCollection.js
@@ -119,25 +119,13 @@ var ServoMixerRuleCollection = function () {
     };
 
     self.getUsedServoIndexes = function () {
-        let out = [];
+        let out = new Set();
 
-        for (let ruleIndex in data) {
-            if (data.hasOwnProperty(ruleIndex)) {
-                let rule = data[ruleIndex];
-                out.push(rule.getTarget());
-            }
-        }
-        for (let ruleIndex in inactiveData) {
-            if (inactiveData.hasOwnProperty(ruleIndex)) {
-                let rule = inactiveData[ruleIndex];
-                out.push(rule.getTarget());
-            }
-        }
+        data.forEach(rule => {
+            if (rule.isUsed()) out.add(rule.getTarget());
+        });
 
-
-        let minIndex = Math.min(...out);
-        let maxIndex = Math.max(...out);
-        return Array.from({ length: maxIndex - minIndex + 1 }, (_, index) => minIndex + index);
+        return Array.from(out).sort((a, b) => a - b);
     }
 
     self.getNextUnusedIndex = function() {


### PR DESCRIPTION
## Summary

`getUsedServoIndexes()` in `servoMixerRuleCollection.js` produced phantom servo entries in the Output Mapping table. When only Servo 1 was configured in profile 1, the output mapping would show both **Servo 0** and **Servo 1**.

## Root Cause

Two bugs in `getUsedServoIndexes()`:

1. **Profile-2 contamination** — the function iterated both `data` (profile 1) and `inactiveData` (profile 2). If profile 2 had a servo at index 0, target=0 was included even though no profile-1 rule used it. The Servo Mixer table only shows profile 1 rules, so this servo 0 appeared phantom.

2. **Range fill** — the function returned a filled `[min..max]` range rather than the exact configured targets. With non-contiguous targets (e.g., 1 and 4), this invented phantom servos 2 and 3.

## Changes

- `js/servoMixerRuleCollection.js`: Rewrote `getUsedServoIndexes()` to use a `Set` of `isUsed()` targets from `data` (active profile) only, returning them sorted. Removed `inactiveData` iteration and range fill.

## Testing

- Verified live in running configurator connected to ORBITH743 FC
- Before fix: output mapping showed Servo 0 and Servo 1 with only one servo rule (target=1)
- After fix: output mapping shows only Servo 1
- Code review performed — all edge cases confirmed correct (empty data, single rule, non-contiguous targets, duplicate targets, all-zero-rate rules after inflate)

## Notes

Documentation not needed (bug fix).