### PR TITLE
OSD custom elements: add 16-bit icon support

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -3793,7 +3793,8 @@ function openIconPicker($targetInput) {
     var $grid = $('<div>').addClass('ce-icon-picker-grid');
     var currentVal = parseInt($targetInput.val()) || 0;
 
-    for (var c = 1; c <= 255; c++) {
+    var maxFontChar = (FONT.data && FONT.data.character_image_urls.length > 0) ? FONT.data.character_image_urls.length - 1 : 511;
+    for (var c = 1; c <= maxFontChar; c++) {
         var url = (FONT.data && FONT.data.character_image_urls[c]) ? FONT.draw(c) : '';
         var $tile = $('<div>').addClass('ce-icon-picker-tile')
             .attr('data-char', c)
@@ -3919,7 +3920,7 @@ function buildSlotRow(i, ii) {
     $formatSelect.on('change', updateHiddenType);
 
     // Icon picker: hidden input + clickable preview button
-    var $icoInput = $('<input>').addClass('value').addClass('ico').attr('type', 'hidden').attr('min', 1).attr('max', 255);
+    var $icoInput = $('<input>').addClass('value').addClass('ico').attr('type', 'hidden').attr('min', 1).attr('max', 65535);
     var $icoBtn = $('<div>').addClass('value ico ce-ico-picker-btn').hide()
         .append($('<img>').addClass('ce-ico-preview'))
         .append($('<span>').addClass('ce-ico-label'));
@@ -4372,7 +4373,7 @@ function customElementNormaliseRow(row){
                 valueCell.find('.text').val(valueCell.find('.text').val().replace(/[^A-Z0-9!.\* ]/g, ""));
                 break;
             case 2:
-                valueCell.find('.ico').val(valueCell.find('.ico').val() > 255 ? 255 : valueCell.find('.ico').val());
+                valueCell.find('.ico').val(valueCell.find('.ico').val() > 65535 ? 65535 : valueCell.find('.ico').val());
                 valueCell.find('.ico').val((valueCell.find('.ico').val() != '' && valueCell.find('.ico').val() < 1 )? 1 : valueCell.find('.ico').val());
         }
     }

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -3793,8 +3793,8 @@ function openIconPicker($targetInput) {
     var $grid = $('<div>').addClass('ce-icon-picker-grid');
     var currentVal = parseInt($targetInput.val()) || 0;
 
-    var maxFontChar = (FONT.data && FONT.data.character_image_urls.length > 0) ? FONT.data.character_image_urls.length - 1 : 511;
-    for (var c = 1; c <= maxFontChar; c++) {
+    let maxFontChar = (FONT.data && FONT.data.character_image_urls.length > 0) ? FONT.data.character_image_urls.length - 1 : 511;
+    for (let c = 1; c <= maxFontChar; c++) {
         var url = (FONT.data && FONT.data.character_image_urls[c]) ? FONT.draw(c) : '';
         var $tile = $('<div>').addClass('ce-icon-picker-tile')
             .attr('data-char', c)
@@ -3920,7 +3920,7 @@ function buildSlotRow(i, ii) {
     $formatSelect.on('change', updateHiddenType);
 
     // Icon picker: hidden input + clickable preview button
-    var $icoInput = $('<input>').addClass('value').addClass('ico').attr('type', 'hidden').attr('min', 1).attr('max', 65535);
+    let $icoInput = $('<input>').addClass('value').addClass('ico').attr('type', 'hidden').attr('min', 1).attr('max', 65535);
     var $icoBtn = $('<div>').addClass('value ico ce-ico-picker-btn').hide()
         .append($('<img>').addClass('ce-ico-preview'))
         .append($('<span>').addClass('ce-ico-label'));
@@ -4373,7 +4373,7 @@ function customElementNormaliseRow(row){
                 valueCell.find('.text').val(valueCell.find('.text').val().replace(/[^A-Z0-9!.\* ]/g, ""));
                 break;
             case 2:
-                valueCell.find('.ico').val(valueCell.find('.ico').val() > 65535 ? 65535 : valueCell.find('.ico').val());
+                valueCell.find('.ico').val(Math.min(valueCell.find('.ico').val(), 65535));
                 valueCell.find('.ico').val((valueCell.find('.ico').val() != '' && valueCell.find('.ico').val() < 1 )? 1 : valueCell.find('.ico').val());
         }
     }


### PR DESCRIPTION
The icon input for static custom element icons was restricted to values 0–255. This change raises the limit to 65535 and updates the icon picker to display the full font character set (up to 512 characters), so users can select and save 16-bit icon values that the firmware
 

<img width="1507" height="860" alt="image" src="https://github.com/user-attachments/assets/1a298e09-0081-467c-9a09-771bec423903" />

Inav PR: https://github.com/iNavFlight/inav/pull/11608
