### PR TITLE
Fix OSD tab and connected-header UI glitches

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,6 @@
                             <div class="battery-status"></div>
                         </div>
                     </div>
-                    <div class="battery-label">Batt</div>
                     <div class="battery-legend" i18n="sensorBatteryVoltage"></div>
                     <div class="bottomStatusIcons">
                         <div id="armedIcon" class="statusicon armed cf_tip" data-i18n_title="mainHelpArmed"></div>

--- a/js/gui.js
+++ b/js/gui.js
@@ -477,6 +477,9 @@ GUI_control.prototype.update_dataflash_global = function () {
         width: (100-(FC.DATAFLASH.totalSize - FC.DATAFLASH.usedSize) / FC.DATAFLASH.totalSize * 100) + "%",
         display: 'block'
         });
+        $(".dataflash-free_global_label").css({
+        display: 'block'
+        });
         $(".dataflash-free_global_label").html(i18n.getMessage('sensorDataFlashFreeSpace') + formatFilesize(FC.DATAFLASH.totalSize - FC.DATAFLASH.usedSize) + " free");
     } else {
         $(".noflash_global").css({
@@ -484,6 +487,10 @@ GUI_control.prototype.update_dataflash_global = function () {
         });
 
         $(".dataflash-contents_global").css({
+        display: 'none'
+        });
+
+        $(".dataflash-free_global_label").css({
         display: 'none'
         });
     }

--- a/js/waypointCollection.js
+++ b/js/waypointCollection.js
@@ -433,7 +433,8 @@ let WaypointCollection = function () {
 
     self.getElevation = async function(globalSettings) {
         const [nLoop, point2measure, altPoint2measure, namePoint2measure, refPoint2measure] = self.getPoint2Measure(true);
-        let lengthMission = self.getDistance(true);
+        // false: real distance; true returns -1 for looping JUMP missions, zeroing samples
+        let lengthMission = self.getDistance(false);
         let totalMissionDistance = lengthMission.length >= 1 ? lengthMission[lengthMission.length -1].toFixed(1) : 0;
         let samples;
         let sampleMaxNum;
@@ -453,7 +454,9 @@ let WaypointCollection = function () {
             samples = sampleMaxNum;
         }
 
-        let elevation = "N/A";
+        samples = Math.max(1, samples); // opentopodata rejects < 2 samples (we send samples+1)
+
+        let elevation = [];
         let coordList = "";
         point2measure.forEach(function (item) {
             coordList += item + '|';

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1986,11 +1986,6 @@ dialog {
     display: none;
 }
 
-.battery-label {
-    display: inline;
-    color: #aaa;
-}
-
 /* Battery element styling*/
 
 #quad-status_wrapper {
@@ -2015,9 +2010,12 @@ dialog {
 }
 
 .battery-legend {
-    display: inline;
+    display: inline-block;
+    vertical-align: middle;
+    min-width: 6ch;
+    text-align: center;
     color: silver;
-    margin-right: 8px;
+    font-variant-numeric: tabular-nums;
 }
 
 .quad-status-contents progress::-webkit-progress-bar {

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -340,10 +340,6 @@
     padding-top:10px;
 }
 
-.tab-osd .content_toolbar {
-    text-align: right;
-}
-
 .tab-osd .content_toolbar button {
     margin-right: 1em;
 }
@@ -791,7 +787,16 @@
     text-align: center;
 }
 
-.osd_group { max-width: 300px; }
+.osd__elements > .spacer_right:not(.settings) {
+    column-width: 300px;
+    column-gap: 10px;
+}
+
+.osd_group {
+    float: none;
+    display: flow-root;
+    break-inside: avoid;
+}
 
 .ce-card-body {
     padding: 8px 10px;

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -129,6 +129,9 @@ const icons = Object.create(null)
 
 const missionControlTab = {};
 missionControlTab.isYmapLoad = false;
+
+// Shared between plotElevation() (inside initialize) and cleanup()
+let elevationChartInstance = null;
 missionControlTab.initialize = function (callback) {
 
     let cursorInitialized = false;
@@ -4666,13 +4669,13 @@ function iconKey(filename) {
                 }
 
                 // Destroy existing chart if it exists
-                if (window.elevationChartInstance) {
-                    window.elevationChartInstance.destroy();
-                    window.elevationChartInstance = null;
+                if (elevationChartInstance) {
+                    elevationChartInstance.destroy();
+                    elevationChartInstance = null;
                 }
 
                 // Create empty chart with message
-                window.elevationChartInstance = new Chart(ctx, {
+                elevationChartInstance = new Chart(ctx, {
                     type: 'line',
                     data: {
                         labels: [0],
@@ -4790,18 +4793,21 @@ function iconKey(filename) {
                             ]
                         };
 
-                        // Update existing chart if it exists, otherwise create new one
-                        if (window.elevationChartInstance) {
+                        // reuse only if still bound to the current canvas (replaced on tab reload)
+                        if (elevationChartInstance && elevationChartInstance.canvas === ctx) {
                             // Update data
-                            window.elevationChartInstance.data = newData;
-                            window.elevationChartInstance.options.plugins.title.text = chartTitle;
-                            window.elevationChartInstance.options.scales.y.min = Math.floor(-10 + Math.min(minMission, minElevation));
-                            window.elevationChartInstance.options.scales.y.max = Math.ceil(10 + Math.max(maxMission, maxElevation));
+                            elevationChartInstance.data = newData;
+                            elevationChartInstance.options.plugins.title.text = chartTitle;
+                            elevationChartInstance.options.scales.y.min = Math.floor(-10 + Math.min(minMission, minElevation));
+                            elevationChartInstance.options.scales.y.max = Math.ceil(10 + Math.max(maxMission, maxElevation));
                             // Trigger re-render without animation for better performance during drag operations
-                            window.elevationChartInstance.update('none');
+                            elevationChartInstance.update('none');
                         } else {
+                            if (elevationChartInstance) {
+                                elevationChartInstance.destroy();
+                            }
                             // Create new chart
-                            window.elevationChartInstance = new Chart(ctx, {
+                            elevationChartInstance = new Chart(ctx, {
                                 type: 'line',
                                 data: newData,
                                 options: {
@@ -4874,6 +4880,10 @@ missionControlTab.setBit = function(bits, bit, value) {
 // }
 
 missionControlTab.cleanup = function (callback) {
+    if (elevationChartInstance) {
+        elevationChartInstance.destroy();
+        elevationChartInstance = null;
+    }
     if (callback) callback();
 };
 

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -3502,6 +3502,7 @@ OSD.GUI.updateAll = function() {
         OSD.GUI.updateFields(event);
     });
     $('.supported').fadeIn();
+    $('.content_toolbar.supported').css('display', 'flex');
     OSD.GUI.updateVideoMode();
     OSD.GUI.updateUnits();
     OSD.GUI.updateFields();


### PR DESCRIPTION
Fixes several small UI issues on the connected-state header and the OSD tab.

## Connected header

- **Battery voltage** is back to a voltage-only readout. The previously added "Batt" label is removed, and the value now has a fixed, font-relative width with tabular digits so it no longer jumps sideways when the voltage changes (e.g. 9.9 V → 16.8 V).
- **Dataflash panel** no longer shows the "Dataflash:" label when the flight controller has no dataflash chip — it now only shows "No dataflash chip found".

## OSD tab

- **Toolbar buttons** (Save / Font Manager) are right-aligned in a single row again. They had started stacking on the left after the toolbar was converted to flexbox, because showing the tab forced an inline `display: block` onto the toolbar that overrode its flex layout.
- **Element group boxes** in the left panel now lay out as balanced columns instead of unevenly packed floats, so the multi-column view no longer has large random gaps. Each box also correctly wraps its content.

## Affected files

`index.html`, `js/gui.js`, `src/css/main.css`, `src/css/tabs/osd.css`, `tabs/osd.js`
