### PR TITLE
Fix MSP connection stability: load stalls and connect/reconnect recovery

### DIFF
--- a/js/connection/connectionBle.js
+++ b/js/connection/connectionBle.js
@@ -59,30 +59,66 @@ class ConnectionBle extends Connection {
         return this._deviceDescription;
     }
 
-    async connectImplementation(path, options, callback) {      
-        console.log("Request BLE Device");    
-        await this.openDevice()
-            .then(() => {
-                this.addOnReceiveErrorListener(error => {
-                    GUI.log(i18n.getMessage('connectionBleInterrupted'));
-                    this.abort();
-                });
+    async connectImplementation(path, options, callback) {
+        console.log("Request BLE Device");
+        try {
+            // Fail cleanly if a GATT step hangs, instead of pending forever.
+            await this._withTimeout(this.openDevice(), 12000, "BLE connection timed out");
 
-                if (callback) {
-                    callback({
-                        // Dummy values
-                        connectionId: 0xff,
-                        bitrate: 115200 
-                    });
-                }
-            }).catch(error => {
-                GUI.log(i18n.getMessage('connectionBleError', [error]));
-                if (callback) {
-                    callback(false);
-                }
+            this.addOnReceiveErrorListener(error => {
+                GUI.log(i18n.getMessage('connectionBleInterrupted'));
+                this.abort();
             });
 
+            if (callback) {
+                callback({
+                    // Dummy values
+                    connectionId: 0xff,
+                    bitrate: 115200
+                });
+            }
+        } catch (error) {
+            GUI.log(i18n.getMessage('connectionBleError', [error]));
+            // Tear down a half-open GATT so the next attempt starts clean.
+            this._cleanupGatt();
+            if (callback) {
+                callback(false);
+            }
+        }
+
         return Promise.resolve();
+    }
+
+    _withTimeout(promise, ms, message) {
+        let timer;
+        const timeout = new Promise((_, reject) => {
+            timer = setTimeout(() => reject(new Error(message)), ms);
+        });
+        return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+    }
+
+    _cleanupGatt() {
+        if (this._device) {
+            try {
+                if (this._handleDisconnect) {
+                    this._device.removeEventListener('gattserverdisconnected', this._handleDisconnect);
+                }
+                if (this._readCharacteristic && this._handleOnCharateristicValueChanged) {
+                    this._readCharacteristic.removeEventListener('characteristicvaluechanged', this._handleOnCharateristicValueChanged);
+                }
+                if (this._device.gatt && this._device.gatt.connected) {
+                    this._device.gatt.disconnect();
+                }
+            } catch (e) {
+                console.log('BLE cleanup error (ignored):', e.message);
+            }
+        }
+        this._device = false;
+        this._writeCharacteristic = false;
+        this._readCharacteristic = false;
+        this._deviceDescription = false;
+        this._handleDisconnect = false;
+        this._handleOnCharateristicValueChanged = false;
     }
 
     async openDevice(){
@@ -196,41 +232,42 @@ class ConnectionBle extends Connection {
     }
 
     disconnectImplementation(callback) {
-        if (this._device) {
-            this._device.removeEventListener('gattserverdisconnected', this._handleDisconnect);
-            this._readCharacteristic.removeEventListener('characteristicvaluechanged', this._handleOnCharateristicValueChanged);
-
-            if (this._device.gatt.connected) {
-                this._device.gatt.disconnect();
-            }        
-            this._device = false;
-            this._writeCharacteristic = false; 
-            this._readCharacteristic = false;
-            this._deviceDescription = false; 
-        }
+        this._cleanupGatt();
 
         if (callback) {
             callback(true);
         }
     }
 
-    async sendImplementation (data, callback) {;
-        if (!this._writeCharacteristic) {
+    async sendImplementation (data, callback) {
+        if (!this._writeCharacteristic || !this._device || !this._device.gatt || !this._device.gatt.connected) {
+            if (callback) {
+                callback({ bytesSent: 0, resultCode: 1 });
+            }
             return;
         }
-        
+
         let sent = 0;
         let dataBuffer = new Uint8Array(data);
-        for (var i = 0; i < dataBuffer.length; i += BLE_WRITE_BUFFER_LENGTH) {
-            var length = BLE_WRITE_BUFFER_LENGTH;
+        try {
+            for (var i = 0; i < dataBuffer.length; i += BLE_WRITE_BUFFER_LENGTH) {
+                var length = BLE_WRITE_BUFFER_LENGTH;
 
-            if (i + BLE_WRITE_BUFFER_LENGTH > dataBuffer.length) {
-                length = dataBuffer.length % BLE_WRITE_BUFFER_LENGTH;
+                if (i + BLE_WRITE_BUFFER_LENGTH > dataBuffer.length) {
+                    length = dataBuffer.length % BLE_WRITE_BUFFER_LENGTH;
+                }
+
+                var outBuffer = dataBuffer.subarray(i, i + length);
+                sent += outBuffer.length;
+                await this._writeCharacteristic.writeValue(outBuffer);
             }
-
-            var outBuffer = dataBuffer.subarray(i, i + length);
-            sent += outBuffer.length;
-            await this._writeCharacteristic.writeValue(outBuffer);   
+        } catch (error) {
+            // GATT can drop mid-write; report failure instead of throwing.
+            console.log('BLE write failed:', error.message);
+            if (callback) {
+                callback({ bytesSent: 0, resultCode: 1 });
+            }
+            return;
         }
 
         if (callback) {
@@ -239,7 +276,6 @@ class ConnectionBle extends Connection {
                 resultCode: 0
             });
         }
-        
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionBle.js
+++ b/js/connection/connectionBle.js
@@ -106,7 +106,7 @@ class ConnectionBle extends Connection {
                 if (this._readCharacteristic && this._handleOnCharateristicValueChanged) {
                     this._readCharacteristic.removeEventListener('characteristicvaluechanged', this._handleOnCharateristicValueChanged);
                 }
-                if (this._device.gatt && this._device.gatt.connected) {
+                if (this._device.gatt?.connected) {
                     this._device.gatt.disconnect();
                 }
             } catch (e) {
@@ -239,8 +239,12 @@ class ConnectionBle extends Connection {
         }
     }
 
-    async sendImplementation (data, callback) {
-        if (!this._writeCharacteristic || !this._device || !this._device.gatt || !this._device.gatt.connected) {
+    sendImplementation(data, callback) {
+        void this._writeChunks(data, callback);
+    }
+
+    async _writeChunks(data, callback) {
+        if (!this._writeCharacteristic || !this._device?.gatt?.connected) {
             if (callback) {
                 callback({ bytesSent: 0, resultCode: 1 });
             }
@@ -248,16 +252,16 @@ class ConnectionBle extends Connection {
         }
 
         let sent = 0;
-        let dataBuffer = new Uint8Array(data);
+        const dataBuffer = new Uint8Array(data);
         try {
-            for (var i = 0; i < dataBuffer.length; i += BLE_WRITE_BUFFER_LENGTH) {
-                var length = BLE_WRITE_BUFFER_LENGTH;
+            for (let i = 0; i < dataBuffer.length; i += BLE_WRITE_BUFFER_LENGTH) {
+                let length = BLE_WRITE_BUFFER_LENGTH;
 
                 if (i + BLE_WRITE_BUFFER_LENGTH > dataBuffer.length) {
                     length = dataBuffer.length % BLE_WRITE_BUFFER_LENGTH;
                 }
 
-                var outBuffer = dataBuffer.subarray(i, i + length);
+                const outBuffer = dataBuffer.subarray(i, i + length);
                 sent += outBuffer.length;
                 await this._writeCharacteristic.writeValue(outBuffer);
             }

--- a/js/gui.js
+++ b/js/gui.js
@@ -6,6 +6,7 @@ import interval from './intervals';
 import { scaleRangeInt } from './helpers';
 import i18n from './localization';
 import mspDeduplicationQueue from "./msp/mspDeduplicationQueue";
+import mspQueue from './serial_queue';
 
 var GUI_control = function () {
     this.connecting_to = false;
@@ -93,6 +94,13 @@ GUI_control.prototype.log = function (message) {
 // default switch doesn't require callback to be set
 GUI_control.prototype.tab_switch_cleanup = function (callback) {
     MSP.callbacks_cleanup(); // we don't care about any old data that might or might not arrive
+    // Drop the previous tab's still-queued requests and release the port lock,
+    // otherwise they keep retrying and re-reserve their (shared) MSP code in the
+    // dedup queue, which then rejects the new tab's same-code requests and hangs
+    // its load.
+    mspQueue.flush();
+    mspQueue.freeHardLock();
+    mspQueue.freeSoftLock();
     mspDeduplicationQueue.flush();
 
     interval.killAll(['global_data_refresh', 'msp-load-update', 'ltm-connection-check']);

--- a/js/msp.js
+++ b/js/msp.js
@@ -380,9 +380,32 @@ var MSP = {
             message.retryCounter = 10;
         }
 
-        mspQueue.put(message);
+        this._enqueue(message);
 
         return true;
+    },
+    /*
+     * Hand a message to the queue. put() can reject it (queue locked, or a
+     * request with the same MSP code already pending - the dedup key is the bare
+     * code, which collides for the per-setting MSP2_COMMON_SETTING reads). A
+     * rejected message would never fire its callback and hang any promise
+     * awaiting it, so retry briefly before giving up.
+     */
+    _enqueue(message) {
+        if (mspQueue.put(message)) {
+            return;
+        }
+        if (message.putRetries === undefined) {
+            message.putRetries = 25;
+        }
+        if (message.putRetries > 0) {
+            message.putRetries--;
+            var self = this;
+            setTimeout(function () { self._enqueue(message); }, 150);
+        } else if (message.onFinish) {
+            // Give up rather than hang forever; let the caller's chain proceed.
+            message.onFinish(false);
+        }
     },
      _crc8_dvb_s2(crc, ch) {
         crc ^= ch;

--- a/js/msp.js
+++ b/js/msp.js
@@ -400,8 +400,7 @@ var MSP = {
         }
         if (message.putRetries > 0) {
             message.putRetries--;
-            var self = this;
-            setTimeout(function () { self._enqueue(message); }, 150);
+            setTimeout(() => this._enqueue(message), 150);
         } else if (message.onFinish) {
             // Give up rather than hang forever; let the caller's chain proceed.
             message.onFinish(false);

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -164,7 +164,9 @@ var SerialBackend = (function () {
 
         if (GUI.connect_lock != true) { // GUI control overrides the user control
 
-                var clicks = $(this).data('clicks');
+                // Use the real connection state, not a toggle flag that competing
+                // async aborts could desync.
+                var isConnectedOrConnecting = (GUI.connected_to !== false) || (GUI.connecting_to !== false);
                 var selected_baud = parseInt(privateScope.$baud.val());
                 var selected_port = privateScope.$port.find('option:selected').data().isManual ?
                     publicScope.$portOverride.val() :
@@ -174,9 +176,17 @@ var SerialBackend = (function () {
                     GUI.log(i18n.getMessage('dfu_connect_message'));
                 }
                 else if (selected_port != '0') {
-                    if (!clicks) {
+                    if (!isConnectedOrConnecting) {
                         console.log('Connecting to: ' + selected_port);
                         GUI.connecting_to = selected_port;
+
+                        // Clear leftover MSP state so a fast reconnect isn't
+                        // blocked by a previous session's retrying requests.
+                        mspQueue.flush();
+                        mspQueue.freeHardLock();
+                        mspQueue.freeSoftLock();
+                        mspDeduplicationQueue.flush();
+                        MSP.disconnect_cleanup();
 
                         // lock port select & baud while we are connecting / connected
                         $('#port, #baud, #delay').prop('disabled', true);
@@ -237,6 +247,7 @@ var SerialBackend = (function () {
                             GUI.tab_switch_in_progress = false;
                             CONFIGURATOR.connectionValid = false;
                             GUI.connected_to = false;
+                            GUI.connecting_to = false;
                             GUI.allowedTabs = GUI.defaultAllowedTabsWhenDisconnected.slice();
 
                             /*
@@ -274,8 +285,6 @@ var SerialBackend = (function () {
                             $('#tabs .tab_landing a').trigger( "click" );
                         }
                     }
-
-                    $(this).data("clicks", !clicks);
                 }
             }
         }
@@ -448,6 +457,10 @@ var SerialBackend = (function () {
             console.log('Failed to open serial port');
             GUI.log(i18n.getMessage('serialPortOpenFail'));
 
+            // Clear connecting state so the button reflects "disconnected".
+            GUI.connecting_to = false;
+            GUI.connected_to = false;
+
             var $connectButton = $('#connectbutton');
 
             $connectButton.find('.connect_state').text(i18n.getMessage('connect'));
@@ -455,9 +468,6 @@ var SerialBackend = (function () {
 
             // unlock port select & baud
             $('#port, #baud, #delay').prop('disabled', false);
-
-            // reset data
-            $connectButton.find('.connect').data("clicks", false);
         }
     }
 

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -166,7 +166,7 @@ var SerialBackend = (function () {
 
                 // Use the real connection state, not a toggle flag that competing
                 // async aborts could desync.
-                var isConnectedOrConnecting = (GUI.connected_to !== false) || (GUI.connecting_to !== false);
+                const isIdle = (GUI.connected_to === false) && (GUI.connecting_to === false);
                 var selected_baud = parseInt(privateScope.$baud.val());
                 var selected_port = privateScope.$port.find('option:selected').data().isManual ?
                     publicScope.$portOverride.val() :
@@ -176,7 +176,7 @@ var SerialBackend = (function () {
                     GUI.log(i18n.getMessage('dfu_connect_message'));
                 }
                 else if (selected_port != '0') {
-                    if (!isConnectedOrConnecting) {
+                    if (isIdle) {
                         console.log('Connecting to: ' + selected_port);
                         GUI.connecting_to = selected_port;
 


### PR DESCRIPTION
Addresses several connection robustness issues affecting serial and Bluetooth (BLE) connections, where the configurator could get stuck and require a restart.

## MSP load stall when switching tabs during background settings load

Switching tabs while a tab was still streaming its settings in the background could permanently stall the new tab's load — it stayed on "Waiting for data...", tabs could no longer be switched, and only a restart recovered it.

The settings reads of every tab share the same MSP command code (only the payload differs). The previous tab's still-queued reads lingered after the switch and re-reserved that shared code in the deduplication queue, which then rejected the new tab's same-code reads. A rejected request never fired its callback, so the promise awaiting it hung forever.

- `tab_switch_cleanup` now also flushes the MSP queue and releases the port lock, so a tab switch fully abandons the previous tab's MSP traffic.
- `send_message` no longer silently drops a request that the queue rejects; it retries the enqueue and finally invokes the callback instead of leaving its promise hanging.

## Robust connect/disconnect state and BLE reconnect recovery

A failed or hung connection (most visible over BLE) could leave the connect button and the BLE GATT connection in an inconsistent state, blocking all further connection attempts until the configurator was restarted.

- Connect-vs-disconnect is now decided from the real connection state instead of a toggling flag that competing async aborts (connect timeout, GATT disconnect, receive error) could push out of sync. Connecting state is reset on a failed open and on disconnect.
- The MSP queue, locks and callbacks are cleared at the start of every connect attempt, so a fast reconnect isn't blocked by a previous session's retrying requests.
- BLE: the connect chain now has a timeout, so a hung GATT step fails cleanly instead of leaving the app stuck; a half-open GATT is torn down before the next attempt; and writes are guarded against a dropped link instead of throwing an uncaught error.

## Result

- No more permanent "Waiting for data..." stall when changing tabs mid-load.
- Failed or fast reconnects recover on their own without restarting the configurator (serial and BLE).

## Affected files

`js/gui.js`, `js/msp.js`, `js/serial_backend.js`, `js/connection/connectionBle.js`
