### PR TITLE
Fix console errors when running from source in development

### DIFF
--- a/js/appUpdater.js
+++ b/js/appUpdater.js
@@ -16,8 +16,14 @@ appUpdater.checkRelease = function (currVersion) {
         let newVersion = releaseData.tag_name;
         let newPrerelase = releaseData.prerelease;
 
-        if (newPrerelase == false && semver.gt(newVersion, currVersion)) {
-            
+        let updateAvailable = false;
+        try {
+            updateAvailable = !newPrerelase && semver.gt(newVersion, currVersion);
+        } catch (_) {
+            // Non-semver version string (e.g. untagged dev builds) — skip update check
+        }
+
+        if (updateAvailable) {
             window.electronAPI.appGetVersion().then(currentVersion => {
                 GUI.log(newVersion, currentVersion);
                 GUI.log(currVersion);

--- a/tabs/search.js
+++ b/tabs/search.js
@@ -6,6 +6,9 @@ import i18n from './../js/localization';
 const searchTab = { };
 
 
+// Tabs that have no corresponding .js file and must be skipped during JS indexing.
+const jslessTab = new Set(["debug_trace", "options"]);
+
 const tabNames = [
  "adjustments",
  "advanced_tuning",
@@ -140,9 +143,11 @@ const tabNames = [
 
 
   searchTab.indexTab =  async function indexTab(tabName) {
-    import(`./${tabName}.js?raw`).then(({default: javascript}) => {
-        this.geti18nJs(tabName, javascript);
-    }).catch(error => console.error(`Failed to index JS for tab ${tabName}:`, error));;
+    if (!jslessTab.has(tabName)) {
+        import(`./${tabName}.js?raw`).then(({default: javascript}) => {
+            this.geti18nJs(tabName, javascript);
+        }).catch(error => console.error(`Failed to index JS for tab ${tabName}:`, error));
+    }
 
     import(`./${tabName}.html?raw`).then(({default: html}) => {
         this.geti18nHTML(tabName, html);


### PR DESCRIPTION
## Summary

Eliminates two spurious console errors that appear every time the configurator is run from an untagged source checkout.

## Changes

**`tabs/search.js`** — Add `jslessTab` exclusion set for tabs that have no `.js` file (`debug_trace`, `options`). Their JS import is now skipped; HTML indexing still runs normally, so search results for those tabs are unaffected.

**`js/appUpdater.js`** — Wrap the `semver.gt()` comparison in a try/catch so builds with non-semver version strings (e.g. `untagged-<hash>` from git-describe) silently skip the update check instead of throwing an uncaught TypeError.

## Errors eliminated

```
search.js:145 Failed to index JS for tab debug_trace: Error: Unknown variable dynamic import: ./debug_trace.js
search.js:145 Failed to index JS for tab options: Error: Unknown variable dynamic import: ./options.js
Uncaught TypeError: Invalid Version: untagged-58a74ccc453672f866b7  (appUpdater.js)
```

## Testing

Verified in development mode (`yarn start`) — both errors no longer appear in DevTools console. Update check still works correctly for release builds with valid semver versions.