### PR TITLE
fix(cli): get mouseover handler via textcomplete Completer, not jQuery internals

### DIFF
--- a/js/CliAutoComplete.js
+++ b/js/CliAutoComplete.js
@@ -286,23 +286,24 @@ CliAutoComplete._initTextcomplete = function() {
 
         const textCompleteDropDownElement = $('.textcomplete-dropdown');
 
+        // savedMouseoverItemHandler is closure-local so it resets to null each time
+        // _initTextcomplete() is called, which happens after every cleanup()/rebuild cycle.
         if (!savedMouseoverItemHandler) {
-            // save the original 'mouseover' handeler
-            try {
-                savedMouseoverItemHandler = $._data(textCompleteDropDownElement[0], 'events').mouseover[0].handler;
-            } catch (error) {
-                console.log(error);
-            }
+            // _onMouseover is the library's private item-highlight handler. There is no
+            // public API to retrieve it, so we bind it directly from the Completer object
+            // stored by the plugin under the standard $textarea.data('textComplete') key.
+            const completer = $textarea.data('textComplete');
+            savedMouseoverItemHandler = $.proxy(completer.dropdown._onMouseover, completer.dropdown);
 
             if (savedMouseoverItemHandler) {
                 textCompleteDropDownElement
                 .off('mouseover') // initially disable it
-                .off('mousemove') // avoid `mousemove` accumulation if previous show did not trigger `mousemove`
-                .on('mousemove', '.textcomplete-item', function(e) {
+                .off('mousemove.cliAutocomplete') // avoid accumulation if previous show did not trigger `mousemove`
+                .on('mousemove.cliAutocomplete', '.textcomplete-item', function(e) {
                         // the mouse has moved so reenable `mouseover`
                     $(this).parent()
-                    .off('mousemove')
-                    .on('mouseover', '.textcomplete-item', savedMouseoverItemHandler);
+                    .off('mousemove.cliAutocomplete')
+                    .on('mouseover.cliAutocomplete', '.textcomplete-item', savedMouseoverItemHandler);
 
                     // trigger the mouseover handler to select the item under the cursor
                     savedMouseoverItemHandler(e);


### PR DESCRIPTION
## Summary

Fixes `TypeError: Cannot read properties of undefined (reading '0')` logged to the
DevTools console when the CLI autocomplete dropdown appears.

The `textComplete:show` handler was retrieving jquery-textcomplete's internal mouseover
handler via `$._data(el, 'events').mouseover[0].handler` — jQuery's undocumented private
event cache. This access fails when the internal structure doesn't match (different jQuery
versions, different textcomplete initialization order), causing the TypeError and leaving
the suppress-hover-on-show feature silently broken.

## Changes

- Replace `$._data(el, 'events').mouseover[0].handler` with `$.proxy(completer.dropdown._onMouseover, completer.dropdown)`, accessing the handler through the Completer object stored by the plugin via the public `$textarea.data('textComplete')` API
- Namespace CLI-owned `mousemove` and `mouseover` handlers as `.cliAutocomplete` so they are distinct from textcomplete's own namespaced events

## Testing

- Connected to SITL, opened CLI tab, waited for autocomplete cache to build
- Typed `se` in CLI input and pressed Tab — autocomplete dropdown appeared with correct suggestions (serial, serialpassthrough, servo, set)
- Confirmed DevTools console showed zero errors or warnings across multiple dropdown open/close cycles
- Verified dropdown event state: `mouseover: false` (suppressed as intended), `mousemove: true` (re-enable hook armed), `mousedown: true` (textcomplete click handler intact)

## Code Review

Reviewed with inav-code-review — initial pass flagged the unnecessary `completer.dropdown` null guard (removed) and the un-namespaced handler re-addition (fixed with `.cliAutocomplete` namespace). No critical issues in final version.

## Documentation

No user-facing documentation changes required (bug fix, no behavior change visible to users).