### PR TITLE
fix: remove duplicate event handlers introduced by fdd4fcb8

### DIFF
--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -361,83 +361,6 @@ $(function() {
         updateToggleAllButton();
 
 
-        // Accordion Navigation Groups
-        $('.group-header').on('click', function(e) {
-            e.stopPropagation(); // Prevent triggering tab click
-            const header = $(this);
-            const items = header.next('.group-items');
-
-            // Toggle this group
-            header.toggleClass('active');
-            items.toggleClass('expanded');
-
-            // Update aria-expanded for accessibility
-            header.attr('aria-expanded', header.hasClass('active'));
-
-            // Update the expand/collapse all button state
-            updateToggleAllButton();
-        });
-
-        // Keyboard accessibility for accordion headers
-        $('.group-header').on('keydown', function(e) {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                $(this).trigger('click');
-            }
-        });
-
-        function updateToggleAllButton() {
-            const allExpanded = $('.nav-group .group-header.active').length === $('.nav-group .group-header').length;
-            const $expandIcon = $('#toggleAllGroups .expand-icon');
-            const $collapseIcon = $('#toggleAllGroups .collapse-icon');
-            const $toggleText = $('#toggleAllGroups .toggle-text');
-
-            if (allExpanded) {
-                $expandIcon.hide();
-                $collapseIcon.show();
-                $toggleText.attr('data-i18n', 'navCollapseAll');
-                $toggleText.text(i18n.getMessage('navCollapseAll'));
-            } else {
-                $expandIcon.show();
-                $collapseIcon.hide();
-                $toggleText.attr('data-i18n', 'navExpandAll');
-                $toggleText.text(i18n.getMessage('navExpandAll'));
-            }
-        }
-
-        // Expand/Collapse All Toggle
-        $('#toggleAllGroups').on('click', function(e) {
-            e.preventDefault();
-            const allExpanded = $('.nav-group .group-header.active').length === $('.nav-group .group-header').length;
-
-            if (allExpanded) {
-                // Collapse all except first
-                $('.nav-group .group-header').removeClass('active').attr('aria-expanded', 'false');
-                $('.nav-group .group-items').removeClass('expanded');
-                $('#tabs ul.mode-connected .nav-group:first-child .group-header').addClass('active').attr('aria-expanded', 'true');
-                $('#tabs ul.mode-connected .nav-group:first-child .group-items').addClass('expanded');
-                store.set('expand_all_groups', false);
-            } else {
-                // Expand all
-                $('.nav-group .group-header').addClass('active').attr('aria-expanded', 'true');
-                $('.nav-group .group-items').addClass('expanded');
-                store.set('expand_all_groups', true);
-            }
-
-            updateToggleAllButton();
-        });
-
-        // Initialize: apply saved expand all preference or expand first group by default
-        if (store.get('expand_all_groups', false)) {
-            $('.nav-group .group-header').addClass('active').attr('aria-expanded', 'true');
-            $('.nav-group .group-items').addClass('expanded');
-        } else {
-            $('#tabs ul.mode-connected .nav-group:first-child .group-header').addClass('active').attr('aria-expanded', 'true');
-            $('#tabs ul.mode-connected .nav-group:first-child .group-items').addClass('expanded');
-        }
-
-        updateToggleAllButton();
-
         // options
         $('#options').on('click', function() {
             var el = $(this);
@@ -466,15 +389,6 @@ $(function() {
                     $('div.notifications input').on('change', function () {
                         var check = $(this).is(':checked');
                         store.set('update_notify', check);
-                    });
-                    
-                    if (store.get('disable_3d_acceleration', false)) {
-                        $('div.disable_3d_acceleration input').prop('checked', true);
-                    }
-
-                     $('div.disable_3d_acceleration input').on('change', function () {
-                        var check = $(this).is(':checked');
-                        store.set('disable_3d_acceleration', check);
                     });
 
                     if (store.get('disable_3d_acceleration', false)) {


### PR DESCRIPTION
## Summary

- Commit `fdd4fcb8` re-added the accordion navigation block and the `disable_3d_acceleration` options handler that were already present in `configurator_main.js`, creating duplicate registrations of each
- The doubled accordion handlers caused every group-header click to toggle `.active` twice (on then immediately off), making it impossible to expand or collapse navigation groups
- The doubled `disable_3d_acceleration` handlers caused the change event to fire twice and the checkbox state to be initialised twice on options open

## Changes

- Remove duplicate accordion `.group-header` click/keydown handlers, `updateToggleAllButton()`, `#toggleAllGroups` click handler, and initialisation block (77 lines)
- Remove duplicate `disable_3d_acceleration` checkbox init and change handler (9 lines)

## Test plan

- [x] Navigation groups expand and collapse on single click
- [x] "Expand All / Collapse All" toggle works correctly
- [x] Options dialog `disable_3d_acceleration` checkbox loads and saves correctly
- [x] No regressions in other tab navigation behaviour