### PR TITLE
feat(mixer): add buzzer to unified PWM/PINIO/LED output selection

### DIFF
--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -177,12 +177,16 @@ var OutputMappingCollection = function () {
             }
         }
 
-        // Pre-assign BEEPER outputs — explicitly overridden by user, takes precedence over flag-based assignment
+        // Pre-assign BEEPER outputs — explicitly overridden by user, takes precedence over flag-based assignment.
+        // A timer's mode applies to every pad sharing it, but only one pad can ever be the real
+        // beeper (firmware wires up just the first match), so only that first pad is pre-assigned here.
+        let beeperTimerClaimed = {};
         for (let i = 0; i < data.length; i++) {
             let timerId = data[i]['timerId'];
             let mode = timerOverrides[timerId] || self.TIMER_OUTPUT_MODE_AUTO;
-            if (mode === self.TIMER_OUTPUT_MODE_BEEPER) {
+            if (mode === self.TIMER_OUTPUT_MODE_BEEPER && !beeperTimerClaimed[timerId]) {
                 timerMap[i] = OUTPUT_TYPE_BEEPER;
+                beeperTimerClaimed[timerId] = true;
             }
         }
 
@@ -272,24 +276,11 @@ var OutputMappingCollection = function () {
         data.push(element);
     };
 
+    // Counts every pad from the first real output through the end of data —
+    // not just currently-flagged ones, since a BEEPER timer's sibling pads are
+    // legitimately flagless (see getTimerMap()) but still occupy a real column.
     self.getOutputCount = function () {
-        let retVal = 0;
-
-        for (let i = 0; i < data.length; i++) {
-            let flags = data[i]['usageFlags'];
-            if (
-                BitHelper.bit_check(flags, TIM_USE_MOTOR) ||
-                BitHelper.bit_check(flags, TIM_USE_SERVO) ||
-                BitHelper.bit_check(flags, TIM_USE_LED) ||
-                BitHelper.bit_check(flags, TIM_USE_BEEPER) ||
-                BitHelper.bit_check(flags, TIM_USE_PINIO) ||
-                data[i]['specialLabels'] >= SPECIAL_LABEL_PINIO_BASE
-            ) {
-                retVal++;
-            };
-        }
-
-        return retVal;
+        return data.length - getFirstOutputOffset();
     }
 
     function getFirstOutputOffset() {

--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -106,8 +106,8 @@ var OutputMappingCollection = function () {
         return colorTable[timerIndex % colorTable.length];
     }
 
-    self.isLedPin = function(timer) {
-        return data[timer].specialLabels == SPECIAL_LABEL_LED;
+    self.isLedPin = function(outputIndex) {
+        return BitHelper.bit_check(data[outputIndex]['usageFlags'], TIM_USE_LED);
     }
 
     self.isBeeperPin = function(outputIndex) {
@@ -187,6 +187,16 @@ var OutputMappingCollection = function () {
             if (mode === self.TIMER_OUTPUT_MODE_BEEPER && !beeperTimerClaimed[timerId]) {
                 timerMap[i] = OUTPUT_TYPE_BEEPER;
                 beeperTimerClaimed[timerId] = true;
+            }
+        }
+
+        let ledTimerClaimed = {};
+        for (let i = 0; i < data.length; i++) {
+            let timerId = data[i]['timerId'];
+            let mode = timerOverrides[timerId] || self.TIMER_OUTPUT_MODE_AUTO;
+            if (mode === self.TIMER_OUTPUT_MODE_LED && !ledTimerClaimed[timerId]) {
+                timerMap[i] = OUTPUT_TYPE_LED;
+                ledTimerClaimed[timerId] = true;
             }
         }
 

--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -180,6 +180,8 @@ var OutputMappingCollection = function () {
                     servosToGo--;
                 } else if (!isDedicated && BitHelper.bit_check(flags, TIM_USE_LED)) {
                     timerMap[i] = OUTPUT_TYPE_LED;
+                } else if (!isDedicated && BitHelper.bit_check(flags, TIM_USE_BEEPER)) {
+                    timerMap[i] = OUTPUT_TYPE_BEEPER;
                 }
             }
         }
@@ -246,6 +248,7 @@ var OutputMappingCollection = function () {
                 BitHelper.bit_check(flags, TIM_USE_MOTOR) ||
                 BitHelper.bit_check(flags, TIM_USE_SERVO) ||
                 BitHelper.bit_check(flags, TIM_USE_LED) ||
+                BitHelper.bit_check(flags, TIM_USE_BEEPER) ||
                 BitHelper.bit_check(flags, TIM_USE_PINIO) ||
                 data[i]['specialLabels'] >= SPECIAL_LABEL_PINIO_BASE
             ) {
@@ -262,6 +265,7 @@ var OutputMappingCollection = function () {
                 BitHelper.bit_check(data[i]['usageFlags'], TIM_USE_MOTOR) ||
                 BitHelper.bit_check(data[i]['usageFlags'], TIM_USE_SERVO) ||
                 BitHelper.bit_check(data[i]['usageFlags'], TIM_USE_LED) ||
+                BitHelper.bit_check(data[i]['usageFlags'], TIM_USE_BEEPER) ||
                 BitHelper.bit_check(data[i]['usageFlags'], TIM_USE_PINIO) ||
                 data[i]['specialLabels'] >= SPECIAL_LABEL_PINIO_BASE
             ) {

--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -43,6 +43,7 @@ var OutputMappingCollection = function () {
     self.TIMER_OUTPUT_MODE_SERVOS = 2;
     self.TIMER_OUTPUT_MODE_LED = 3;
     self.TIMER_OUTPUT_MODE_PINIO = 4;
+    self.TIMER_OUTPUT_MODE_BEEPER = 5;
 
     self.flushTimerOverrides = function() {
         timerOverrides = {};
@@ -76,13 +77,13 @@ var OutputMappingCollection = function () {
         for (let entry of directAssignments) {
             let displayIndex = entry.outputIndex - offset;
             if (displayIndex < 0 || displayIndex >= outputCount) continue;
-            if (entry.type === 1) {
+            if (entry.type === TIM_USE_MOTOR) {
                 outputMap[displayIndex] = 'Motor ' + entry.number;
-            } else if (entry.type === 2) {
+            } else if (entry.type === TIM_USE_SERVO) {
                 outputMap[displayIndex] = 'Servo ' + entry.number;
-            } else if (entry.type === 3) {
-                outputMap[displayIndex] = 'Led';
-            } else if (entry.type === 4) {
+            } else if (entry.type === TIM_USE_BEEPER) {
+                outputMap[displayIndex] = 'Buzzer';
+            } else if (entry.type === TIM_USE_PINIO) {
                 outputMap[displayIndex] = 'USER' + entry.number;
             }
         }

--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -114,7 +114,7 @@ var OutputMappingCollection = function () {
         return BitHelper.bit_check(data[outputIndex]['usageFlags'], TIM_USE_BEEPER);
     }
 
-    function isTimerDefaultFlag(timerId, flag) {
+    function isTimerDefault(timerId, flag) {
         let found = false;
         for (let i = 0; i < data.length; i++) {
             if (data[i]['timerId'] !== timerId) continue;
@@ -140,7 +140,7 @@ var OutputMappingCollection = function () {
 
     // Returns true when the timer's compile-time default assignment is BEEPER.
     self.isTimerDefaultBeeper = function(timerId) {
-        return isTimerDefaultFlag(timerId, TIM_USE_BEEPER);
+        return isTimerDefault(timerId, TIM_USE_BEEPER);
     }
 
     self.getOutputTimerColor = function (output) {

--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -116,9 +116,9 @@ var OutputMappingCollection = function () {
 
     function isTimerDefault(timerId, flag) {
         let found = false;
-        for (let i = 0; i < data.length; i++) {
-            if (data[i]['timerId'] !== timerId) continue;
-            let flags = data[i]['usageFlags'];
+        for (const entry of data) {
+            if (entry['timerId'] !== timerId) continue;
+            const flags = entry['usageFlags'];
             if (BitHelper.bit_check(flags, TIM_USE_MOTOR) || BitHelper.bit_check(flags, TIM_USE_SERVO)) return false;
             if (BitHelper.bit_check(flags, flag)) found = true;
         }
@@ -129,11 +129,11 @@ var OutputMappingCollection = function () {
     self.isTimerDefaultLed = function(timerId) {
         // LED can also be identified by specialLabels, so check both.
         let hasLed = false;
-        for (let i = 0; i < data.length; i++) {
-            if (data[i]['timerId'] !== timerId) continue;
-            let flags = data[i]['usageFlags'];
+        for (const entry of data) {
+            if (entry['timerId'] !== timerId) continue;
+            const flags = entry['usageFlags'];
             if (BitHelper.bit_check(flags, TIM_USE_MOTOR) || BitHelper.bit_check(flags, TIM_USE_SERVO)) return false;
-            if (BitHelper.bit_check(flags, TIM_USE_LED) || data[i]['specialLabels'] === SPECIAL_LABEL_LED) hasLed = true;
+            if (BitHelper.bit_check(flags, TIM_USE_LED) || entry['specialLabels'] === SPECIAL_LABEL_LED) hasLed = true;
         }
         return hasLed;
     }

--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -110,6 +110,39 @@ var OutputMappingCollection = function () {
         return data[timer].specialLabels == SPECIAL_LABEL_LED;
     }
 
+    self.isBeeperPin = function(outputIndex) {
+        return BitHelper.bit_check(data[outputIndex]['usageFlags'], TIM_USE_BEEPER);
+    }
+
+    function isTimerDefaultFlag(timerId, flag) {
+        let found = false;
+        for (let i = 0; i < data.length; i++) {
+            if (data[i]['timerId'] !== timerId) continue;
+            let flags = data[i]['usageFlags'];
+            if (BitHelper.bit_check(flags, TIM_USE_MOTOR) || BitHelper.bit_check(flags, TIM_USE_SERVO)) return false;
+            if (BitHelper.bit_check(flags, flag)) found = true;
+        }
+        return found;
+    }
+
+    // Returns true when the timer's compile-time default assignment is LED.
+    self.isTimerDefaultLed = function(timerId) {
+        // LED can also be identified by specialLabels, so check both.
+        let hasLed = false;
+        for (let i = 0; i < data.length; i++) {
+            if (data[i]['timerId'] !== timerId) continue;
+            let flags = data[i]['usageFlags'];
+            if (BitHelper.bit_check(flags, TIM_USE_MOTOR) || BitHelper.bit_check(flags, TIM_USE_SERVO)) return false;
+            if (BitHelper.bit_check(flags, TIM_USE_LED) || data[i]['specialLabels'] === SPECIAL_LABEL_LED) hasLed = true;
+        }
+        return hasLed;
+    }
+
+    // Returns true when the timer's compile-time default assignment is BEEPER.
+    self.isTimerDefaultBeeper = function(timerId) {
+        return isTimerDefaultFlag(timerId, TIM_USE_BEEPER);
+    }
+
     self.getOutputTimerColor = function (output) {
         let timerId = self.getTimerId(output);
 

--- a/js/outputMapping.js
+++ b/js/outputMapping.js
@@ -30,10 +30,11 @@ var OutputMappingCollection = function () {
     const TIM_USE_BEEPER = 25;
     const TIM_USE_PINIO = 26;
 
-    const OUTPUT_TYPE_MOTOR = 0;
-    const OUTPUT_TYPE_SERVO = 1;
-    const OUTPUT_TYPE_LED   = 2;
-    const OUTPUT_TYPE_PINIO = 3;
+    const OUTPUT_TYPE_MOTOR  = 0;
+    const OUTPUT_TYPE_SERVO  = 1;
+    const OUTPUT_TYPE_LED    = 2;
+    const OUTPUT_TYPE_PINIO  = 3;
+    const OUTPUT_TYPE_BEEPER = 4;
 
     const SPECIAL_LABEL_LED = 1;
     const SPECIAL_LABEL_PINIO_BASE = 2;  // values 2..5 = USER1..USER4 (add channel index 0-3)
@@ -143,6 +144,15 @@ var OutputMappingCollection = function () {
             }
         }
 
+        // Pre-assign BEEPER outputs — explicitly overridden by user, takes precedence over flag-based assignment
+        for (let i = 0; i < data.length; i++) {
+            let timerId = data[i]['timerId'];
+            let mode = timerOverrides[timerId] || self.TIMER_OUTPUT_MODE_AUTO;
+            if (mode === self.TIMER_OUTPUT_MODE_BEEPER) {
+                timerMap[i] = OUTPUT_TYPE_BEEPER;
+            }
+        }
+
         // Two priority passes: dedicated outputs first, then auto.
         // Matches firmware pwmBuildTimerOutputList() behavior.
         for (let priority = 0; priority < 2; priority++) {
@@ -210,6 +220,8 @@ var OutputMappingCollection = function () {
                 outputMap[i] = "Led";
             } else if (assignment == OUTPUT_TYPE_PINIO) {
                 outputMap[i] = "USER" + (data[i + offset]['specialLabels'] - SPECIAL_LABEL_PINIO_BASE + 1);
+            } else if (assignment == OUTPUT_TYPE_BEEPER) {
+                outputMap[i] = "Buzzer";
             }
         }
 

--- a/js/tests/outputMapping.test.mjs
+++ b/js/tests/outputMapping.test.mjs
@@ -62,6 +62,19 @@ const TIMER_OUTPUT_MODE_AUTO    = 0;
 const TIMER_OUTPUT_MODE_MOTORS  = 1;
 const TIMER_OUTPUT_MODE_SERVOS  = 2;
 const TIMER_OUTPUT_MODE_LED     = 3;
+const TIMER_OUTPUT_MODE_BEEPER  = 5;
+
+// BEEPER/PINIO-specific constants (from outputMapping.js) — added to cover
+// getTimerMap()'s BEEPER pre-assignment de-dup and getOutputCount()'s
+// length-based (not flag-count-based) total, per PR #2654.
+const TIM_USE_BEEPER = 25;
+const TIM_USE_PINIO  = 26;
+
+const OUTPUT_TYPE_PINIO  = 3;
+const OUTPUT_TYPE_BEEPER = 4;
+
+const SPECIAL_LABEL_PINIO_BASE = 2;  // values >= 2 = USER1..USER4 (capacity available)
+const PIN_LABEL_NONE = 0;            // capacity exhausted: usageFlags has TIM_USE_PINIO but no specialLabels
 
 // ── Inline getTimerMap() from outputMapping.js ────────────────────────────────
 // This is the EXACT two-pass algorithm from js/outputMapping.js getTimerMap().
@@ -110,6 +123,113 @@ function getTimerMap(data, timerOverrides, motors, servos) {
     }
 
     return timerMap;
+}
+
+// ── Inline getTimerMap() extended with BEEPER/PINIO pre-assignment ──────────
+// This mirrors the FULL current js/outputMapping.js getTimerMap(), including
+// the two pre-assignment loops added for PR #2654:
+//
+//   1. PINIO pre-assignment: any pad whose specialLabels >= SPECIAL_LABEL_PINIO_BASE
+//      is unconditionally OUTPUT_TYPE_PINIO (firmware only assigns specialLabels
+//      when PINIO_COUNT capacity is available; when capacity is exhausted the
+//      companion firmware change leaves specialLabels at PIN_LABEL_NONE (0), so
+//      this pre-assignment loop intentionally does NOT match it).
+//   2. BEEPER pre-assignment: a timer set to TIMER_OUTPUT_MODE_BEEPER only ever
+//      wires up ONE real beeper (firmware wires just the first matching pad on
+//      that timer), so `beeperTimerClaimed` ensures only the first (lowest
+//      index) pad sharing that timerId gets OUTPUT_TYPE_BEEPER; sibling pads on
+//      the same timer are intentionally left unassigned here.
+//
+// Any changes to outputMapping.js's getTimerMap() must be reflected here.
+function getTimerMapWithBeeperPinio(data, timerOverrides, motors, servos) {
+    let timerMap = new Array(data.length).fill(null);
+    let motorsToGo = motors;
+    let servosToGo = servos;
+
+    // Pre-assign PINIO outputs — identified by specialLabels, not timer priority.
+    for (let i = 0; i < data.length; i++) {
+        if (data[i].specialLabels >= SPECIAL_LABEL_PINIO_BASE) {
+            timerMap[i] = OUTPUT_TYPE_PINIO;
+        }
+    }
+
+    // Pre-assign BEEPER outputs — only the first pad per timerId can be the
+    // real beeper; siblings on the same timer are intentionally skipped.
+    const beeperTimerClaimed = {};
+    for (let i = 0; i < data.length; i++) {
+        const timerId = data[i].timerId;
+        const mode = timerOverrides[timerId] !== undefined
+                        ? timerOverrides[timerId]
+                        : TIMER_OUTPUT_MODE_AUTO;
+        if (mode === TIMER_OUTPUT_MODE_BEEPER && !beeperTimerClaimed[timerId]) {
+            timerMap[i] = OUTPUT_TYPE_BEEPER;
+            beeperTimerClaimed[timerId] = true;
+        }
+    }
+
+    for (let priority = 0; priority < 2; priority++) {
+        const isDedicated = (priority === 0);
+
+        for (let i = 0; i < data.length; i++) {
+            if (timerMap[i] !== null) continue;
+
+            const flags   = data[i].usageFlags;
+            const timerId = data[i].timerId;
+            const mode    = timerOverrides[timerId] !== undefined
+                                ? timerOverrides[timerId]
+                                : TIMER_OUTPUT_MODE_AUTO;
+
+            if (!isDedicated && (mode === TIMER_OUTPUT_MODE_MOTORS || mode === TIMER_OUTPUT_MODE_SERVOS)) {
+                continue;
+            }
+
+            if (motorsToGo > 0
+                    && BitHelper.bit_check(flags, TIM_USE_MOTOR)
+                    && (isDedicated ? mode === TIMER_OUTPUT_MODE_MOTORS
+                                    : mode !== TIMER_OUTPUT_MODE_MOTORS)) {
+                timerMap[i] = OUTPUT_TYPE_MOTOR;
+                motorsToGo--;
+            } else if (servosToGo > 0
+                    && BitHelper.bit_check(flags, TIM_USE_SERVO)
+                    && (isDedicated ? mode === TIMER_OUTPUT_MODE_SERVOS
+                                    : mode !== TIMER_OUTPUT_MODE_SERVOS)) {
+                timerMap[i] = OUTPUT_TYPE_SERVO;
+                servosToGo--;
+            } else if (!isDedicated && BitHelper.bit_check(flags, TIM_USE_LED)) {
+                timerMap[i] = OUTPUT_TYPE_LED;
+            } else if (!isDedicated && BitHelper.bit_check(flags, TIM_USE_BEEPER)) {
+                timerMap[i] = OUTPUT_TYPE_BEEPER;
+            }
+        }
+    }
+
+    return timerMap;
+}
+
+// ── Inline getFirstOutputOffset() / getOutputCount() from outputMapping.js ──
+// getOutputCount() now returns data.length - getFirstOutputOffset() (a range,
+// not a count of flagged pads), since BEEPER-timer sibling pads are
+// legitimately flagless (or carry only TIM_USE_PINIO with no specialLabels
+// when PINIO capacity is exhausted) yet still occupy a real output column
+// that must not be dropped when real motor/servo outputs follow them.
+function getFirstOutputOffset(data) {
+    for (let i = 0; i < data.length; i++) {
+        if (
+            BitHelper.bit_check(data[i].usageFlags, TIM_USE_MOTOR) ||
+            BitHelper.bit_check(data[i].usageFlags, TIM_USE_SERVO) ||
+            BitHelper.bit_check(data[i].usageFlags, TIM_USE_LED) ||
+            BitHelper.bit_check(data[i].usageFlags, TIM_USE_BEEPER) ||
+            BitHelper.bit_check(data[i].usageFlags, TIM_USE_PINIO) ||
+            data[i].specialLabels >= SPECIAL_LABEL_PINIO_BASE
+        ) {
+            return i;
+        }
+    }
+    return 0;
+}
+
+function getOutputCount(data) {
+    return data.length - getFirstOutputOffset(data);
 }
 
 // ── buildOutputLabels: mirrors getOutputTable() numbering ────────────────────
@@ -745,6 +865,123 @@ runTest('Dedicated motors at S1+S2, auto at S3+S4: both agree Motor1=S1, Motor2=
         `JS: [${jsLabels}] != FW: [${fwLabels}]`);
     assert(jsLabels[0] === 'Motor 1', `S1 expected Motor 1, got ${jsLabels[0]}`);
     assert(jsLabels[1] === 'Motor 2', `S2 expected Motor 2, got ${jsLabels[1]}`);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-10: BEEPER pre-assignment — only the FIRST pad sharing a BEEPER-mode
+// timer becomes OUTPUT_TYPE_BEEPER. Firmware's beeperInit() only ever wires
+// up the first matching pad on a timer, so siblings must NOT be labeled
+// "Buzzer" too (regression for PR #2654).
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\nTC-10: BEEPER pre-assignment claims only the first pad per timer');
+
+runTest('BEEPER timer with 3 sibling pads: only first (lowest index) gets OUTPUT_TYPE_BEEPER', () => {
+    const outputs = [
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_BEEPER), timerId: 0 }, // true beeper pad
+        { usageFlags: 0, timerId: 0 },                                    // sibling 1
+        { usageFlags: 0, timerId: 0 },                                    // sibling 2
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_MOTOR), timerId: 1 },  // unrelated motor
+    ];
+    const overrides = { 0: TIMER_OUTPUT_MODE_BEEPER };
+    const map = getTimerMapWithBeeperPinio(outputs, overrides, 1, 0);
+    assert(map[0] === OUTPUT_TYPE_BEEPER, `index0 (first pad) expected OUTPUT_TYPE_BEEPER, got ${map[0]}`);
+    assert(map[1] !== OUTPUT_TYPE_BEEPER, `index1 (sibling) must NOT be OUTPUT_TYPE_BEEPER, got ${map[1]}`);
+    assert(map[2] !== OUTPUT_TYPE_BEEPER, `index2 (sibling) must NOT be OUTPUT_TYPE_BEEPER, got ${map[2]}`);
+    assert(map[3] === OUTPUT_TYPE_MOTOR, `index3 (unrelated) expected OUTPUT_TYPE_MOTOR, got ${map[3]}`);
+});
+
+runTest('BEEPER timer siblings not at array index 0: first pad SHARING that timerId claims BEEPER', () => {
+    // The unrelated motor pad at index0 belongs to a DIFFERENT timer (9).
+    // Among the pads sharing timerId 3 (indices 1,2,3), only the first
+    // (index1) should claim OUTPUT_TYPE_BEEPER — proving the claim is
+    // per-timerId, not simply "global array index 0".
+    const outputs = [
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_MOTOR), timerId: 9 }, // unrelated motor, different timer
+        { usageFlags: 0, timerId: 3 },                                   // first pad sharing BEEPER timer 3
+        { usageFlags: 0, timerId: 3 },                                   // sibling
+        { usageFlags: 0, timerId: 3 },                                   // sibling
+    ];
+    const overrides = { 3: TIMER_OUTPUT_MODE_BEEPER };
+    const map = getTimerMapWithBeeperPinio(outputs, overrides, 1, 0);
+    assert(map[0] === OUTPUT_TYPE_MOTOR, `index0 (different timer) expected OUTPUT_TYPE_MOTOR, got ${map[0]}`);
+    assert(map[1] === OUTPUT_TYPE_BEEPER, `index1 (first pad on timer 3) expected OUTPUT_TYPE_BEEPER, got ${map[1]}`);
+    assert(map[2] !== OUTPUT_TYPE_BEEPER, `index2 (sibling) must NOT be OUTPUT_TYPE_BEEPER, got ${map[2]}`);
+    assert(map[3] !== OUTPUT_TYPE_BEEPER, `index3 (sibling) must NOT be OUTPUT_TYPE_BEEPER, got ${map[3]}`);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-11: PINIO capacity-available sibling — a BEEPER-timer sibling pad
+// flagged TIM_USE_PINIO with specialLabels >= SPECIAL_LABEL_PINIO_BASE (i.e.
+// firmware had PINIO_COUNT capacity to spare) must get OUTPUT_TYPE_PINIO.
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\nTC-11: PINIO sibling with capacity available gets OUTPUT_TYPE_PINIO');
+
+runTest('BEEPER-timer sibling with TIM_USE_PINIO + specialLabels >= BASE gets OUTPUT_TYPE_PINIO', () => {
+    const outputs = [
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_BEEPER), timerId: 0 },                              // true beeper
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_PINIO), timerId: 0, specialLabels: SPECIAL_LABEL_PINIO_BASE }, // sibling, capacity available
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_MOTOR), timerId: 1 },
+    ];
+    const overrides = { 0: TIMER_OUTPUT_MODE_BEEPER };
+    const map = getTimerMapWithBeeperPinio(outputs, overrides, 1, 0);
+    assert(map[0] === OUTPUT_TYPE_BEEPER, `index0 expected OUTPUT_TYPE_BEEPER, got ${map[0]}`);
+    assert(map[1] === OUTPUT_TYPE_PINIO, `index1 (capacity-available sibling) expected OUTPUT_TYPE_PINIO, got ${map[1]}`);
+    assert(map[2] === OUTPUT_TYPE_MOTOR, `index2 expected OUTPUT_TYPE_MOTOR, got ${map[2]}`);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-12: PINIO capacity-EXHAUSTED sibling — the companion firmware change
+// leaves specialLabels at PIN_LABEL_NONE (0) when PINIO_COUNT capacity (max 4,
+// shared with target-defined PINIO pins) is exhausted, even though
+// usageFlags still carries TIM_USE_PINIO. That pad must stay UNASSIGNED
+// (neither OUTPUT_TYPE_PINIO nor OUTPUT_TYPE_BEEPER) — and must still be
+// counted by getOutputCount(), not silently dropped.
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\nTC-12: PINIO sibling with capacity exhausted stays unassigned but counted');
+
+runTest('BEEPER-timer sibling with TIM_USE_PINIO but specialLabels=PIN_LABEL_NONE stays unassigned', () => {
+    const outputs = [
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_MOTOR), timerId: 5 },                                  // index0: motor, defines offset
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_BEEPER), timerId: 0 },                                 // index1: true beeper
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_PINIO), timerId: 0, specialLabels: PIN_LABEL_NONE },   // index2: exhausted-capacity sibling
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_MOTOR), timerId: 6 },                                  // index3: motor
+    ];
+    const overrides = { 0: TIMER_OUTPUT_MODE_BEEPER };
+    const map = getTimerMapWithBeeperPinio(outputs, overrides, 2, 0);
+    assert(map[2] !== OUTPUT_TYPE_PINIO, `index2 (capacity-exhausted sibling) must NOT be OUTPUT_TYPE_PINIO, got ${map[2]}`);
+    assert(map[2] !== OUTPUT_TYPE_BEEPER, `index2 (capacity-exhausted sibling) must NOT be OUTPUT_TYPE_BEEPER, got ${map[2]}`);
+    assert(map[2] === null, `index2 (capacity-exhausted sibling) expected to stay unassigned (null), got ${map[2]}`);
+
+    // Not silently dropped: getOutputCount() must still include this pad in the total.
+    const count = getOutputCount(outputs);
+    assert(count === 4, `getOutputCount() expected 4 (all pads from offset 0), got ${count}`);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-13: getOutputCount() regression — a real motor/servo output that appears
+// AFTER a BEEPER timer's flagless/PINIO-flagged sibling pads must still be
+// counted. This is the actual regression an earlier code review caught: the
+// old flag-based counting silently dropped real outputs that came later in
+// the array once earlier siblings broke the flag-based tally.
+// ─────────────────────────────────────────────────────────────────────────────
+console.log('\nTC-13: getOutputCount() regression — real output after BEEPER siblings');
+
+runTest('Real servo AFTER flagless/PINIO-flagged BEEPER siblings is included in getOutputCount()', () => {
+    const outputs = [
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_BEEPER), timerId: 0 },                                // index0: true beeper (defines offset=0)
+        { usageFlags: 0, timerId: 0 },                                                                    // index1: flagless sibling
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_PINIO), timerId: 0, specialLabels: PIN_LABEL_NONE },  // index2: capacity-exhausted sibling
+        { usageFlags: BitHelper.bit_set(0, TIM_USE_SERVO), timerId: 7 },                                 // index3: REAL servo, after the siblings
+    ];
+    const overrides = { 0: TIMER_OUTPUT_MODE_BEEPER };
+
+    const count = getOutputCount(outputs);
+    assert(count === 4, `getOutputCount() expected 4 (all pads from first real output onward), got ${count}`);
+
+    // And the real servo must actually be reachable/assigned — not lost due
+    // to an undercounted range.
+    const map = getTimerMapWithBeeperPinio(outputs, overrides, 0, 1);
+    assert(map[3] === OUTPUT_TYPE_SERVO, `index3 (real servo after siblings) expected OUTPUT_TYPE_SERVO, got ${map[3]}`);
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -43,13 +43,6 @@
                     </div>
                 </div>
             
-                <div class="platform-type gui_box grey">
-                    <div class="gui_box_titlebar">
-                        <div class="spacer_box_title" data-i18n="timerOutputs"></div>
-                    </div>
-                    <div class="spacer_box" id="timerOutputsList" style="padding: 0; width: calc(100% - 12px)"></div>
-                </div>
-
             </div>
             <div class="rightWrapper">
                 <div class="platform-type gui_box grey">

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -97,6 +97,9 @@
                 <div class="spacer_box_title" data-i18n="mappingTableTitle"></div>
             </div>
             <table class="output-table">
+                <tr id="timer-row">
+
+                </tr>
                 <tr id="output-row">
 
                 </tr>

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -87,58 +87,38 @@ mixerTab.initialize = function (callback, scrollPosition) {
 
         $outputRow.append('<th data-i18n="mappingTableOutput"></th>');
         $functionRow.append('<th data-i18n="mappingTableFunction"></th>');
-        
-        for (let i = 1; i <= outputCount; i++) {
 
+        let seenTimers = new Set();
+
+        for (let i = 1; i <= outputCount; i++) {
             let timerId = FC.OUTPUT_MAPPING.getTimerId(i - 1);
             let color = FC.OUTPUT_MAPPING.getOutputTimerColor(i - 1);
             let isLed = FC.OUTPUT_MAPPING.isLedPin(i - 1);
+            let isFirstPad = !seenTimers.has(timerId);
+            seenTimers.add(timerId);
 
-            $outputRow.append('<td style="background-color: ' + color + '">S' + i + (isLed ? '/LED' : '') + ' (Timer&nbsp;' + (timerId + 1) + ')</td>');
-            $functionRow.append('<td id="function-' + i +'">-</td>');
+            let cellContent = '';
+            if (isFirstPad) {
+                let usageMode = FC.OUTPUT_MAPPING.getTimerOverride(timerId);
+                cellContent +=
+                    '<select id="timer-output-' + timerId + '">' +
+                        '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO   + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO   ? ' selected' : '') + '>AUTO</option>' +
+                        '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS ? ' selected' : '') + '>MOTORS</option>' +
+                        '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS ? ' selected' : '') + '>SERVOS</option>' +
+                        '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED    + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED    ? ' selected' : '') + '>LED</option>' +
+                        '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO  + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO  ? ' selected' : '') + '>PINIO / DUTY CYCLE</option>' +
+                        '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER ? ' selected' : '') + '>BEEPER</option>' +
+                    '</select><br>';
+            }
+            cellContent += 'S' + i + (isLed ? '/LED' : '') + ' (Timer&nbsp;' + (timerId + 1) + ')';
+
+            $outputRow.append('<td style="background-color: ' + color + '">' + cellContent + '</td>');
+            $functionRow.append('<td id="function-' + i + '">-</td>');
         }
 
         $outputRow.find('td').css('width', 100 / (outputCount + 1) + '%');
 
-    }
-
-    function updateTimerOverride() {
-        let timers = FC.OUTPUT_MAPPING.getUsedTimerIds();
-
-        for(let i =0; i < timers.length;++i) {
-            let timerId = timers[i];
-            let $select = $('#timer-output-' + timerId);
-            if(!$select) {
-                continue;
-            }
-            FC.OUTPUT_MAPPING.setTimerOverride(timerId, $select.val());
-        }
-    }
-
-    function renderTimerOverride() {
-        let outputCount = FC.OUTPUT_MAPPING.getOutputCount(),
-            $container = $('#timerOutputsList'), timers = {};
-
-
-        let usedTimers = FC.OUTPUT_MAPPING.getUsedTimerIds();
-
-        for (let t of usedTimers) {
-            var usageMode = FC.OUTPUT_MAPPING.getTimerOverride(t);
-            $container.append(
-                        '<div class="select" style="padding: 5px; margin: 1px; background-color: ' + FC.OUTPUT_MAPPING.getTimerColor(t) + '">' +
-                            '<select id="timer-output-' + t + '">' +
-                                '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO + '' + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO ? ' selected' : '')+ '>AUTO</option>'+
-                                '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS + '' + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS ? ' selected' : '')+ '>MOTORS</option>'+
-                                '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS + '' + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS ? ' selected' : '')+ '>SERVOS</option>'+
-                                '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED + '' + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED ? ' selected' : '')+ '>LED</option>'+
-                                '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO + '' + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO ? ' selected' : '')+ '>PINIO / DUTY CYCLE</option>'+
-                                '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER + '' + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER ? ' selected' : '')+ '>BEEPER</option>'+
-                            '</select>' +
-                            '<label for="timer-output-' + t + '">' +
-                                '<span> Timer ' + (parseInt(t) + 1) + '</span>' +
-                            '</label>' +
-                        '</div>'
-            );
+        for (let t of seenTimers) {
             $('#timer-output-' + t).on('change', function() {
                 updateTimerOverride();
                 if (FC.OUTPUT_MAPPING.hasDirectAssignment()) {
@@ -148,7 +128,19 @@ mixerTab.initialize = function (callback, scrollPosition) {
                 }
             });
         }
+    }
 
+    function updateTimerOverride() {
+        let timers = FC.OUTPUT_MAPPING.getUsedTimerIds();
+
+        for(let i = 0; i < timers.length; ++i) {
+            let timerId = timers[i];
+            let $select = $('#timer-output-' + timerId);
+            if(!$select) {
+                continue;
+            }
+            FC.OUTPUT_MAPPING.setTimerOverride(timerId, $select.val());
+        }
     }
 
     function renderOutputMapping() {
@@ -862,7 +854,6 @@ mixerTab.initialize = function (callback, scrollPosition) {
 
         renderOutputTable();
         renderOutputMapping();
-        renderTimerOverride();
 
         // Attempt to enhance output preview with firmware-authoritative assignments.
         // Tab is already functional above; this re-renders if/when firmware responds.

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -105,14 +105,24 @@ mixerTab.initialize = function (callback, scrollPosition) {
         // Timer row: one colspan cell per group, containing the mode dropdown.
         for (let group of groups) {
             let usageMode = FC.OUTPUT_MAPPING.getTimerOverride(group.timerId);
+            // When no explicit override is set (AUTO), pre-select the timer's natural mode
+            // so LED-only and beeper-only timers show their purpose rather than "AUTO".
+            let displayMode = usageMode;
+            if (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO) {
+                if (FC.OUTPUT_MAPPING.isTimerDefaultLed(group.timerId)) {
+                    displayMode = FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED;
+                } else if (FC.OUTPUT_MAPPING.isTimerDefaultBeeper(group.timerId)) {
+                    displayMode = FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER;
+                }
+            }
             let selectHtml =
                 '<select id="timer-output-' + group.timerId + '">' +
-                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO   + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO   ? ' selected' : '') + '>AUTO</option>' +
-                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS ? ' selected' : '') + '>MOTORS</option>' +
-                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS ? ' selected' : '') + '>SERVOS</option>' +
-                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED    + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED    ? ' selected' : '') + '>LED</option>' +
-                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO  + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO  ? ' selected' : '') + '>PINIO / DUTY CYCLE</option>' +
-                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER ? ' selected' : '') + '>BEEPER</option>' +
+                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO   + (displayMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO   ? ' selected' : '') + '>AUTO</option>' +
+                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS + (displayMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS ? ' selected' : '') + '>MOTORS</option>' +
+                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS + (displayMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS ? ' selected' : '') + '>SERVOS</option>' +
+                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED    + (displayMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED    ? ' selected' : '') + '>LED</option>' +
+                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO  + (displayMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO  ? ' selected' : '') + '>PINIO / DUTY CYCLE</option>' +
+                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER + (displayMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER ? ' selected' : '') + '>BEEPER</option>' +
                 '</select>';
             $timerRow.append('<td colspan="' + group.count + '" style="background-color: ' + group.color + '">' + selectHtml + '</td>');
         }
@@ -122,7 +132,8 @@ mixerTab.initialize = function (callback, scrollPosition) {
             let timerId = FC.OUTPUT_MAPPING.getTimerId(i - 1);
             let color = FC.OUTPUT_MAPPING.getOutputTimerColor(i - 1);
             let isLed = FC.OUTPUT_MAPPING.isLedPin(i - 1);
-            $outputRow.append('<td style="background-color: ' + color + '">S' + i + (isLed ? '/LED' : '') + ' (Timer&nbsp;' + (timerId + 1) + ')</td>');
+            let isBeeper = FC.OUTPUT_MAPPING.isBeeperPin(i - 1);
+            $outputRow.append('<td style="background-color: ' + color + '">S' + i + (isLed ? '/LED' : '') + (isBeeper ? '/Buzzer' : '') + ' (Timer&nbsp;' + (timerId + 1) + ')</td>');
             $functionRow.append('<td id="function-' + i + '">-</td>');
         }
 
@@ -154,15 +165,16 @@ mixerTab.initialize = function (callback, scrollPosition) {
     }
 
     function renderOutputMapping() {
+        let isMR = FC.MIXER_CONFIG.platformType == PLATFORM.MULTIROTOR || FC.MIXER_CONFIG.platformType == PLATFORM.TRICOPTER;
+        let jsMap = FC.OUTPUT_MAPPING.getOutputTable(isMR, FC.MOTOR_RULES.getNumberOfConfiguredMotors(), FC.SERVO_RULES.getUsedServoIndexes());
         let outputMap;
         if (FC.OUTPUT_MAPPING.hasDirectAssignment()) {
             outputMap = FC.OUTPUT_MAPPING.getOutputTableDirect();
+            for (let i = 0; i < Math.min(outputMap.length, jsMap.length); i++) {
+                if (outputMap[i] === '-') outputMap[i] = jsMap[i]; // fill in default LED and beeper
+            }
         } else {
-            outputMap = FC.OUTPUT_MAPPING.getOutputTable(
-                FC.MIXER_CONFIG.platformType == PLATFORM.MULTIROTOR || FC.MIXER_CONFIG.platformType == PLATFORM.TRICOPTER,
-                FC.MOTOR_RULES.getNumberOfConfiguredMotors(),
-                FC.SERVO_RULES.getUsedServoIndexes()
-            );
+            outputMap = jsMap;
         }
 
         for (let i = 1; i <= FC.OUTPUT_MAPPING.getOutputCount(); i++) {

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -107,12 +107,12 @@ mixerTab.initialize = function (callback, scrollPosition) {
             [O.TIMER_OUTPUT_MODE_MOTORS, 'MOTORS'],
             [O.TIMER_OUTPUT_MODE_SERVOS, 'SERVOS'],
             [O.TIMER_OUTPUT_MODE_LED,    'LED'],
-            [O.TIMER_OUTPUT_MODE_PINIO,  'PINIO / DUTY CYCLE'],
+            [O.TIMER_OUTPUT_MODE_PINIO,  'PINIO / PWM'],
             [O.TIMER_OUTPUT_MODE_BEEPER, 'BEEPER'],
         ].map(([value, label]) =>
             '<option value=' + value + (displayMode === value ? ' selected' : '') + '>' + label + '</option>'
         ).join('');
-        return '<select id="timer-output-' + group.timerId + '">' + optionsHtml + '</select>';
+        return 'Timer&nbsp;' + (group.timerId + 1) + ' <select id="timer-output-' + group.timerId + '">' + optionsHtml + '</select>';
     }
 
     function renderOutputTable() {
@@ -129,7 +129,7 @@ mixerTab.initialize = function (callback, scrollPosition) {
 
         for (const group of groups) {
             const selectHtml = buildTimerSelectHtml(group);
-            $timerRow.append('<td colspan="' + group.count + '" style="background-color: ' + group.color + '">' + selectHtml + '</td>');
+            $timerRow.append('<td colspan="' + group.count + '" style="background-color: ' + group.color + '; padding-right: 4px">' + selectHtml + '</td>');
         }
 
         for (let i = 1; i <= outputCount; i++) {
@@ -137,7 +137,7 @@ mixerTab.initialize = function (callback, scrollPosition) {
             const color = FC.OUTPUT_MAPPING.getOutputTimerColor(i - 1);
             const isLed = FC.OUTPUT_MAPPING.isLedPin(i - 1);
             const isBeeper = FC.OUTPUT_MAPPING.isBeeperPin(i - 1);
-            $outputRow.append('<td style="background-color: ' + color + '">S' + i + (isLed ? '/LED' : '') + (isBeeper ? '/Buzzer' : '') + ' (Timer&nbsp;' + (timerId + 1) + ')</td>');
+            $outputRow.append('<td style="background-color: ' + color + '">S' + i + (isLed ? '/LED' : '') + (isBeeper ? '/Buzzer' : '') + '</td>');
             $functionRow.append('<td id="function-' + i + '">-</td>');
         }
 

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -104,9 +104,7 @@ mixerTab.initialize = function (callback, scrollPosition) {
 
         // Timer row: one colspan cell per group, containing the mode dropdown.
         for (let group of groups) {
-            let usageMode = FC.OUTPUT_MAPPING.getTimerOverride(group.timerId);
-            // When no explicit override is set (AUTO), pre-select the timer's natural mode
-            // so LED-only and beeper-only timers show their purpose rather than "AUTO".
+            let usageMode = FC.OUTPUT_MAPPING.getTimerOverride(group.timerId) ?? FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO;
             let displayMode = usageMode;
             if (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO) {
                 if (FC.OUTPUT_MAPPING.isTimerDefaultLed(group.timerId)) {
@@ -171,7 +169,7 @@ mixerTab.initialize = function (callback, scrollPosition) {
         if (FC.OUTPUT_MAPPING.hasDirectAssignment()) {
             outputMap = FC.OUTPUT_MAPPING.getOutputTableDirect();
             for (let i = 0; i < Math.min(outputMap.length, jsMap.length); i++) {
-                if (outputMap[i] === '-') outputMap[i] = jsMap[i]; // fill in default LED and beeper
+                if (outputMap[i] === '-' && jsMap[i] && jsMap[i] !== '-') outputMap[i] = jsMap[i]; // fill in default LED and beeper
             }
         } else {
             outputMap = jsMap;

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -80,64 +80,70 @@ mixerTab.initialize = function (callback, scrollPosition) {
         import('./mixer.html?raw').then(({default: html}) => GUI.load(html, Settings.processHtml(processHtml)));
     }
 
-    function renderOutputTable() {
-        let outputCount = FC.OUTPUT_MAPPING.getOutputCount(),
-            $timerRow = $('#timer-row'),
-            $outputRow = $('#output-row'),
-            $functionRow = $('#function-row');
-
-        $timerRow.append('<th></th>');
-        $outputRow.append('<th data-i18n="mappingTableOutput"></th>');
-        $functionRow.append('<th data-i18n="mappingTableFunction"></th>');
-
-        // Build consecutive timer groups for colspan cells.
-        let groups = [];
+    function buildTimerGroups(outputCount) {
+        const groups = [];
         for (let i = 0; i < outputCount; i++) {
-            let timerId = FC.OUTPUT_MAPPING.getTimerId(i);
-            let color = FC.OUTPUT_MAPPING.getOutputTimerColor(i);
+            const timerId = FC.OUTPUT_MAPPING.getTimerId(i);
+            const color = FC.OUTPUT_MAPPING.getOutputTimerColor(i);
             if (groups.length > 0 && groups.at(-1).timerId === timerId) {
                 groups.at(-1).count++;
             } else {
                 groups.push({ timerId, count: 1, color });
             }
         }
+        return groups;
+    }
 
-        // Timer row: one colspan cell per group, containing the mode dropdown.
-        for (let group of groups) {
-            let usageMode = FC.OUTPUT_MAPPING.getTimerOverride(group.timerId) ?? FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO;
-            let displayMode = usageMode;
-            if (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO) {
-                if (FC.OUTPUT_MAPPING.isTimerDefaultLed(group.timerId)) {
-                    displayMode = FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED;
-                } else if (FC.OUTPUT_MAPPING.isTimerDefaultBeeper(group.timerId)) {
-                    displayMode = FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER;
-                }
-            }
-            let selectHtml =
-                '<select id="timer-output-' + group.timerId + '">' +
-                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO   + (displayMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO   ? ' selected' : '') + '>AUTO</option>' +
-                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS + (displayMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS ? ' selected' : '') + '>MOTORS</option>' +
-                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS + (displayMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS ? ' selected' : '') + '>SERVOS</option>' +
-                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED    + (displayMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED    ? ' selected' : '') + '>LED</option>' +
-                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO  + (displayMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO  ? ' selected' : '') + '>PINIO / DUTY CYCLE</option>' +
-                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER + (displayMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER ? ' selected' : '') + '>BEEPER</option>' +
-                '</select>';
+    function buildTimerSelectHtml(group) {
+        const O = FC.OUTPUT_MAPPING;
+        const usageMode = O.getTimerOverride(group.timerId) ?? O.TIMER_OUTPUT_MODE_AUTO;
+        let displayMode = usageMode;
+        if (usageMode === O.TIMER_OUTPUT_MODE_AUTO) {
+            if (O.isTimerDefaultLed(group.timerId))         displayMode = O.TIMER_OUTPUT_MODE_LED;
+            else if (O.isTimerDefaultBeeper(group.timerId)) displayMode = O.TIMER_OUTPUT_MODE_BEEPER;
+        }
+        const optionsHtml = [
+            [O.TIMER_OUTPUT_MODE_AUTO,   'AUTO'],
+            [O.TIMER_OUTPUT_MODE_MOTORS, 'MOTORS'],
+            [O.TIMER_OUTPUT_MODE_SERVOS, 'SERVOS'],
+            [O.TIMER_OUTPUT_MODE_LED,    'LED'],
+            [O.TIMER_OUTPUT_MODE_PINIO,  'PINIO / DUTY CYCLE'],
+            [O.TIMER_OUTPUT_MODE_BEEPER, 'BEEPER'],
+        ].map(([value, label]) =>
+            '<option value=' + value + (displayMode === value ? ' selected' : '') + '>' + label + '</option>'
+        ).join('');
+        return '<select id="timer-output-' + group.timerId + '">' + optionsHtml + '</select>';
+    }
+
+    function renderOutputTable() {
+        const outputCount = FC.OUTPUT_MAPPING.getOutputCount();
+        const $timerRow = $('#timer-row');
+        const $outputRow = $('#output-row');
+        const $functionRow = $('#function-row');
+
+        $timerRow.append('<th></th>');
+        $outputRow.append('<th data-i18n="mappingTableOutput"></th>');
+        $functionRow.append('<th data-i18n="mappingTableFunction"></th>');
+
+        const groups = buildTimerGroups(outputCount);
+
+        for (const group of groups) {
+            const selectHtml = buildTimerSelectHtml(group);
             $timerRow.append('<td colspan="' + group.count + '" style="background-color: ' + group.color + '">' + selectHtml + '</td>');
         }
 
-        // Output and function rows: one uniform-height cell per pad.
         for (let i = 1; i <= outputCount; i++) {
-            let timerId = FC.OUTPUT_MAPPING.getTimerId(i - 1);
-            let color = FC.OUTPUT_MAPPING.getOutputTimerColor(i - 1);
-            let isLed = FC.OUTPUT_MAPPING.isLedPin(i - 1);
-            let isBeeper = FC.OUTPUT_MAPPING.isBeeperPin(i - 1);
+            const timerId = FC.OUTPUT_MAPPING.getTimerId(i - 1);
+            const color = FC.OUTPUT_MAPPING.getOutputTimerColor(i - 1);
+            const isLed = FC.OUTPUT_MAPPING.isLedPin(i - 1);
+            const isBeeper = FC.OUTPUT_MAPPING.isBeeperPin(i - 1);
             $outputRow.append('<td style="background-color: ' + color + '">S' + i + (isLed ? '/LED' : '') + (isBeeper ? '/Buzzer' : '') + ' (Timer&nbsp;' + (timerId + 1) + ')</td>');
             $functionRow.append('<td id="function-' + i + '">-</td>');
         }
 
         $outputRow.find('td').css('width', 100 / (outputCount + 1) + '%');
 
-        for (let group of groups) {
+        for (const group of groups) {
             $('#timer-output-' + group.timerId).on('change', function() {
                 updateTimerOverride();
                 if (FC.OUTPUT_MAPPING.hasDirectAssignment()) {

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -133,7 +133,6 @@ mixerTab.initialize = function (callback, scrollPosition) {
         }
 
         for (let i = 1; i <= outputCount; i++) {
-            const timerId = FC.OUTPUT_MAPPING.getTimerId(i - 1);
             const color = FC.OUTPUT_MAPPING.getOutputTimerColor(i - 1);
             const isLed = FC.OUTPUT_MAPPING.isLedPin(i - 1);
             const isBeeper = FC.OUTPUT_MAPPING.isBeeperPin(i - 1);

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -82,44 +82,54 @@ mixerTab.initialize = function (callback, scrollPosition) {
 
     function renderOutputTable() {
         let outputCount = FC.OUTPUT_MAPPING.getOutputCount(),
+            $timerRow = $('#timer-row'),
             $outputRow = $('#output-row'),
             $functionRow = $('#function-row');
 
+        $timerRow.append('<th></th>');
         $outputRow.append('<th data-i18n="mappingTableOutput"></th>');
         $functionRow.append('<th data-i18n="mappingTableFunction"></th>');
 
-        let seenTimers = new Set();
+        // Build consecutive timer groups for colspan cells.
+        let groups = [];
+        for (let i = 0; i < outputCount; i++) {
+            let timerId = FC.OUTPUT_MAPPING.getTimerId(i);
+            let color = FC.OUTPUT_MAPPING.getOutputTimerColor(i);
+            if (groups.length > 0 && groups[groups.length - 1].timerId === timerId) {
+                groups[groups.length - 1].count++;
+            } else {
+                groups.push({ timerId, count: 1, color });
+            }
+        }
 
+        // Timer row: one colspan cell per group, containing the mode dropdown.
+        for (let group of groups) {
+            let usageMode = FC.OUTPUT_MAPPING.getTimerOverride(group.timerId);
+            let selectHtml =
+                '<select id="timer-output-' + group.timerId + '">' +
+                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO   + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO   ? ' selected' : '') + '>AUTO</option>' +
+                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS ? ' selected' : '') + '>MOTORS</option>' +
+                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS ? ' selected' : '') + '>SERVOS</option>' +
+                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED    + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED    ? ' selected' : '') + '>LED</option>' +
+                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO  + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO  ? ' selected' : '') + '>PINIO / DUTY CYCLE</option>' +
+                    '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER ? ' selected' : '') + '>BEEPER</option>' +
+                '</select>';
+            $timerRow.append('<td colspan="' + group.count + '" style="background-color: ' + group.color + '">' + selectHtml + '</td>');
+        }
+
+        // Output and function rows: one uniform-height cell per pad.
         for (let i = 1; i <= outputCount; i++) {
             let timerId = FC.OUTPUT_MAPPING.getTimerId(i - 1);
             let color = FC.OUTPUT_MAPPING.getOutputTimerColor(i - 1);
             let isLed = FC.OUTPUT_MAPPING.isLedPin(i - 1);
-            let isFirstPad = !seenTimers.has(timerId);
-            seenTimers.add(timerId);
-
-            let cellContent = '';
-            if (isFirstPad) {
-                let usageMode = FC.OUTPUT_MAPPING.getTimerOverride(timerId);
-                cellContent +=
-                    '<select id="timer-output-' + timerId + '">' +
-                        '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO   + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_AUTO   ? ' selected' : '') + '>AUTO</option>' +
-                        '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_MOTORS ? ' selected' : '') + '>MOTORS</option>' +
-                        '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS ? ' selected' : '') + '>SERVOS</option>' +
-                        '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED    + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED    ? ' selected' : '') + '>LED</option>' +
-                        '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO  + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO  ? ' selected' : '') + '>PINIO / DUTY CYCLE</option>' +
-                        '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER ? ' selected' : '') + '>BEEPER</option>' +
-                    '</select><br>';
-            }
-            cellContent += 'S' + i + (isLed ? '/LED' : '') + ' (Timer&nbsp;' + (timerId + 1) + ')';
-
-            $outputRow.append('<td style="background-color: ' + color + '">' + cellContent + '</td>');
+            $outputRow.append('<td style="background-color: ' + color + '">S' + i + (isLed ? '/LED' : '') + ' (Timer&nbsp;' + (timerId + 1) + ')</td>');
             $functionRow.append('<td id="function-' + i + '">-</td>');
         }
 
         $outputRow.find('td').css('width', 100 / (outputCount + 1) + '%');
 
-        for (let t of seenTimers) {
-            $('#timer-output-' + t).on('change', function() {
+        for (let group of groups) {
+            $('#timer-output-' + group.timerId).on('change', function() {
                 updateTimerOverride();
                 if (FC.OUTPUT_MAPPING.hasDirectAssignment()) {
                     mspHelper.queryOutputAssignment(renderOutputMapping);

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -132,6 +132,7 @@ mixerTab.initialize = function (callback, scrollPosition) {
                                 '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS + '' + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_SERVOS ? ' selected' : '')+ '>SERVOS</option>'+
                                 '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED + '' + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_LED ? ' selected' : '')+ '>LED</option>'+
                                 '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO + '' + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_PINIO ? ' selected' : '')+ '>PINIO / DUTY CYCLE</option>'+
+                                '<option value=' + FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER + '' + (usageMode == FC.OUTPUT_MAPPING.TIMER_OUTPUT_MODE_BEEPER ? ' selected' : '')+ '>BEEPER</option>'+
                             '</select>' +
                             '<label for="timer-output-' + t + '">' +
                                 '<span> Timer ' + (parseInt(t) + 1) + '</span>' +

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -95,8 +95,8 @@ mixerTab.initialize = function (callback, scrollPosition) {
         for (let i = 0; i < outputCount; i++) {
             let timerId = FC.OUTPUT_MAPPING.getTimerId(i);
             let color = FC.OUTPUT_MAPPING.getOutputTimerColor(i);
-            if (groups.length > 0 && groups[groups.length - 1].timerId === timerId) {
-                groups[groups.length - 1].count++;
+            if (groups.length > 0 && groups.at(-1).timerId === timerId) {
+                groups.at(-1).count++;
             } else {
                 groups.push({ timerId, count: 1, color });
             }


### PR DESCRIPTION
## Summary

Adds buzzer (PWM beeper) pads to the Output Mapping table in the Mixer tab, making them visible alongside motor, servo, LED, and PINIO outputs and allowing them to be reassigned at runtime.

<img width="683" height="260" alt="image" src="https://github.com/user-attachments/assets/76fd73e0-3cfd-403e-9e83-14eb18ea1559" />


Works on 1024 width screens, looks better on 1280 or higher.

## Changes

- **`js/outputMapping.js`**
  - Added `TIMER_OUTPUT_MODE_BEEPER = 5` constant
  - `getOutputCount()` and `getFirstOutputOffset()` now include pads with `TIM_USE_BEEPER`
  - `getTimerMap()` assigns `OUTPUT_TYPE_BEEPER` for beeper-flagged pads in AUTO mode
  - `getOutputTableDirect()` maps firmware-reported beeper assignments to `"Buzzer"`
  - New: `isBeeperPin(outputIndex)` — detects beeper pads for label display
  - New: `isTimerDefaultLed(timerId)` / `isTimerDefaultBeeper(timerId)` — detect compile-time default timer assignments for dropdown pre-selection

- **`tabs/mixer.html`**
  - Output Mapping table restructured to three rows: timer-mode dropdowns (colspan per timer group), pad labels, function assignments — gives uniform cell heights across all pads

- **`tabs/mixer.js`**
  - Timer mode selectors moved from a separate box into the Output Mapping table
  - Colspan groups span pads sharing the same timer, with one dropdown per group
  - `renderOutputTable()`: LED pads labeled `S13/LED`, buzzer pads labeled `S14/Buzzer`
  - Timer dropdowns pre-select LED or BEEPER (not AUTO) for timers whose compile-time default is LED or buzzer, using `getTimerOverride() ?? AUTO` to correctly handle timers with no stored override
  - `renderOutputMapping()`: fills LED/buzzer function cells from the JS-computed map when the firmware direct-assignment response (which only reports motors, servos, and explicitly-overridden buzzers) leaves them as `"-"`

## Testing

Tested on BrotherHobby H743 hardware (INAV 9.1.0, `DEF_TIM(TIM2, CH1, PA15, TIM_USE_BEEPER, 0, 0)`):

- S14/Buzzer (Timer 2) column appears in Output Mapping table ✅
- Timer 2 dropdown pre-selects BEEPER ✅
- Function row shows "Buzzer" for the buzzer pad ✅
- Timer 1 (LED) dropdown pre-selects LED, function row shows "Led" ✅
- Motor assignments (Motor 1–4) unaffected ✅
- No JavaScript console errors ✅

Boards with GPIO-only buzzers (e.g. SDMODELH7V1, PC13 not in `timerHardware[]`) show no extra column — correct behavior.

## Code Review

Two rounds of review with inav-code-review agent. All critical and important findings addressed, including the `?? AUTO` fallback fix and gap-fill guard.