### PR TITLE
Fix macOS x64 CI OOM during webpack bundle build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,8 @@ jobs:
             timeout_minutes: 10
             on_retry_command: rm -rfv node_modules
         - name: Build MacOS x64
+          env:
+            NODE_OPTIONS: --max-old-space-size=4096
           run: yarn run make -- --arch="x64"
         - name: Upload MacOS x64 zip
           uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem

The `build-mac` job on `macos-15-intel` fails with a JavaScript heap out-of-memory error during the webpack bundle step:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

The Intel runner hits the default 2GB V8 heap limit during `JsonParse` of the webpack bundle. The arm64 runner on `macos-15` (Apple Silicon) succeeds because it has more available memory.

## Fix

Set `NODE_OPTIONS: --max-old-space-size=4096` on the "Build MacOS x64" step to raise the heap limit to 4GB before the build starts.

## Target branch

`maintenance-9.x`