### PR TITLE
fix(presets): remove nav_fw_launch_climb_angle override from airplane presets

### DIFF
--- a/js/defaults_dialog_entries.js
+++ b/js/defaults_dialog_entries.js
@@ -582,10 +582,6 @@ var defaultsDialogData = [
                 key: "nav_fw_launch_max_altitude",
                 value: 5000
             },
-            {
-                key: "nav_fw_launch_climb_angle",
-                value: 25
-            },
             /*
              * TPA
              */
@@ -806,10 +802,6 @@ var defaultsDialogData = [
             {
                 key: "nav_fw_launch_max_altitude",
                 value: 5000
-            },
-            {
-                key: "nav_fw_launch_climb_angle",
-                value: 25
             },
             /*
              * TPA


### PR DESCRIPTION
## Summary

- Removes `nav_fw_launch_climb_angle: 25` from both the **Airplane with a Tail** and **Airplane without a Tail** presets
- The override was introduced in commit 341f2bb9 during a merge conflict resolution with no documented rationale
- The firmware default is 18°; this preset silently clobbered it with 25° for all users applying either airplane preset

## Background

Bisecting the history of `js/defaults_dialog_entries.js` showed that `nav_fw_launch_climb_angle` was not present in the pre-merge wizard branch. It appeared only in the merge result of 341f2bb9 (`Merge branch 'master' into dzikuvx-wizard`), introduced alongside a full restructure of the airplane preset settings during conflict resolution. No rationale is documented in the commit or surrounding discussion.

## Review request: other launch parameters

While investigating this, I noticed that three other `nav_fw_launch_*` overrides were also introduced at the same time and remain in both presets. These may or may not be intentional overrides of firmware defaults — please review:

| Setting | Airplane with a Tail | Airplane without a Tail |
|---|---|---|
| `nav_fw_launch_max_angle` | 45° | 75° |
| `nav_fw_launch_motor_delay` | 100 ms | 100 ms |
| `nav_fw_launch_max_altitude` | 5000 cm | 5000 cm |

If these also lack rationale and override sensible firmware defaults, they should be removed in a follow-up. Leaving them in scope for a separate decision so this PR stays minimal.

## Test plan

- [x] Apply "Airplane with a Tail" preset — confirm `nav_fw_launch_climb_angle` is no longer set (firmware default 18° applies)
- [x] Apply "Airplane without a Tail" preset — same check
- [x] Confirm no other preset settings changed