### PR TITLE
German (de) translation

### DIFF
--- a/js/localization.js
+++ b/js/localization.js
@@ -6,7 +6,7 @@ import i18next from 'i18next';
 import store from './store'
 
 
-const availableLanguages = ['en', 'ja', 'ru', 'bg', 'uk', 'zh_CN'];
+const availableLanguages = ['en', 'de', 'ja', 'ru', 'bg', 'uk', 'zh_CN'];
 
 const i18n = {};
 

--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -1,0 +1,6791 @@
+{
+    "translation_version": {
+        "message": "0"
+    },
+    "language_de": {
+        "message": "Deutsch"
+    },
+    "language_en": {
+        "message": "English"
+    },
+    "language_bg": {
+        "message": "Български"
+    },
+    "language_uk": {
+        "message": "українська"
+    },
+    "language_ja": {
+        "message": "日本語"
+    },
+    "language_zh_CN": {
+        "message": "简体中文"
+    },
+    "language_ru": {
+        "message": "Русский"
+    },
+    "language": {
+        "message": "Sprache"
+    },
+    "options_title": {
+        "message": "Einstellungen"
+    },
+    "options_receive_app_notifications": {
+        "message": "<strong>Benachrichtige mich</strong> über Anwendungs-Updates"
+    },
+    "options_improve_configurator": {
+        "message": "Sende anonyme Nutzungsstatistiken zu den Entwicklern"
+    },
+    "options_disable3dAcceleration": {
+        "message": "3D-Beschleunigung deaktivieren. Falls die 3D-Modelle nicht angezeigt werden. Erfordert App-Neustart."
+    },
+    "options_showProfileParameters": {
+        "message": "Hebe Parameter hervor, die an Akku- und Steuerungsprofile gebunden sind"
+    },
+    "options_cliAutocomplete": {
+        "message": "Erweiterte Kommandozeilen-Vervollständigung"
+    },
+    "navExpandAll": {
+        "message": "Alle ausklappen"
+    },
+    "navCollapseAll": {
+        "message": "Alle einklappen"
+    },
+    "options_unit_type": {
+        "message": "Gib an, wie Einheiten im Konfigurator dargestellt werden"
+    },
+    "options_render": {
+        "message": "Konfigurator Darstellungsoptionen"
+    },
+    "unexpectedError": {
+        "message": "Unerwarteter Fehler: $1"
+    },
+    "disconnecting": {
+        "message": "Trenne..."
+    },
+    "connect": {
+        "message": "Verbinden"
+    },
+    "connecting": {
+        "message": "Verbinde..."
+    },
+    "disconnect": {
+        "message": "Trennen"
+    },
+    "autoConnect": {
+        "message": "Automatisch Verbinden"
+    },
+    "autoConnectEnabled": {
+        "message": "Automatisch Verbinden: Aktiv - Konfigurator verbindet automatisch, wenn ein neuer COM Port erkannt wird"
+    },
+    "autoConnectDisabled": {
+        "message": "Automatisch Verbinden: Inaktiv - Nutzer wählt den COM Port und Verbindet mit der \"Verbinden\" Taste manuell"
+    },
+    "deviceRebooting": {
+        "message": "Gerät - <span style=\"color: red\">Neustart</span>"
+    },
+    "deviceReady": {
+        "message": "Gerät - <span style=\"color: #37a8db\">Bereit</span>"
+    },
+    "savingDefaults": {
+        "message": "Gerät - <span style=\"color: red\">Speichere Standardwerte</span>"
+    },
+    "changeMixerProfileReboot": {
+        "message": "Das Wechseln des Mixer-Profils erfordert einen Neustart. Fortfahren?"
+    },
+    "fcNotConnected": {
+        "message": "Nicht verbunden"
+    },
+    "backupFileIncompatible": {
+        "message": "Die ausgewählte Sicherungsdatei wurde mit einer älteren Version des Konfigurators erstellt und ist mit dieser Version nicht kompatibel."
+    },
+    "backupFileUnmigratable": {
+        "message": "Die ausgewählte Sicherungsdatei wurde mit einer älteren Version des Konfigurators erstellt und kann nicht übertragen werden."
+    },
+    "configMigrationFrom": {
+        "message": "Übertrage Sicherungsdatei, die mit Konfigurator erstellt wurde: $1"
+    },
+    "configMigratedTo": {
+        "message": "Übertrage Konfiguration in den Konfigurator: $1"
+    },
+    "configMigrationSuccessful": {
+        "message": "Konfigurations-Übertragung vollständig: $1"
+    },
+    "documentation": {
+        "message": "Dokumentation"
+    },
+    "tabFirmwareFlasher": {
+        "message": "Firmware-Flasher"
+    },
+    "tabLanding": {
+        "message": "Willkommen"
+    },
+    "tabHelp": {
+        "message": "Dokumentation & Unterstützung"
+    },
+    "navGroupSetup": {
+        "message": "Einrichtung & Konfiguration"
+    },
+    "navGroupFlight": {
+        "message": "Flugsteuerung"
+    },
+    "navGroupTuning": {
+        "message": "Tuning"
+    },
+    "navGroupNavigation": {
+        "message": "Navigation & Mission"
+    },
+    "navGroupSensors": {
+        "message": "Sensoren & Peripherie"
+    },
+    "navGroupLogging": {
+        "message": "Datenaufzeichnung"
+    },
+    "navGroupProgramming": {
+        "message": "Programmierung"
+    },
+    "navGroupTools": {
+        "message": "Werkzeuge"
+    },
+    "tabSetup": {
+        "message": "Status"
+    },
+    "tabCalibration": {
+        "message": "Kalibrierung"
+    },
+    "tabConfiguration": {
+        "message": "Konfiguration"
+    },
+    "tabPorts": {
+        "message": "Anschlüsse"
+    },
+    "tabPidTuning": {
+        "message": "Tuning"
+    },
+    "tabReceiver": {
+        "message": "Empfänger"
+    },
+    "tabMisc": {
+        "message": "Sonstiges"
+    },
+    "tabModeSelection": {
+        "message": "Modus Auswahl"
+    },
+    "tabServos": {
+        "message": "Servos"
+    },
+    "tabFailsafe": {
+        "message": "Failsafe"
+    },
+    "tabEzTune": {
+        "message": "Ez Tune"
+    },
+    "tabGPS": {
+        "message": "GPS"
+    },
+    "tabOutputs": {
+        "message": "Ausgänge"
+    },
+    "tabLedStrip": {
+        "message": "LED Streifen"
+    },
+    "tabRawSensorData": {
+        "message": "Sensoren"
+    },
+    "tabCLI": {
+        "message": "Kommandozeile"
+    },
+    "tabLogging": {
+        "message": "Verkabeltes Logging"
+    },
+    "tabOnboardLogging": {
+        "message": "Blackbox"
+    },
+    "tabAdjustments": {
+        "message": "Anpassungen"
+    },
+    "tabAuxiliary": {
+        "message": "Modi"
+    },
+    "tabSitl": {
+        "message": "SITL"
+    },
+    "sitlDemoMode": {
+        "message": "Demo Modus"
+    },
+    "sitlResetDemoModeData": {
+        "message": "Demo Modus Zurücksetzen"
+    },
+    "sitlOSNotSupported": {
+        "message": "SITL wird auf diesem Betriebssystem nicht unterstützt."
+    },
+    "sitlOptions": {
+        "message": "SITL Optionen"
+    },
+    "sitlEnableSim": {
+        "message": "Simulator Aktivieren"
+    },
+    "sitlSimulator": {
+        "message": "Simulator"
+    },
+    "sitlUseImu": {
+        "message": "Verwende IMU"
+    },
+    "sitlSimIP": {
+        "message": "Simulator-IP"
+    },
+    "sitlPort": {
+        "message": "Simulator Anschluss"
+    },
+    "sitlChannelMap": {
+        "message": "Kanal Zuordnung"
+    },
+    "sitlSimInput": {
+        "message": "Simulator Eingabe"
+    },
+    "sitlInavOutput": {
+        "message": "INAV Ausgabe"
+    },
+    "sitlLog": {
+        "message": "Log"
+    },
+    "sitlStart": {
+        "message": "Start"
+    },
+    "sitlStop": {
+        "message": "Stopp"
+    },
+    "sitlStopped": {
+        "message": "SITL angehalten\n"
+    },
+    "sitlProfiles": {
+        "message": "SITL Profile"
+    },
+    "sitlNew": {
+        "message": "Neu"
+    },
+    "sitlSave": {
+        "message": "Speichern"
+    },
+    "sitlDelete": {
+        "message": "Löschen"
+    },
+    "sitlNewProfile": {
+        "message": "Neues SITL Profil"
+    },
+    "sitlEnterName": {
+        "message": "(Profil Name)"
+    },
+    "sitlProfileExists": {
+        "message": "Profil Name wird bereits verwendet."
+    },
+    "sitlStdProfileCantDeleted": {
+        "message": "SITL standard Profil kann nicht gelöscht werden."
+    },
+    "sitlStdProfileCantOverwritten": {
+        "message": "SITL standard Profil kann nicht überschrieben werden. Bitte neues Profil erstellen."
+    },
+    "serialReceiver": {
+        "message": "Serieller Empfänger"
+    },
+    "sitlSerialProtocoll": {
+        "message": "Anschluss Voreinstellungen für Empfänger-Protokoll"
+    },
+    "sitlSerialStopbits": {
+        "message": "Stop-Bits"
+    },
+    "sitlSerialPort": {
+        "message": "Serieller Empfänger / Proxy FC ist mit Seriellem Anschluss des Hosts verbunden"
+    },
+    "sitlSerialUART": {
+        "message": "Serieller Empfänger ist für SITL UART Konfiguriert"
+    },
+    "sitlSerialParity": {
+        "message": "Parität"
+    },
+    "sitlSerialTcpEnable": {
+        "message": "Aktivieren"
+    },
+    "sitlHelp": {
+        "message": "SITL (Software in the loop) erlaubt es INAV direkt auf dem PC ausgeführt zu werden, ohne einen Flight Controller für simulierte Flüge zu benötigen. Hierfür wurde INAV mit einem PC Compiler erstellt. Die Sensordaten werden durch einen Simulator bereitgestellt.<br/>Derzeit unterstützt werden:<br/><ul><li><a href=\"https://www.realflight.com\" target=\"_blank\">RealFlight</a><br/></li><li><a href=\"https://www.x-plane.com\" target=\"_blank\">X-Plane</a></li></ul>"
+    },
+    "sitlProfilesHelp": {
+        "message": "Profile werden lokal gespeichert. Die Profile enthalten nicht nur alle daten dieses Tabs, sondern auch die Konfigurationsdatei (\"EEPROM\") von INAV selbst. <br><span style=\"color: red\">Note:</span><br>Standard Profile können nicht überschrieben werden. Um Änderungen zu speichern, erstelle ein neues Profil. "
+    },
+    "sitlEnableSimulatorHelp": {
+        "message": "Wenn diese Option deaktiviert wird, können nur UARTs (MSP/Configurator) verwendet werden. Nützlich um INAV zu konfigurieren, ohne den Simulator starten zu müssen."
+    },
+    "sitlUseImuHelp": {
+        "message": "Verwende IMU Sensor-Daten vom Simulator anstelle von Lage-Informationen. (Experimentell, nicht empfohlen)."
+    },
+    "sitlIpHelp": {
+        "message": "IP Adresse des Computers auf dem der Simulator läuft. Wenn der Simulator auf dem selben PC läuft, lass dies auf \"127.0.0.1"
+    },
+    "sitlPortHelp": {
+        "message": "Anschluss-Nummer der Simulator Schnittstelle. Wichtig: Der Anschluss für RealFlight kann nicht geändert werden."
+    },
+    "sitlSerialReceiverHelp": {
+        "message": "Verwende Empfänger (SBUS/CRSF/etc.) welcher per UART-USB Adapter oder Proxy-FC direkt an den Host angeschlossen ist."
+    },
+    "auxiliaryAcroEnabled": {
+        "message": "ACRO"
+    },
+    "serialPortOpened": {
+        "message": "MSP Verbindung <span style=\"color: #37a8db\">erfolgreich</span> geöffnet mit ID: $1"
+    },
+    "serialPortOpenFail": {
+        "message": "<span style=\"color: red\">Fehler</span> beim Öffnen der MSP Verbindung"
+    },
+    "serialPortClosedOk": {
+        "message": "MSP Verbindung <span style=\"color: #37a8db\">erfolgreich</span> geschlossen"
+    },
+    "serialPortClosedFail": {
+        "message": "<span style=\"color: red\">Fehler</span> beim schließen der MSP Verbindung"
+    },
+    "serialPortUnrecoverable": {
+        "message": "Nicht behebbarer <span style=\"color: red\">Fehler</span> bei der seriellen Verbindung, trenne...'"
+    },
+    "connectionConnected": {
+        "message": "Verbunden zu: $1"
+    },
+    "connectionBleType": {
+        "message": "BLE Gerätetyp: $1"
+    },
+    "connectionBleNotSupported": {
+        "message": "<span style=\"color: red\">Verbindungsfehler:</span> Firmware unterstützt keine BLE Verbindung. Abgebrochen."
+    },
+    "connectionBleInterrupted": {
+        "message": "Die Verbindung wurde unerwartet unterbrochen."
+    },
+    "connectionBleError": {
+        "message": "Fehler beim Öffnen des BLE Gerätes: $1"
+    },
+    "connectionBleCliEnter": {
+        "message": "Verbindung über BLE aktiv, Ausgaben können langsamer sein als normal."
+    },
+    "connectionUdpTimeout": {
+        "message": "UDP Verbindung - Zeitüberschreitung."
+    },
+    "usbDeviceOpened": {
+        "message": "USB Gerät <span style=\"color: #37a8db\">erfolgreich</span> geöffnet."
+    },
+    "usbDeviceOpenFail": {
+        "message": "<span style=\"color: red\">Fehler</span> beim Öffnen des USB Gerätes!"
+    },
+    "usbDeviceClosed": {
+        "message": "USB Gerät <span style=\"color: #37a8db\">erfolgreich</span> geschlossen."
+    },
+    "usbDeviceCloseFail": {
+        "message": "<span style=\"color: red\">Fehler</span> beim Schließen des USB Gerätes."
+    },
+    "usbDeviceUdevNotice": {
+        "message": "Sind <strong>udev regeln</strong> korrekt installiert? Siehe Dokumentation für Anweisungen"
+    },
+    "stm32UsbDfuNotFound": {
+        "message": "USB DFU nicht gefunden"
+    },
+    "stm32RebootingToBootloader": {
+        "message": "Initialisiere Neustart in den Bootloader ..."
+    },
+    "stm32RebootingToBootloaderFailed": {
+        "message": "Neustart zu Bootloader: FEHLGESCHLAGEN"
+    },
+    "stm32TimedOut": {
+        "message": "STM32 - Zeitüberschreitung, Programmierung: FEHLGESCHLAGEN"
+    },
+    "stm32WrongResponse": {
+        "message": "STM32 Kommunikation fehlgeschlagen, falsche antwort, erwartet: $1 (0x$2) empfangen: $3 (0x$4)"
+    },
+    "stm32ContactingBootloader": {
+        "message": "Kontaktiere Bootloader ..."
+    },
+    "stm32ContactingBootloaderFailed": {
+        "message": "Kommunikation mit Bootloader fehlgeschlagen!"
+    },
+    "stm32ResponseBootloaderFailed": {
+        "message": "Keine Antrwort vom Bootloader, programmierung: FEHLGESCHLAGEN"
+    },
+    "stm32GlobalEraseExtended": {
+        "message": "Führe globale Speicherlöschung durch (via erweiterte Löschung) ..."
+    },
+    "stm32LocalEraseExtended": {
+        "message": "Führe lokale Speicherlöschung durch (via erweiterte Löschung) ..."
+    },
+    "stm32GlobalErase": {
+        "message": "Führe globale Speicherlöschung durch ..."
+    },
+    "stm32LocalErase": {
+        "message": "Führe lokale Speicherlöschung durch ..."
+    },
+    "stm32InvalidHex": {
+        "message": "Ungültige hex"
+    },
+    "stm32Erase": {
+        "message": "Lösche ..."
+    },
+    "stm32Flashing": {
+        "message": "Schreibe ..."
+    },
+    "stm32Verifying": {
+        "message": "Verifiziere ..."
+    },
+    "stm32ProgrammingSuccessful": {
+        "message": "Programmierung: ERFOLGREICH"
+    },
+    "stm32ProgrammingFailed": {
+        "message": "Programmierung: FEHLGESCHLAGEN"
+    },
+    "stm32AddressLoadFailed": {
+        "message": "Adress-Ladevorgang für den Option-Bytes-Sektor fehlgeschlagen. Sehr wahrscheinlich aufgrund von Leseschutz."
+    },
+    "stm32AddressLoadSuccess": {
+        "message": "Adress-Ladevorgang für den Option-Bytes-Sektor erfolgreich."
+    },
+    "stm32AddressLoadUnknown": {
+        "message": "Adress-Ladevorgang für den Option-Bytes-Sektor mit unbekanntem Fehler fehlgeschlagen. Abbruch."
+    },
+    "stm32NotReadProtected": {
+        "message": "Leseschutz nicht aktiv"
+    },
+    "stm32ReadProtected": {
+        "message": "Board scheint lesegeschützt. Schutz wird aufgehoben. Nicht trennen/abstecken!"
+    },
+    "stm32UnprotectSuccessful": {
+        "message": "Schutzaufhebung erfolgreich."
+    },
+    "stm32UnprotectUnplug": {
+        "message": "AKTION ERFORDERLICH: Flight Controller im DFU-Modus abstecken und neu verbinden, um das Flashen erneut zu versuchen!"
+    },
+    "stm32UnprotectFailed": {
+        "message": "Schutzaufhebung des Boards fehlgeschlagen"
+    },
+    "stm32UnprotectInitFailed": {
+        "message": "Starten der Schutzaufhebungs-Routine fehlgeschlagen"
+    },
+    "noConfigurationReceived": {
+        "message": "Keine Konfiguration innerhalb von <span style=\"color: red\">10 Sekunden</span> empfangen, Kommunikation <span style=\"color: red\">fehlgeschlagen</span>"
+    },
+    "firmwareVersionNotSupported": {
+        "message": "Diese Firmware-Version wird <span style=\"color: red\">nicht unterstützt</span>. Diese Configurator-Version unterstützt Firmware von $1 bis $2 (ausgeschlossen)"
+    },
+    "firmwareVariantNotSupported": {
+        "message": "Diese Firmware-Variante wird <span style=\"color: red\">nicht unterstützt</span>. Bitte auf INAV-Firmware aktualisieren. Nutze die CLI für ein Backup vor dem Flashen. Das CLI-Backup-/Restore-Vorgehen steht in der Dokumentation."
+    },
+    "tabSwitchConnectionRequired": {
+        "message": "Du musst zuerst <strong>verbinden</strong>, bevor du die Tabs öffnen kannst."
+    },
+    "tabSwitchWaitForOperation": {
+        "message": "Das geht gerade <span style=\"color: red\">nicht</span>, bitte warte, bis der aktuelle Vorgang abgeschlossen ist ..."
+    },
+    "tabSwitchUpgradeRequired": {
+        "message": "Du musst deine Firmware <strong>aktualisieren</strong>, bevor du den $1-Tab nutzen kannst."
+    },
+    "firmwareVersion": {
+        "message": "Firmware-Version: <strong>$1</strong>"
+    },
+    "apiVersionReceived": {
+        "message": "MultiWii-API-Version <span style=\"color: #37a8db\">empfangen</span> - <strong>$1</strong>"
+    },
+    "uniqueDeviceIdReceived": {
+        "message": "Eindeutige Geräte-ID <span style=\"color: #37a8db\">empfangen</span> - <strong>0x$1</strong>"
+    },
+    "boardInfoReceived": {
+        "message": "Board: <strong>$1</strong>, Version: <strong>$2</strong>"
+    },
+    "buildInfoReceived": {
+        "message": "Laufende Firmware veröffentlicht am: <strong>$1</strong>"
+    },
+    "fcInfoReceived": {
+        "message": "Flight-Controller-Info, Kennung: <strong>$1</strong>, Version: <strong>$2</strong>"
+    },
+    "notifications_app_just_updated_to_version": {
+        "message": "Anwendung wurde soeben aktualisiert auf Version: $1"
+    },
+    "notifications_click_here_to_start_app": {
+        "message": "Hier klicken, um die Anwendung zu starten"
+    },
+    "statusbar_port_utilization": {
+        "message": "Port-Auslastung:"
+    },
+    "statusbar_usage_download": {
+        "message": "D: $1%"
+    },
+    "statusbar_usage_upload": {
+        "message": "U: $1%"
+    },
+    "statusbar_packet_error": {
+        "message": "Paketfehler:"
+    },
+    "statusbar_i2c_error": {
+        "message": "I2C-Fehler:"
+    },
+    "statusbar_cycle_time": {
+        "message": "Cycle Time:"
+    },
+    "statusbar_cpu_load": {
+        "message": "CPU-Last: $1%"
+    },
+    "statusbar_arming_flags": {
+        "message": "Arming-Flags:"
+    },
+    "dfu_connect_message": {
+        "message": "Bitte nutze den Firmware-Flasher, um auf DFU-Geräte zuzugreifen"
+    },
+    "dfu_erased_kilobytes": {
+        "message": "$1 kB Flash <span style=\"color: #37a8db\">erfolgreich</span> gelöscht"
+    },
+    "dfu_device_flash_info": {
+        "message": "Gerät mit Gesamt-Flash-Größe $1 kiB erkannt"
+    },
+    "dfu_error_image_size": {
+        "message": "<span style=\"color: red; font-weight: bold\">Fehler</span>: Das bereitgestellte Image ist größer als der verfügbare Flash auf dem Chip! Image: $1 kiB, Limit = $2 kiB"
+    },
+    "eeprom_saved_ok": {
+        "message": "EEPROM <span style=\"color: #37a8db\">gespeichert</span>"
+    },
+    "defaultWelcomeIntro": {
+        "message": "Willkommen beim <strong>INAV - Configurator</strong> zum Flashen, Konfigurieren und Tunen deines Flight Controllers."
+    },
+    "defaultWelcomeHead": {
+        "message": "Firmware & Treiber"
+    },
+    "defaultWelcomeHead2": {
+        "message": "INAV-Freunde"
+    },
+    "defaultWelcomeText2": {
+        "message": "INAV wird von einer großartigen Community aus Nutzern, Entwicklern und Unternehmen unterstützt. Hier eine kurze Liste: <a href=\"http://www.mateksys.com/\" target=\"_blank\">Mateksys</a>, <a href=\"https://www.speedybee.com/\" target=\"_blank\">SpeedyBee</a>, <a href=\"https://geprc.com/\" target=\"_blank\">GEPRC</a>. "
+    },
+    "defaultWelcomeText": {
+        "message": "Der Firmware-Quellcode kann <a href=\"https://github.com/iNavFlight\" title=\"www.github.com\" target=\"_blank\">hier</a> heruntergeladen werden<br />Das neueste binäre Firmware-Image ist <a href=\"https://github.com/iNavFlight/inav/releases\" title=\"www.github.com\" target=\"_blank\">hier</a> verfügbar.<br /><br />Die neuesten <strong>STM USB VCP Treiber</strong> können <a href=\"http://www.st.com/web/en/catalog/tools/PF257938\" title=\"http://www.st.com\" target=\"_blank\">hier</a> heruntergeladen werden<br />Das neueste <strong>Zadig</strong> für DFU-Flashing unter Windows kann <a href=\"http://zadig.akeo.ie/\" title=\"http://zadig.akeo.ie\" target=\"_blank\">hier</a> heruntergeladen werden<br />"
+    },
+    "defaultContributingHead": {
+        "message": "Mitwirken"
+    },
+    "defaultContributingText": {
+        "message": "Wenn du INAV noch besser machen möchtest, kannst du auf viele Arten helfen, darunter:<br /><ul><li>Fragen anderer Nutzer in den Foren und im IRC beantworten.</li><li>Code zur Firmware und zum Configurator beitragen — neue Features, Fixes, Verbesserungen</li><li><a href=\"https://github.com/iNavFlight/inav/pulls\" target=\"_blank\">Neue Features/Fixes</a> testen und Feedback geben.</li><li>Bei <a href=\"https://github.com/iNavFlight/inav/issues\" target=\"_blank\">Issues helfen und Feature-Wünsche kommentieren</a>.</li></ul>"
+    },
+    "defaultChangelogHead": {
+        "message": "Configurator - Changelog"
+    },
+    "defaultButtonFirmwareFlasher": {
+        "message": "Firmware-Flasher"
+    },
+    "defaultDonateHead": {
+        "message": "Open Source / Spendenhinweis"
+    },
+    "defaultDonateText": {
+        "message": "Dieses Werkzeug ist vollständig <strong>Open Source</strong> und für alle <strong>INAV</strong>-Nutzer kostenlos verfügbar.<br />Wenn dir INAV oder der INAV Configurator nützlich war, erwäge bitte, seine Entwicklung durch eine Spende zu <strong>unterstützen</strong>."
+    },
+    "defaultSponsorsHead": {
+        "message": "INAV wird unterstützt von"
+    },
+    "communityRCGroupsSupport": {
+        "message": "RC-Groups-Support"
+    },
+    "communityDiscordServer": {
+        "message": "Discord-Server"
+    },
+    "communitySlackSupport": {
+        "message": "Slack-Support-Live-Chat"
+    },
+    "communityTelegramSupport": {
+        "message": "Telegram-Kanal"
+    },
+    "communityFacebookSupport": {
+        "message": "Facebook-Gruppe"
+    },
+    "initialSetupBackupAndRestoreApiVersion": {
+        "message": "<span style=\"color: red\">Backup- und Wiederherstellungs-Funktion deaktiviert.</span> Deine Firmware hat API-Version <span style=\"color: red\">$1</span>, Backup und Wiederherstellung erfordert <span style=\"color: #37a8db\">$2</span>. Bitte sichere deine Einstellungen über die CLI, siehe INAV-Dokumentation für das Vorgehen."
+    },
+    "initialSetupButtonCalibrateAccel": {
+        "message": "Beschleunigungssensor kalibrieren"
+    },
+    "initialSetupCalibrateAccelText": {
+        "message": "6-Punkt-Kalibrierung des Beschleunigungssensors. Siehe INAV-Wiki und folge der Sensor-Kalibrierung für weitere Informationen"
+    },
+    "initialSetupButtonCalibrateMag": {
+        "message": "Magnetometer kalibrieren"
+    },
+    "initialSetupCalibrateMagText": {
+        "message": "Bewege den Multirotor um mindestens <strong>360</strong> Grad um alle Rotationsachsen, du hast 30 Sekunden für diese Aufgabe"
+    },
+    "initialSetupButtonReset": {
+        "message": "Auf Standardeinstellungen zurücksetzen"
+    },
+    "initialSetupResetText": {
+        "message": "Einstellungen auf <strong>Standard</strong> zurücksetzen"
+    },
+    "initialSetupButtonBackup": {
+        "message": "Backup"
+    },
+    "initialSetupButtonRestore": {
+        "message": "Wiederherstellen"
+    },
+    "initialSetupBackupRestoreText": {
+        "message": "<strong>Sichere</strong> deine Konfiguration für den Fall eines Unfalls. <strong>CLI</strong>-Einstellungen sind <span style=\"color: red\">nicht</span> enthalten — siehe CLI-Befehl 'dump'"
+    },
+    "initialSetupBackupSuccess": {
+        "message": "Backup <span style=\"color: #37a8db\">erfolgreich</span> gespeichert"
+    },
+    "initialSetupRestoreSuccess": {
+        "message": "Konfiguration <span style=\"color: #37a8db\">erfolgreich</span> wiederhergestellt"
+    },
+    "initialSetupButtonResetZaxis": {
+        "message": "Z-Achse zurücksetzen, Offset: 0 Grad"
+    },
+    "initialSetupButtonResetZaxisValue": {
+        "message": "Z-Achse zurücksetzen, Offset: $1 Grad"
+    },
+    "initialSetupMixerHead": {
+        "message": "Mixer-Typ"
+    },
+    "initialSetupThrottleHead": {
+        "message": "Throttle-Einstellungen"
+    },
+    "initialSetupMinimum": {
+        "message": "Minimum:"
+    },
+    "initialSetupMaximum": {
+        "message": "Maximum:"
+    },
+    "initialSetupFailsafe": {
+        "message": "Failsafe:"
+    },
+    "initialSetupMinCommand": {
+        "message": "MinCommand:"
+    },
+    "initialSetupBatteryHead": {
+        "message": "Akku"
+    },
+    "initialSetupMinCellV": {
+        "message": "Min. Zellenspannung:"
+    },
+    "initialSetupMaxCellV": {
+        "message": "Max. Zellenspannung:"
+    },
+    "initialSetupVoltageScale": {
+        "message": "Spannungs-Skalierung:"
+    },
+    "initialSetupAccelTrimsHead": {
+        "message": "Beschleunigungssensor-Trims"
+    },
+    "initialSetupPitch": {
+        "message": "Pitch:"
+    },
+    "initialSetupRoll": {
+        "message": "Roll:"
+    },
+    "initialSetupMagHead": {
+        "message": "Magnetometer"
+    },
+    "initialSetupDeclination": {
+        "message": "Deklination:"
+    },
+    "initialSetupInfoHead": {
+        "message": "Info"
+    },
+    "initialSetupBatteryVoltage": {
+        "message": "Akkuspannung:"
+    },
+    "initialSetupBatteryDetectedCells": {
+        "message": "Erkannte Zellenzahl:"
+    },
+    "initialSetupBatteryDetectedCellsValue": {
+        "message": "$1"
+    },
+    "initialSetupBatteryPercentage": {
+        "message": "Akku verbleibend:"
+    },
+    "initialSetupBatteryPercentageValue": {
+        "message": "$1 %"
+    },
+    "initialSetupBatteryRemainingCapacity": {
+        "message": "Verbleibende Akkukapazität"
+    },
+    "initialSetupBatteryRemainingCapacityValue": {
+        "message": "$1 $2"
+    },
+    "initialSetupBatteryFull": {
+        "message": "Vollen Akku beim Verbinden annehmen"
+    },
+    "initialSetupBatteryFullValue": {
+        "message": "$1"
+    },
+    "initialSetupBatteryThresholds": {
+        "message": "Kapazitäts-Schwellen aktiv"
+    },
+    "initialSetupBatteryThresholdsValue": {
+        "message": "$1"
+    },
+    "initialSetup_Wh_drawn": {
+        "message": "Entnommene Kapazität:"
+    },
+    "initialSetup_Wh_drawnValue": {
+        "message": "$1 Wh"
+    },
+    "initialSetupBatteryVoltageValue": {
+        "message": "$1 V"
+    },
+    "initialSetupDrawn": {
+        "message": "Entnommene Kapazität:"
+    },
+    "initialSetupCurrentDraw": {
+        "message": "Stromaufnahme:"
+    },
+    "initialSetupPowerDraw": {
+        "message": "Leistungsaufnahme:"
+    },
+    "initialSetupPowerDrawValue": {
+        "message": "$1 W"
+    },
+    "initialSetupBatteryMahValue": {
+        "message": "$1 mAh"
+    },
+    "initialSetupCurrentDrawValue": {
+        "message": "$1 A"
+    },
+    "initialSetupRSSI": {
+        "message": "RSSI:"
+    },
+    "initialSetupRSSIValue": {
+        "message": "$1 %"
+    },
+    "initialSetupGPSHead": {
+        "message": "GPS"
+    },
+    "initialSetupInstrumentsHead": {
+        "message": "Instrumente"
+    },
+    "initialSetupButtonSave": {
+        "message": "Speichern"
+    },
+    "initialSetupModel": {
+        "message": "Modell: $1"
+    },
+    "initialSetupAttitude": {
+        "message": "$1 Grad"
+    },
+    "initialSetupAccelCalibStarted": {
+        "message": "Beschleunigungssensor-Kalibrierung gestartet"
+    },
+    "initialSetupAccelCalibEnded": {
+        "message": "Beschleunigungssensor-Kalibrierung <span style=\"color: #37a8db\">abgeschlossen</span>"
+    },
+    "initialSetupMagCalibStarted": {
+        "message": "Magnetometer-Kalibrierung gestartet"
+    },
+    "initialSetupMagCalibEnded": {
+        "message": "Magnetometer-Kalibrierung <span style=\"color: #37a8db\">abgeschlossen</span>"
+    },
+    "initialSetupOpflowCalibStarted": {
+        "message": "Optical-Flow-Kalibrierung gestartet"
+    },
+    "initialSetupOpflowCalibEnded": {
+        "message": "Optical-Flow-Kalibrierung <span style=\"color: #37a8db\">abgeschlossen</span>"
+    },
+    "initialSetupSettingsRestored": {
+        "message": "Einstellungen auf <strong>Standard</strong> zurückgesetzt"
+    },
+    "initialSetupEepromSaved": {
+        "message": "EEPROM <span style=\"color: #37a8db\">gespeichert</span>: Setup"
+    },
+    "RX_PPM": {
+        "message": "PPM-RX-Eingang"
+    },
+    "RX_SERIAL": {
+        "message": "Serieller Empfänger (SPEKSAT, SBUS, SUMD)"
+    },
+    "RX_PWM": {
+        "message": "PWM-RX-Eingang (eine Leitung pro Kanal)"
+    },
+    "RX_MSP": {
+        "message": "MSP-RX-Eingang (Steuerung über MSP-Port)"
+    },
+    "RX_SPI": {
+        "message": "RX-SPI-basierter Empfänger (NRF24L01, RFM22)"
+    },
+    "RX_NONE": {
+        "message": "Kein Empfänger"
+    },
+    "featureVBAT": {
+        "message": "Akkuspannungs-Überwachung"
+    },
+    "featureTX_PROF_SEL": {
+        "message": "Profilauswahl per TX-Stick-Kommando"
+    },
+    "featureINFLIGHT_ACC_CAL": {
+        "message": "Level-Kalibrierung im Flug"
+    },
+    "featureMOTOR_STOP": {
+        "message": "Motoren bei niedrigem Throttle stoppen"
+    },
+    "featureSERVO_TILT": {
+        "message": "Servo-Gimbal"
+    },
+    "featureBAT_PROFILE_AUTOSWITCH": {
+        "message": "Automatische Akku-Profil-Auswahl"
+    },
+    "featureBAT_PROFILE_AUTOSWITCHTip": {
+        "message": "Akku-Profil automatisch anhand der Akkuspannung wählen, wenn der Akku angesteckt wird"
+    },
+    "featureTHR_VBAT_COMP": {
+        "message": "Throttle-Spannungskompensation"
+    },
+    "featureTHR_VBAT_COMPTip": {
+        "message": "Kompensiert automatisch den Spannungsabfall beim Entladen des Akkus, um den Schub relativ zum Throttle konstant zu halten"
+    },
+    "featureSOFTSERIAL": {
+        "message": "CPU-basierte serielle Ports aktivieren"
+    },
+    "featureSOFTSERIALTip": {
+        "message": "Konfiguriere die Ports nach dem Aktivieren im Ports-Tab."
+    },
+    "featureGPS": {
+        "message": "GPS für Navigation und Telemetrie"
+    },
+    "featureGPSTip": {
+        "message": "Zuerst das Port-Szenario konfigurieren"
+    },
+    "featureFAILSAFE": {
+        "message": "Failsafe-Einstellungen bei RX-Signalverlust anwenden"
+    },
+    "featureSONAR": {
+        "message": "Sonar"
+    },
+    "featureTELEMETRY": {
+        "message": "Telemetrie-Ausgabe"
+    },
+    "featureCURRENT_METER": {
+        "message": "Akkustrom-Überwachung"
+    },
+    "featureREVERSIBLE_MOTORS": {
+        "message": "Modus für umkehrbare Motoren (zur Verwendung mit umkehrbaren ESCs)"
+    },
+    "featureRSSI_ADC": {
+        "message": "Analoger RSSI-Eingang"
+    },
+    "featureLED_STRIP": {
+        "message": "Unterstützung für mehrfarbige RGB-LED-Strips"
+    },
+    "featureDASHBOARD": {
+        "message": "OLED-Bildschirm-Anzeige"
+    },
+    "featureONESHOT125": {
+        "message": "ONESHOT-ESC-Unterstützung"
+    },
+    "featureONESHOT125Tip": {
+        "message": "Vor dem Aktivieren Flugakku trennen und Propeller entfernen."
+    },
+    "featurePWM_OUTPUT_ENABLE": {
+        "message": "Motor- und Servo-Ausgang aktivieren"
+    },
+    "featurePWM_OUTPUT_ENABLETip": {
+        "message": "Das Aktivieren dieser Option ist erforderlich, damit INAV Signale an den ESC sendet. Es ist eine Sicherheitsmaßnahme, die verhindert, dass Servos direkt nach dem Flashen des Flight Controllers beschädigt werden."
+    },
+    "featureBLACKBOX": {
+        "message": "Blackbox-Flugdatenschreiber"
+    },
+    "featureBLACKBOXTip": {
+        "message": "Nach dem Aktivieren über den Blackbox-Tab konfigurieren."
+    },
+    "onboardLoggingBlackbox": {
+        "message": "Blackbox-Aufzeichnungsgerät"
+    },
+    "onboardLoggingBlackboxRate": {
+        "message": "Anteil der Flight-Loop-Iterationen, der aufgezeichnet wird (Aufzeichnungsrate)"
+    },
+    "featureCHANNEL_FORWARDING": {
+        "message": "AUX-Kanäle an Servo-Ausgänge weiterleiten"
+    },
+    "featureSOFTSPI": {
+        "message": "CPU-basiertes SPI"
+    },
+    "featurePWM_SERVO_DRIVER": {
+        "message": "Externer PWM-Servo-Treiber"
+    },
+    "featurePWM_SERVO_DRIVERTip": {
+        "message": "Nutze den externen PCA9685-PWM-Treiber, um bis zu 16 Servos an den Flight Controller anzuschließen. Der PCA9685 muss angeschlossen sein, um dieses Feature zu aktivieren."
+    },
+    "featureRSSI_ADCTip": {
+        "message": "RSSI ist ein Maß für die Signalstärke und sehr praktisch, damit du weißt, wann dein Modell außer Reichweite gerät oder unter RF-Störungen leidet."
+    },
+    "featureOSD": {
+        "message": "OSD"
+    },
+    "featureAIRMODE": {
+        "message": "AIRMODE dauerhaft aktivieren"
+    },
+    "featureFW_LAUNCH": {
+        "message": "Launch-Modus für Flächenmodelle dauerhaft aktivieren"
+    },
+    "featureFW_AUTOTRIM": {
+        "message": "Servos bei Flächenmodellen kontinuierlich trimmen"
+    },
+    "featureFW_AUTOTRIMTip": {
+        "message": "Beim Fliegen in einem stabilisierten Modus werden die Servo-Mittelpunkte kontinuierlich angepasst, damit das Flugzeug beim Umschalten in den manuellen Modus geradeaus weiterfliegt. Erfordert GPS."
+    },
+    "featureDYNAMIC_FILTERS": {
+        "message": "Dynamische Gyro-Filter"
+    },
+    "featureDYNAMIC_FILTERSTip": {
+        "message": "Nutzt automatische FFT-Gyro-Analyse, um Notch-Filter zur Dämpfung von Gyro-Rauschen einzurichten. Sollte immer aktiviert sein!"
+    },
+    "configurationFeatureEnabled": {
+        "message": "Aktiviert"
+    },
+    "configurationFeatureName": {
+        "message": "Feature"
+    },
+    "configurationFeatureDescription": {
+        "message": "Beschreibung"
+    },
+    "configurationMixer": {
+        "message": "Mixer"
+    },
+    "configurationFeatures": {
+        "message": "Weitere Features"
+    },
+    "configurationReceiver": {
+        "message": "Empfänger-Modus"
+    },
+    "configurationRSSI": {
+        "message": "RSSI (Signalstärke)"
+    },
+    "configurationEscFeatures": {
+        "message": "ESC-/Motor-Features"
+    },
+    "serialrx_inverted": {
+        "message": "Serieller Port invertiert (im Vergleich zum Protokoll-Standard)"
+    },
+    "serialrx_halfduplex": {
+        "message": "Serieller Empfänger Halbduplex"
+    },
+    "serialrx_frSkyPitchRollLabel": {
+        "message": "Pitch- & Roll-Sensoren in der Telemetrie verwenden"
+    },
+    "serialrx_frSkyPitchRollHelp": {
+        "message": "Sendet Telemetrie-Sensoren für Pitch- und Roll-Winkel anstelle der standardmäßigen rohen Beschleunigungssensor-Daten. Sollte <strong>aktiviert</strong> werden, wenn die INAV OpenTX/EdgeTX- oder ETHOS-Telemetrie-Dashboard-LUA-Skripte verwendet werden."
+    },
+    "serialrx_frSkyFuelUnitLabel": {
+        "message": "SmartPort Fuel-Einheiten"
+    },
+    "serialrx_frSkyFuelUnitHelp": {
+        "message": "Wähle die Daten, die an den <strong>Fuel</strong>-Telemetrie-Sensor gesendet werden sollen."
+    },
+    "configurationFeaturesHelp": {
+        "message": "<strong>Hinweis:</strong> Nicht alle Kombinationen von Features sind gültig. Erkennt die Flight-Controller-Firmware ungültige Feature-Kombinationen, werden konfliktbehaftete Features deaktiviert.<br /><strong>Hinweis:</strong> Konfiguriere die seriellen Ports <span style=\"color: red\">bevor</span> du die Features aktivierst, die diese Ports nutzen."
+    },
+    "configurationSerialRXHelp": {
+        "message": "<strong>Hinweis:</strong> Denke daran, einen seriellen Port (über den Ports-Tab) für den seriellen Empfänger zu konfigurieren"
+    },
+    "configurationFrSkyOptions": {
+        "message": "FrSky-Optionen"
+    },
+    "configurationFrSkyOptions_HELP": {
+        "message": "Diese Optionen bieten schnellen Zugriff auf die Konfiguration der SmartPort-Telemetrie-Sensoren für die OpenTX/EdgeTX- und ETHOS-Telemetrie-LUA-Skripte. Beachte: Bei Verwendung von SBUS musst du SmartPort-Telemetrie auf einem separaten seriellen Port einrichten."
+    },
+    "configurationSensorAlignmentMag": {
+        "message": "MAG-Ausrichtung"
+    },
+    "configurationSensorAlignmentMagRoll": {
+        "message": "Roll"
+    },
+    "configurationSensorAlignmentMagPitch": {
+        "message": "Pitch"
+    },
+    "configurationSensorAlignmentMagYaw": {
+        "message": "Yaw"
+    },
+    "configurationAccelTrims": {
+        "message": "Beschleunigungssensor-Trim"
+    },
+    "configurationAccelTrimRoll": {
+        "message": "Beschleunigungssensor Roll-Trim"
+    },
+    "configurationAccelTrimPitch": {
+        "message": "Beschleunigungssensor Pitch-Trim"
+    },
+    "configurationMagDeclination": {
+        "message": "Magnetometer-Deklination [Grad]"
+    },
+    "configurationAutoDisarmDelay": {
+        "message": "Sekunden bis Disarm bei niedrigem Throttle"
+    },
+    "configurationAutoDisarmDelayHelp": {
+        "message": "Wird nur bei Stick-Arming verwendet (also nicht bei Verwendung eines Schalters)"
+    },
+    "configurationThrottleMinimum": {
+        "message": "Minimaler Throttle"
+    },
+    "configurationThrottleMid": {
+        "message": "Mittlerer Throttle [Mittelwert der RC-Eingänge]"
+    },
+    "configurationThrottleMaximum": {
+        "message": "Maximaler Throttle"
+    },
+    "configurationThrottleMinimumCommand": {
+        "message": "Minimum Command"
+    },
+    "configurationVoltageCurrentSensor": {
+        "message": "Spannungs- & Stromsensoren"
+    },
+    "configurationBatteryCurrent": {
+        "message": "Akkustrom"
+    },
+    "configurationVoltageSource": {
+        "message": "Spannungsquelle für Alarme und Telemetrie"
+    },
+    "configurationVoltageSourceHelp": {
+        "message": "Rohspannung ist die direkt vom Akku gelesene Spannung. Sag-kompensierte Spannung ist die berechnete Spannung, die der Akku ohne Last hätte (simuliert einen idealen Akku und sollte Fehlalarme durch hohe Lasten vermeiden)"
+    },
+    "configurationBatteryCells": {
+        "message": "Zellenanzahl (0 = automatisch)"
+    },
+    "configurationBatteryCellsHelp": {
+        "message": "Setze dies auf die Zellenzahl deines Akkus, um die automatische Zellenerkennung zu deaktivieren oder das automatische Umschalten von Akku-Profilen zu ermöglichen. 7S-, 9S- und 11S-Akkus können nicht automatisch erkannt werden."
+    },
+    "configurationBatteryCellDetectVoltage": {
+        "message": "Maximale Zellenspannung für die Zellenerkennung"
+    },
+    "configurationBatteryCellDetectVoltageHelp": {
+        "message": "Maximale Zellenspannung für die automatische Zellenerkennung. Sollte höher als die maximale Zellenspannung sein, um mögliche Drift in der gemessenen Spannung zu berücksichtigen und die Zellenerkennung genau zu halten."
+    },
+    "configurationBatteryMinimum": {
+        "message": "Minimale Zellenspannung"
+    },
+    "configurationBatteryMaximum": {
+        "message": "Maximale Zellenspannung"
+    },
+    "configurationBatteryWarning": {
+        "message": "Warn-Zellenspannung"
+    },
+    "configurationBatteryScale": {
+        "message": "Spannungs-Skalierung"
+    },
+    "configurationBatteryVoltage": {
+        "message": "Akkuspannung"
+    },
+    "configurationCurrentScale": {
+        "message": "Stromsensor-Skalierung"
+    },
+    "configurationCurrentScaleHelp": {
+        "message": "Skaliert die Ausgangsspannung auf Milliampere [1/10 mV/A]"
+    },
+    "configurationCurrentOffset": {
+        "message": "Offset in Millivolt-Schritten"
+    },
+    "configurationBatteryMultiwiiCurrent": {
+        "message": "Unterstützung für ältere Multiwii-MSP-Stromausgabe aktivieren"
+    },
+    "configurationBatterySettings": {
+        "message": "Akku-Einstellungen"
+    },
+    "configurationBatterySettingsHelp": {
+        "message": "Diese Einstellungen gelten für das aktuell gewählte Akku-Profil "
+    },
+    "configurationBatteryCapacityValue": {
+        "message": "Kapazität"
+    },
+    "configurationBatteryCapacityWarning": {
+        "message": "Warn-Kapazität (verbleibende %)"
+    },
+    "configurationBatteryCapacityCritical": {
+        "message": "Kritische Kapazität (verbleibende %)"
+    },
+    "configurationBatteryCapacityUnit": {
+        "message": "Einheit der Akkukapazität"
+    },
+    "configurationPowerLimits": {
+        "message": "Leistungsbegrenzung"
+    },
+    "configurationPowerLimitsHelp": {
+        "message": "Begrenze Batteriestrom und Leistungsaufnahme, um Akku und ESCs zu schützen. 0 = deaktiviert. Einheiten: dA (Deci-Ampere) = A×10, dW (Deci-Watt) = W×10, ds (Deci-Sekunden) = s×10."
+    },
+    "configurationPowerLimitsNote": {
+        "message": "Schützt den Akku vor Überstrom durch sanftes Reduzieren des Throttles. Erfordert Stromsensor. Setze Dauer- und Burst-Grenzen passend zu deinen Akku-Spezifikationen."
+    },
+    "configurationLimitContCurrent": {
+        "message": "Dauerstrom-Limit (dA)"
+    },
+    "configurationLimitContCurrentHelp": {
+        "message": "Maximaler Dauerstrom in Deci-Ampere (dA). Beispiel: 500 = 50A. 0 = Strombegrenzung deaktiviert."
+    },
+    "configurationLimitBurstCurrent": {
+        "message": "Burst-Strom-Limit (dA)"
+    },
+    "configurationLimitBurstCurrentHelp": {
+        "message": "Höherer Strom für kurze Bursts (Punch-Outs, Steigflüge). Beispiel: 750 = 75A. Sollte >= Dauerlimit sein."
+    },
+    "configurationLimitBurstCurrentTime": {
+        "message": "Burst-Strom-Zeit (ds)"
+    },
+    "configurationLimitBurstCurrentTimeHelp": {
+        "message": "Dauer, für die der Burst-Strom erlaubt ist, in Deci-Sekunden (ds). Beispiel: 100 = 10 Sekunden. Danach fällt das Limit auf den Dauerwert."
+    },
+    "configurationLimitBurstCurrentFalldownTime": {
+        "message": "Burst-Strom-Abklingzeit (ds)"
+    },
+    "configurationLimitBurstCurrentFalldownTimeHelp": {
+        "message": "Sanfte Übergangszeit vom Burst- zum Dauerlimit in Deci-Sekunden (ds). Beispiel: 20 = 2 Sekunden."
+    },
+    "configurationLimitContPower": {
+        "message": "Dauerleistungs-Limit (dW)"
+    },
+    "configurationLimitContPowerHelp": {
+        "message": "Maximale Dauerleistung in Deci-Watt (dW). Beispiel: 8000 = 800W. 0 = Leistungsbegrenzung deaktiviert. Erfordert Spannungsmessung."
+    },
+    "configurationLimitBurstPower": {
+        "message": "Burst-Leistungs-Limit (dW)"
+    },
+    "configurationLimitBurstPowerHelp": {
+        "message": "Höhere Leistung für kurze Bursts. Beispiel: 10000 = 1000W. Sollte >= Dauerlimit sein."
+    },
+    "configurationLimitBurstPowerTime": {
+        "message": "Burst-Leistungs-Zeit (ds)"
+    },
+    "configurationLimitBurstPowerTimeHelp": {
+        "message": "Dauer, für die die Burst-Leistung erlaubt ist, in Deci-Sekunden (ds). Beispiel: 50 = 5 Sekunden."
+    },
+    "configurationLimitBurstPowerFalldownTime": {
+        "message": "Burst-Leistungs-Abklingzeit (ds)"
+    },
+    "configurationLimitBurstPowerFalldownTimeHelp": {
+        "message": "Sanfte Übergangszeit vom Burst- zum Dauerleistungs-Limit in Deci-Sekunden (ds). Beispiel: 10 = 1 Sekunde."
+    },
+    "configurationLaunch": {
+        "message": "Flächenmodell Auto-Launch-Einstellungen"
+    },
+    "configurationLaunchVelocity": {
+        "message": "Schwellen-Geschwindigkeit"
+    },
+    "configurationLaunchVelocityHelp": {
+        "message": "Vorwärtsgeschwindigkeits-Schwelle für die Swing-Launch-Erkennung. Standard: 300 [100-10000]"
+    },
+    "configurationLaunchAccel": {
+        "message": "Schwellen-Beschleunigung"
+    },
+    "configurationLaunchAccelHelp": {
+        "message": "Vorwärtsbeschleunigungs-Schwelle für Bungee- oder Wurf-Start, 1G = 981 cm/s/s. Standard: 1863 [1000-20000]"
+    },
+    "configurationLaunchMaxAngle": {
+        "message": "Max. Wurfwinkel"
+    },
+    "configurationLaunchMaxAngleHelp": {
+        "message": "Maximaler Wurfwinkel (Pitch/Roll kombiniert), um den Start als erfolgreich zu werten. Auf 180 setzen, um komplett zu deaktivieren. Standard: 45 [5-180]"
+    },
+    "configurationLaunchDetectTime": {
+        "message": "Erkennungszeit"
+    },
+    "configurationLaunchDetectTimeHelp": {
+        "message": "Zeit, für die die Schwellen überschritten werden müssen, um einen Start zu erkennen. Standard: 40 [10-1000]"
+    },
+    "configurationLaunchThr": {
+        "message": "Launch-Throttle"
+    },
+    "configurationLaunchThrHelp": {
+        "message": "Launch-Throttle — Throttle, der während der Startsequenz gesetzt wird. Standard: 1700 [1000-2000]"
+    },
+    "configurationLaunchIdleThr": {
+        "message": "Leerlauf-Throttle"
+    },
+    "configurationLaunchIdleThrHelp": {
+        "message": "Leerlauf-Throttle — Throttle, der vor dem Start der Sequenz gesetzt wird. Liegt er unter dem minimalen Throttle, erzwingt er Motorstopp oder Leerlauf-Throttle (je nachdem, ob MOTOR_STOP aktiviert ist). Liegt er über dem minimalen Throttle, erzwingt er diesen Wert (bei aktiviertem MOTOR_STOP wird er entsprechend der Throttle-Stick-Position behandelt). Standard: 1000 [1000-2000]"
+    },
+    "configurationLaunchIdleDelay": {
+        "message": "Leerlauf-Throttle-Verzögerung"
+    },
+    "configurationLaunchIdleDelayHelp": {
+        "message": "Setzt eine Zeitverzögerung zwischen dem Anheben des Throttles für den Start und dem Anlaufen des Motors im Leerlauf. Standard: 0 [0-60000]"
+    },
+    "configurationWiggleWakeIdle": {
+        "message": "Wackeln zum Aktivieren des Leerlaufs"
+    },
+    "configurationWiggleWakeIdleHelp": {
+        "message": "Wenn aktiviert, erlaubt dieses Feature ein Yaw-Wackeln des Modells, um die Motoren aus dem Leerlauf zu wecken.<br />0: Deaktiviert (Standard)<br />1: 1 Wackeln — höherer Erkennungspunkt, für Flugzeuge ohne leicht bewegbares Leitwerk<br />2: 2 Wackeln — niedrigerer Erkennungspunkt, erfordert aber die wiederholte Aktion. Gedacht für größere Modelle und Flugzeuge mit Leitwerk"
+    },
+    "configurationLaunchMotorDelay": {
+        "message": "Motor-Verzögerung"
+    },
+    "configurationLaunchMotorDelayHelp": {
+        "message": "Verzögerung zwischen erkanntem Start und Beginn der Startsequenz samt Hochdrehen. Standard: 500 [0-5000]"
+    },
+    "configurationLaunchSpinupTime": {
+        "message": "Motor-Hochlaufzeit"
+    },
+    "configurationLaunchSpinupTimeHelp": {
+        "message": "Zeit, um die Leistung vom minimalen Throttle auf nav_fw_launch_thr zu bringen, um große Belastung des ESC und großes Drehmoment des Propellers zu vermeiden. Standard: 100 [0-1000]"
+    },
+    "configurationLaunchMinTime": {
+        "message": "Minimale Launch-Zeit"
+    },
+    "configurationLaunchMinTimeHelp": {
+        "message": "Erlaubt dem Launch-Modus, mindestens diese Zeit [ms] auszuführen und Stick-Bewegungen zu ignorieren. Standard: 0 [0-60000]"
+    },
+    "configurationLaunchTimeout": {
+        "message": "Launch-Timeout"
+    },
+    "configurationLaunchTimeoutHelp": {
+        "message": "Maximale Zeit für die Ausführung der Startsequenz. Nach dieser Zeit wird der LAUNCH-Modus abgeschaltet und der reguläre Flugmodus übernimmt. Standard: 5000 [0-60000]"
+    },
+    "configurationLaunchEndTime": {
+        "message": "Ende-Übergangszeit"
+    },
+    "configurationLaunchEndTimeHelp": {
+        "message": "Sanfte Übergangszeit am Ende des Starts (ms). Diese wird zum Launch-Timeout addiert. Standard: 2000 [0-5000]"
+    },
+    "configurationLaunchMaxAltitude": {
+        "message": "Maximale Höhe"
+    },
+    "configurationLaunchMaxAltitudeHelp": {
+        "message": "Höhe, bei der der LAUNCH-Modus abgeschaltet wird und der reguläre Flugmodus übernimmt. Standard: 0 [0-60000]"
+    },
+    "configurationLaunchClimbAngle": {
+        "message": "Steigwinkel"
+    },
+    "configurationLaunchClimbAngleHelp": {
+        "message": "Steigwinkel (Lage des Modells, nicht die Steigflugbahn) für die Startsequenz (Grad), wird zusätzlich durch global max_angle_inclination_pit begrenzt. Standard: 18 [5-45]"
+    },
+    "configuration3d": {
+        "message": "Umkehrbare Motoren"
+    },
+    "configuration3dDeadbandLow": {
+        "message": "Umkehrbare Motoren Deadband unten"
+    },
+    "configuration3dDeadbandHigh": {
+        "message": "Umkehrbare Motoren Deadband oben"
+    },
+    "configuration3dNeutral": {
+        "message": "Umkehrbare Motoren Neutral"
+    },
+    "configuration3dDeadbandThrottle": {
+        "message": "Umkehrbare Motoren Deadband Throttle"
+    },
+    "configurationSystem": {
+        "message": "Systemkonfiguration"
+    },
+    "configurationLoopTime": {
+        "message": "Flight Controller Loop Time"
+    },
+    "configurationCalculatedCyclesSec": {
+        "message": "Zyklen/Sek (Hz)"
+    },
+    "configurationGPS": {
+        "message": "Konfiguration"
+    },
+    "configurationGPSProtocol": {
+        "message": "Protokoll"
+    },
+    "configurationGPSUseGalileo": {
+        "message": "GPS nutzt Galileo-Satelliten (EU)"
+    },
+    "configurationGPSUseBeidou": {
+        "message": "GPS nutzt BeiDou-Satelliten (CN)"
+    },
+    "configurationGPSUseGlonass": {
+        "message": "GPS nutzt Glonass-Satelliten (RU)"
+    },
+    "gpsPresetMode": {
+        "message": "GPS-Konfigurations-Preset"
+    },
+    "gpsPresetModeHelp": {
+        "message": "Wähle ein für dein GPS-Modul optimiertes Preset oder „Manuell“ für eine eigene Konfiguration. Die automatische Erkennung identifiziert dein GPS-Modul, sofern verbunden."
+    },
+    "gpsUpdateRate": {
+        "message": "GPS-Aktualisierungsrate (Hz)"
+    },
+    "gpsUpdateRateHelp": {
+        "message": "Wie oft das GPS-Modul Positions-Updates sendet. Höhere Raten bieten geringere Latenz, können aber bei mehreren Konstellationen auf M10-Modulen die Genauigkeit verringern."
+    },
+    "gpsAutoDetectFailed": {
+        "message": "GPS-Modul konnte nicht automatisch erkannt werden. Bitte Flight Controller verbinden oder ein manuelles Preset wählen."
+    },
+    "gpsAutoDetectSuccess": {
+        "message": "GPS-Modul erkannt:"
+    },
+    "tzOffset": {
+        "message": "Zeitzonen-Offset"
+    },
+    "tzOffsetHelp": {
+        "message": "Zeitzonen-Offset von UTC. Wird auf die GPS-Zeit für die Protokollierung und das Zeitstempeln von Blackbox-Logs angewendet. (Standard = 0 min)"
+    },
+    "tzAutomaticDST": {
+        "message": "Automatische Sommerzeit"
+    },
+    "tzAutomaticDSTHelp": {
+        "message": "Fügt der GPS-Zeit bei Bedarf automatisch die Sommerzeit hinzu oder ignoriert sie einfach. Enthält Presets für EU und USA — wenn du außerhalb dieser Gebiete lebst, wird empfohlen, die Sommerzeit manuell über tz_offset zu verwalten. (Standard = Aus)"
+    },
+    "configurationGPSBaudrate": {
+        "message": "Baudrate"
+    },
+    "configurationGPSubxSbas": {
+        "message": "Boden-Assistenz-Typ"
+    },
+    "receiverType": {
+        "message": "Empfänger-Typ"
+    },
+    "configurationSerialRX": {
+        "message": "Serieller Empfänger-Anbieter"
+    },
+    "configurationSPIProtocol": {
+        "message": "RX-SPI-Protokoll"
+    },
+    "configurationEepromSaved": {
+        "message": "EEPROM <span style=\"color: #37a8db\">gespeichert</span>: Konfiguration"
+    },
+    "configurationButtonSave": {
+        "message": "Speichern und Neustarten"
+    },
+    "configurationVTX": {
+        "message": "VTX"
+    },
+    "configurationVTXBand": {
+        "message": "Band"
+    },
+    "configurationNoBand": {
+        "message": "Keins"
+    },
+    "configurationVTXNoBandHelp": {
+        "message": "Die VTX-Frequenz wurde manuell gesetzt. Die Wahl eines Bands überschreibt die konfigurierte Frequenz."
+    },
+    "configurationVTXChannel": {
+        "message": "Kanal"
+    },
+    "configurationVTXPower": {
+        "message": "Leistungsstufe"
+    },
+    "configurationVTXPowerHelp": {
+        "message": "VTX-Leistungsstufe. Die genaue Leistung in mW (oder dBm) hängt von der jeweiligen Hardware ab. Siehe VTX-Handbuch."
+    },
+    "configurationVTXLowerPowerDisarm": {
+        "message": "Niedrige Leistung verwenden, solange das Modell disarmed ist"
+    },
+    "configurationVTXLowerPowerDisarmHelp": {
+        "message": "Diese Option lässt den VTX seine niedrigste Leistung nutzen, solange das Modell disarmed ist. Mit „Bis zum ersten Arm“ wird die niedrigste Leistung nur bis zum ersten Armieren genutzt."
+    },
+    "configurationVTXLowPowerDisarmValue_0": {
+        "message": "Deaktiviert"
+    },
+    "configurationVTXLowPowerDisarmValue_1": {
+        "message": "Immer"
+    },
+    "configurationVTXLowPowerDisarmValue_2": {
+        "message": "Bis zum ersten Arm"
+    },
+    "configurationGimbal": {
+        "message": "Serielles Gimbal"
+    },
+    "configurationGimbalSensitivity": {
+        "message": "Gimbal-Empfindlichkeit"
+    },
+    "configurationGimbalPanChannel": {
+        "message": "Pan-Kanal (Yaw)"
+    },
+    "configurationGimbalTiltChannel": {
+        "message": "Tilt-Kanal (Pitch)"
+    },
+    "configurationGimbalRollChannel": {
+        "message": "Roll-Kanal"
+    },
+    "configurationHeadtracker": {
+        "message": "Headtracker"
+    },
+    "configurationHeadtrackerType": {
+        "message": "Headtracker-Typ"
+    },
+    "configurationHeadtrackerPanRatio": {
+        "message": "Headtracker Pan-Bewegungsverhältnis"
+    },
+    "configurationHeadtrackerTiltRatio": {
+        "message": "Headtracker Tilt-Bewegungsverhältnis"
+    },
+    "configurationHeadtrackerRollRatio": {
+        "message": "Headtracker Roll-Bewegungsverhältnis"
+    },
+    "portsHelp": {
+        "message": "<strong>Hinweis:</strong> Nicht alle Kombinationen sind gültig. Erkennt die Flight-Controller-Firmware dies, wird die Konfiguration der seriellen Ports zurückgesetzt."
+    },
+    "portsMSPWarning": {
+        "message": "<strong>Vorsicht:</strong><p>MSP auf mehr als zwei UART-Ports zu legen, kann die USB-Kommunikation stören. Entferne MSP von einem Port, an dem es nicht benötigt wird.</p>"
+    },
+    "portsFirmwareUpgradeRequired": {
+        "message": "Firmware-Update <span style=\"color: red\">erforderlich</span>."
+    },
+    "portsButtonSave": {
+        "message": "Speichern und Neustarten"
+    },
+    "portsTelemetryDisabled": {
+        "message": "Deaktiviert"
+    },
+    "portsFunction_MSP": {
+        "message": "MSP"
+    },
+    "portsFunction_GPS": {
+        "message": "GPS"
+    },
+    "portsFunction_RANGEFINDER": {
+        "message": "Rangefinder"
+    },
+    "portsFunction_OPFLOW": {
+        "message": "Optical Flow"
+    },
+    "portsFunction_ESC": {
+        "message": "ESC-Ausgabe/Telemetrie"
+    },
+    "portsFunction_TELEMETRY_FRSKY": {
+        "message": "FrSky"
+    },
+    "portsFunction_TELEMETRY_HOTT": {
+        "message": "HoTT"
+    },
+    "portsFunction_TELEMETRY_LTM": {
+        "message": "LTM"
+    },
+    "portsFunction_TELEMETRY_MAVLINK": {
+        "message": "MAVLink"
+    },
+    "portsFunction_TELEMETRY_IBUS": {
+        "message": "IBUS"
+    },
+    "portsFunction_GSM_SMS": {
+        "message": "GSM SMS"
+    },
+    "portsFunction_TELEMETRY_MSP": {
+        "message": "MSP"
+    },
+    "portsFunction_TELEMETRY_SMARTPORT": {
+        "message": "SmartPort"
+    },
+    "portsFunction_SMARTPORT_MASTER": {
+        "message": "SmartPort Master"
+    },
+    "portsFunction_RX_SERIAL": {
+        "message": "Serial RX"
+    },
+    "portsFunction_BLACKBOX": {
+        "message": "Blackbox"
+    },
+    "portsFunction_RUNCAM_DEVICE_CONTROL": {
+        "message": "RunCam-Gerät"
+    },
+    "portsFunction_TBS_SMARTAUDIO": {
+        "message": "TBS SmartAudio"
+    },
+    "portsFunction_IRC_TRAMP": {
+        "message": "IRC Tramp"
+    },
+    "portsFunction_VTX_FFPV": {
+        "message": "FuriousFPV VTX"
+    },
+    "portsFunction_FRSKY_OSD": {
+        "message": "FrSky OSD"
+    },
+    "portsFunction_DJI_FPV": {
+        "message": "DJI FPV VTX"
+    },
+    "portsFunction_MSP_DISPLAYPORT": {
+        "message": "MSP DisplayPort"
+    },
+    "portsFunction_SBUS_OUTPUT": {
+        "message": "SBus-Ausgabe"
+    },
+    "portsFunction_GIMBAL": {
+        "message": "Serielles Gimbal"
+    },
+    "portsFunction_HEADTRACKER": {
+        "message": "Serieller Headtracker"
+    },
+    "pidTuning_Other": {
+        "message": "Sonstige"
+    },
+    "pidTuning_Limits": {
+        "message": "Limits"
+    },
+    "pidTuning_HeadingHold_Rate": {
+        "message": "Heading-Hold-Rate (°/s)"
+    },
+    "pidTuning_Max_Inclination_Angle": {
+        "message": "Max. Neigungswinkel"
+    },
+    "pidTuning_Max_Roll": {
+        "message": "Roll (°/10)"
+    },
+    "pidTuning_Max_Pitch": {
+        "message": "Pitch (°/10)"
+    },
+    "pidTuning_ShowAllPIDs": {
+        "message": "Alle PIDs anzeigen"
+    },
+    "pidTuning_PIDmain": {
+        "message": "Haupt-PID-Gains"
+    },
+    "pidTuning_PIDother": {
+        "message": "Zusätzliche PID-Gains"
+    },
+    "pidTuning_SelectNewDefaults": {
+        "message": "Neue Standardwerte wählen"
+    },
+    "pidTuning_ResetPIDController": {
+        "message": "PID Controller zurücksetzen"
+    },
+    "pidTuning_PIDgains": {
+        "message": "PID-Gains"
+    },
+    "pidTuning_Name": {
+        "message": "Name"
+    },
+    "pidTuning_Proportional": {
+        "message": "Proportional"
+    },
+    "pidTuning_Integral": {
+        "message": "Integral"
+    },
+    "pidTuning_Derivative": {
+        "message": "Derivativ"
+    },
+    "pidTuning_FeedForward": {
+        "message": "FeedForward"
+    },
+    "pidTuning_ControlDerivative": {
+        "message": "Control Derivative"
+    },
+    "pidTuning_Basic": {
+        "message": "Basic/Acro"
+    },
+    "pidTuning_Level": {
+        "message": "Angle/Horizon"
+    },
+    "pidTuning_Altitude": {
+        "message": "Barometer & Sonar/Höhe"
+    },
+    "pidTuning_Mag": {
+        "message": "Magnetometer/Heading"
+    },
+    "pidTuning_GPS": {
+        "message": "GPS-Navigation"
+    },
+    "pidTuning_LevelP": {
+        "message": "Stärke"
+    },
+    "pidTuning_LevelI": {
+        "message": "LPF-Grenzfrequenz (Hz)"
+    },
+    "pidTuning_LevelD": {
+        "message": "Übergang (Horizon)"
+    },
+    "pidTuning_LevelHelp": {
+        "message": "Die folgenden Werte ändern das Verhalten der Flugmodi ANGLE und HORIZON. Verschiedene PID Controller behandeln die LEVEL-Werte unterschiedlich. Bitte die Dokumentation beachten."
+    },
+    "pidTuning_RatesAndExpo": {
+        "message": "Rates & Expo"
+    },
+    "pidTuning_Rates_Stabilized": {
+        "message": "Stabilized Rates"
+    },
+    "pidTuning_Rates_Roll": {
+        "message": "Roll (°/s)"
+    },
+    "pidTuning_Rates_Pitch": {
+        "message": "Pitch (°/s)"
+    },
+    "pidTuning_Rates_Yaw": {
+        "message": "Yaw (°/s)"
+    },
+    "pidTuning_Expo_Stabilized": {
+        "message": "Stabilized Expo"
+    },
+    "pidTuning_Expo_Manual": {
+        "message": "Manual Expo"
+    },
+    "pidTuning_Expo_RollPitch": {
+        "message": "Roll & Pitch (%)"
+    },
+    "pidTuning_Expo_Yaw": {
+        "message": "Yaw (%)"
+    },
+    "pidTuning_RateDynamics": {
+        "message": "Rate Dynamics"
+    },
+    "pidTuning_RateDynamics_Sensitivity": {
+        "message": "Empfindlichkeit"
+    },
+    "pidTuning_RateDynamics_Correction": {
+        "message": "Korrektur"
+    },
+    "pidTuning_RateDynamics_Weight": {
+        "message": "Gewichtung"
+    },
+    "pidTuning_RateDynamics_Center": {
+        "message": "Mitte"
+    },
+    "pidTuning_RateDynamics_End": {
+        "message": "Ende"
+    },
+    "pidTuning_RollPitchRate": {
+        "message": "ROLL- &amp; PITCH-Rate"
+    },
+    "pidTuning_RollRate": {
+        "message": "ROLL-Rate"
+    },
+    "pidTuning_PitchRate": {
+        "message": "PITCH-Rate"
+    },
+    "pidTuning_YawRate": {
+        "message": "YAW-Rate"
+    },
+    "pidTuning_RollAndPitchExpo": {
+        "message": "Roll- & Pitch-Expo"
+    },
+    "pidTuning_YawExpo": {
+        "message": "Yaw-Expo"
+    },
+    "pidTuning_MaxRollAngle": {
+        "message": "Max. ROLL-Winkel"
+    },
+    "pidTuning_MaxRollAngleHelp": {
+        "message": "Maximaler ROLL-Winkel im ANGLE-Modus. Begrenzt auch die maximale Querneigung in den Navigationsmodi."
+    },
+    "pidTuning_MaxPitchAngle": {
+        "message": "Max. PITCH-Winkel"
+    },
+    "pidTuning_MaxPitchAngleHelp": {
+        "message": "Maximaler PITCH-Winkel im ANGLE-Modus. Begrenzt auch das maximale Steigen und Sinken in den Navigationsmodi."
+    },
+    "pidTuning_ManualRollRate": {
+        "message": "Manuelle ROLL-Rate"
+    },
+    "pidTuning_ManualPitchRate": {
+        "message": "Manuelle PITCH-Rate"
+    },
+    "pidTuning_ManualYawRate": {
+        "message": "Manuelle YAW-Rate"
+    },
+    "pidTuning_magHoldYawRate": {
+        "message": "Heading-Hold-Ratenlimit"
+    },
+    "pidTuning_MagHoldYawRateHelp": {
+        "message": "Maximale YAW-Drehrate, die der MagHold-Controller vom UAV anfordern kann. Wird nur verwendet, wenn der MagHold-Modus aktiviert ist, während RTH und WAYPOINT-Navigation. Werte unter 30 dps ergeben schöne „cinematische“ Kurven"
+    },
+    "pidTuning_Filters": {
+        "message": "Filter"
+    },
+    "pidTuning_mainFilters": {
+        "message": "Gyro-Filter"
+    },
+    "pidTuning_advancedFilters": {
+        "message": "Erweiterte Gyro-Filter"
+    },
+    "pidTuning_gyro_main_lpf_hz": {
+        "message": "Grenzfrequenz des Haupt-Gyro-Filters"
+    },
+    "pidTuning_gyro_main_lpf_hz_help": {
+        "message": "Höhere Werte bieten geringere Verzögerung, aber mehr Rauschen. Niedrigere Werte bieten weniger Rauschen, aber mehr Verzögerung bei der Gyro-Verarbeitung"
+    },
+    "pidTuning_MatrixFilterMinFrequency": {
+        "message": "Matrix-Filter Min-Frequenz"
+    },
+    "pidTuning_MatrixFilterMinFrequencyHelp": {
+        "message": "Mindestfrequenz für den Matrix-Filter. Der Wert sollte von der Propellergröße abhängen. 150 Hz funktionieren gut mit 5&quot; und kleiner. Für 7&quot; und größer auch unter 100 Hz senken."
+    },
+    "pidTuning_MatrixFilterQFactor": {
+        "message": "Matrix-Filter Q-Faktor"
+    },
+    "pidTuning_MatrixFilterQFactorHelp": {
+        "message": "Je höher der Wert, desto höher die Selektivität des Matrix-Filters. Empfohlen werden Werte zwischen 150 und 300."
+    },
+    "pidTuning_UnicornFilterQFactor": {
+        "message": "Unicorn-Filter Q-Faktor"
+    },
+    "pidTuning_dtermFilters": {
+        "message": "D-Term-Filter"
+    },
+    "pidTuning_dtermLpfCutoffFrequency": {
+        "message": "D-Term LPF Grenzfrequenz"
+    },
+    "pidTuning_dtermLpfCutoffFrequencyHelp": {
+        "message": "Tiefpass-Grenzfrequenz für den D-Term aller PID-Controller"
+    },
+    "pidTuning_rpmFilters": {
+        "message": "Gyro RPM-Filter"
+    },
+    "pidTuning_rpm_gyro_filter_enabled": {
+        "message": "Gyro RPM-Filter (benötigt ESC-Telemetrie)"
+    },
+    "pidTuning_rpm_gyro_min_hz": {
+        "message": "Gyro RPM-Filter min. Frequenz"
+    },
+    "pidTuning_Mechanics": {
+        "message": "Mechanik"
+    },
+    "pidTuning_ITermMechanics": {
+        "message": "I-Term-Mechanik"
+    },
+    "pidTuning_itermRelaxCutoff": {
+        "message": "I-Term Relax Grenzfrequenz"
+    },
+    "pidTuning_itermRelaxCutoffHelp": {
+        "message": "Niedrigere Werte öffnen ein längeres Zeitfenster für I-Term Relax und sorgen für eine stärkere I-Term-Unterdrückung. Höhere Werte verkürzen das Zeitfenster und reduzieren die Unterdrückung."
+    },
+    "pidTuning_antigravityGain": {
+        "message": "Antigravity Gain"
+    },
+    "pidTuning_antigravityAccelerator": {
+        "message": "Antigravity Accelerator"
+    },
+    "pidTuning_antigravityCutoff": {
+        "message": "Antigravity Grenzfrequenz"
+    },
+    "pidTuning_itermBankAngleFreeze": {
+        "message": "Yaw I-Term Freeze Querneigungswinkel"
+    },
+    "pidTuning_itermBankAngleFreezeHelp": {
+        "message": "Friert den Yaw-I-Term ein, wenn das Modell stärker als dieser Winkel (in Grad) gequert ist. Das verhindert, dass das Seitenruder der Kurve entgegenwirkt. 0 deaktiviert diese Funktion. Gilt nur für Flächenmodelle."
+    },
+    "pidTuning_dTermMechanics": {
+        "message": "D-Term-Mechanik"
+    },
+    "pidTuning_d_boost_min": {
+        "message": "D-Boost Min. Scale"
+    },
+    "pidTuning_d_boost_min_help": {
+        "message": "Legt die maximal erlaubte D-Term-Dämpfung während der Knüppelbeschleunigung fest. Wert 1.0 bedeutet, der D-Term wird nicht gedämpft. 0.5 bedeutet, er darf sich halbieren. Niedrigere Werte sorgen für eine schnellere Reaktion bei schnellen Knüppelbewegungen."
+    },
+    "pidTuning_d_boost_max": {
+        "message": "D-Boost Max. Scale"
+    },
+    "pidTuning_d_boost_max_help": {
+        "message": "Legt den maximalen D-Term-Boost bei Erreichen der maximalen Winkelbeschleunigung fest. 1.0 bedeutet, D-Boost ist deaktiviert, 2.0 bedeutet, der D-Term darf um 100 % wachsen. Werte zwischen 1.5 und 1.7 sind meist der Sweet Spot."
+    },
+    "pidTuning_d_boost_max_at_acceleration": {
+        "message": "Maximaler D-Boost bei Beschleunigung [dps^2]"
+    },
+    "pidTuning_d_boost_max_at_acceleration_help": {
+        "message": "D-Boost ist voll aktiv, wenn die Winkelbeschleunigung (vom Gyro oder vom Rate-Sollwert erkannt) den angegebenen Wert erreicht. Zwischen 0 und diesem Wert wird der D-Boost-Faktor linear skaliert."
+    },
+    "pidTuning_d_boost_gyro_delta_lpf_hz": {
+        "message": "D-Boost Gyro LPF"
+    },
+    "pidTuning_d_boost_gyro_delta_lpf_hz_help": {
+        "message": "Sollte auf die Frequenz der Propwash-Oszillationen eingestellt werden. 5-Zoll-Quads funktionieren am besten bei etwa 80 Hz, 7-Zoll-Quads bei etwa 50 Hz."
+    },
+    "pidTuning_tpaMechanics": {
+        "message": "Thrust PID Attenuation"
+    },
+    "pidTuning_TPA": {
+        "message": "Thrust PID Attenuation (TPA)"
+    },
+    "pidTuning_TPABreakPoint": {
+        "message": "TPA Breakpoint"
+    },
+    "pidTuning_FW_TPATimeConstant": {
+        "message": "Fixed Wing TPA Zeitkonstante"
+    },
+    "pidTuning_FW_TPATimeConstantHelp": {
+        "message": "TPA-Glättung und Verzögerungs-Zeitkonstante, um die nicht sofortige Geschwindigkeits-/Throttle-Reaktion des Flächenmodells abzubilden."
+    },
+    "pidTuning_fwLevelTrimMechanics": {
+        "message": "Fixed Wing Mechanik"
+    },
+    "pidTuning_fw_level_pitch_trim": {
+        "message": "Level Trim [Grad]"
+    },
+    "pidTuning_fw_level_pitch_trim_help": {
+        "message": "Pitch-Trim für selbstnivellierende Flugmodi. In Grad. +5 bedeutet, die Nase des Flugzeugs sollte 5 Grad gegenüber der Horizontalen angehoben werden."
+    },
+    "pidTuning_ButtonSave": {
+        "message": "Speichern"
+    },
+    "pidTuning_ButtonRefresh": {
+        "message": "Aktualisieren"
+    },
+    "pidTuning_ProfileHead": {
+        "message": "Profil"
+    },
+    "pidTuning_LoadedProfile": {
+        "message": "Geladenes Profil: <strong style=\"color: #37a8db\">$1</strong>"
+    },
+    "pidTuning_Manual_Rates": {
+        "message": "Manuelle Rates"
+    },
+    "pidTuning_Manual_Roll": {
+        "message": "Roll (%)"
+    },
+    "pidTuning_Manual_Pitch": {
+        "message": "Pitch (%)"
+    },
+    "pidTuning_Manual_Yaw": {
+        "message": "Yaw (%)"
+    },
+    "pidTuning_gyro_dyn_lpf_min_hz": {
+        "message": "Dynamischer Gyro LPF min. Grenzfrequenz"
+    },
+    "pidTuning_gyro_dyn_lpf_max_hz": {
+        "message": "Dynamischer Gyro LPF max. Grenzfrequenz"
+    },
+    "pidTuning_gyro_dyn_lpf_curve_expo": {
+        "message": "Dynamischer Gyro LPF Kurven-Expo"
+    },
+    "pidTuning_gyro_dyn_lpf_min_hz_help": {
+        "message": "Legt die Gyro-LPF-Grenzfrequenz bei minimalem Throttle fest. Bei steigendem Throttle wird die LPF-Grenzfrequenz ebenfalls erhöht, bis zur maximalen Grenzfrequenz."
+    },
+    "pidTuning_gyro_dyn_lpf_max_hz_help": {
+        "message": "Legt die Gyro-LPF-Grenzfrequenz bei maximalem Throttle fest. Bei sinkendem Throttle wird die LPF-Grenzfrequenz ebenfalls verringert, bis zur minimalen Grenzfrequenz."
+    },
+    "loadedMixerProfile": {
+        "message": "Geladenes Mixer-Profil: <strong style=\"color: #37a8db\">$1</strong>, Prüfe den Modes-Tab: MIXER PROFILE 2, falls du die Änderungen nicht siehst"
+    },
+    "loadedBatteryProfile": {
+        "message": "Geladenes Akku-Profil: <strong style=\"color: #37a8db\">$1</strong>"
+    },
+    "setControlProfile": {
+        "message": "Control-Profil setzen: <strong style=\"color: #37a8db\">$1</strong>"
+    },
+    "setMixerProfile": {
+        "message": "Mixer-Profil setzen: <strong style=\"color: #37a8db\">$1</strong>"
+    },
+    "setBatteryProfile": {
+        "message": "Akku-Profil setzen: <strong style=\"color: #37a8db\">$1</strong>"
+    },
+    "pidTuningDataRefreshed": {
+        "message": "PID-Daten <strong>aktualisiert</strong>"
+    },
+    "pidTuningEepromSaved": {
+        "message": "EEPROM <span style=\"color: #37a8db\">gespeichert</span>: PID-Tuning"
+    },
+    "receiverHelp": {
+        "message": "Bitte lies das Receiver-Kapitel der Dokumentation. Konfiguriere den seriellen Port (falls nötig), den Receiver-Modus (serial/ppm/pwm), den Provider (für serielle Receiver), binde den Receiver, setze das Channel-Mapping und konfiguriere die Kanal-Endpunkte/Bereiche am Sender, sodass alle Kanäle von ~1000 bis ~2000 reichen. Setze den Mittelpunkt (Standard 1500), trimme die Kanäle auf 1500, konfiguriere die Knüppel-Deadband und überprüfe das Verhalten, wenn der Sender aus oder außer Reichweite ist. Stelle sicher, dass alle Kanalwerte steigen, wenn du die Knüppel nach oben und rechts bewegst. Falls nicht, kehre den Kanal im Sender um. Wende keinerlei sonstiges Mixing im Sender an.<br /><span style=\"color: red\">WICHTIG:</span> Lies vor dem Fliegen das Failsafe-Kapitel der Dokumentation und konfiguriere Failsafe."
+    },
+    "receiverThrottleMid": {
+        "message": "Throttle MID"
+    },
+    "receiverThrottleExpo": {
+        "message": "Throttle EXPO"
+    },
+    "receiverRcRate": {
+        "message": "RC Rate"
+    },
+    "receiverDeadband": {
+        "message": "RC Deadband"
+    },
+    "receiverHelpDeadband": {
+        "message": "Dies sind Werte (in µs), um die sich der RC-Eingang ändern darf, bevor er als gültig gilt. Bei Sendern mit Jitter an den Ausgängen kann dieser Wert erhöht werden, falls die RC-Eingänge im Leerlauf zucken."
+    },
+    "receiverHelpYawDeadband": {
+        "message": "Dies sind Werte (in µs), um die sich der RC-Eingang ändern darf, bevor er als gültig gilt. Bei Sendern mit Jitter an den Ausgängen kann dieser Wert erhöht werden, falls die RC-Eingänge im Leerlauf zucken. <strong>Diese Einstellung gilt nur für Yaw.</strong>"
+    },
+    "receiverYawDeadband": {
+        "message": "Yaw Deadband"
+    },
+    "receiverRcExpo": {
+        "message": "RC Expo"
+    },
+    "receiverRcYawExpo": {
+        "message": "RC Yaw Expo"
+    },
+    "receiverManualRcExpo": {
+        "message": "Manueller RC Expo"
+    },
+    "receiverManualRcYawExpo": {
+        "message": "Manueller RC Yaw Expo"
+    },
+    "receiverChannelMap": {
+        "message": "Channel Map"
+    },
+    "receiverChannelMapTitle": {
+        "message": "Channel-Mapping-Reihenfolge: A=Aileron, E=Elevator, T=Throttle, R=Rudder. Zum Bearbeiten klicken."
+    },
+    "receiverRssiChannel": {
+        "message": "RSSI Kanal"
+    },
+    "receiverRssiSource": {
+        "message": "RSSI Quelle"
+    },
+    "receiverRefreshRateTitle": {
+        "message": "Diagramm-Aktualisierungsrate"
+    },
+    "receiverButtonSave": {
+        "message": "Speichern"
+    },
+    "receiverButtonRefresh": {
+        "message": "Aktualisieren"
+    },
+    "receiverButtonSticks": {
+        "message": "Steuerknüppel"
+    },
+    "receiverDataRefreshed": {
+        "message": "RC-Tuning-Daten <strong>aktualisiert</strong>"
+    },
+    "receiverEepromSaved": {
+        "message": "EEPROM <span style=\"color: #37a8db\">gespeichert</span>: Receiver"
+    },
+    "auxiliaryHelp": {
+        "message": "Verwende Bereiche, um die Schalter an deinem Sender und die zugehörigen Modus-Zuordnungen festzulegen. Ein Receiver-Kanal, dessen Wert innerhalb eines Min/Max-Bereichs liegt, aktiviert den Modus. Denk daran, deine Einstellungen mit dem Speichern-Button zu sichern."
+    },
+    "auxiliaryToggleUnused": {
+        "message": "Ungenutzte Modi ausblenden"
+    },
+    "auxiliaryMin": {
+        "message": "Min"
+    },
+    "auxiliaryMax": {
+        "message": "Max"
+    },
+    "auxiliaryAddRange": {
+        "message": "Bereich hinzufügen"
+    },
+    "auxiliaryAutoChannelSelect": {
+        "message": "AUTO"
+    },
+    "auxiliaryButtonSave": {
+        "message": "Speichern"
+    },
+    "auxiliaryEepromSaved": {
+        "message": "EEPROM <span style=\"color: #37a8db\">gespeichert</span>"
+    },
+    "eepromSaved": {
+        "message": "EEPROM <span style=\"color: #37a8db\">gespeichert</span>"
+    },
+    "adjustmentsHelp": {
+        "message": "Konfiguriere die Adjustment-Schalter. Details findest du im Abschnitt 'In-Flight Adjustments' des Handbuchs. Die durch Adjustment-Funktionen vorgenommenen Änderungen werden nicht automatisch gespeichert. Es gibt 4 Slots. Jeder Schalter, der gleichzeitig Anpassungen vornimmt, benötigt exklusiv einen Slot."
+    },
+    "adjustmentsExamples": {
+        "message": "Beispiele"
+    },
+    "adjustmentsExample1": {
+        "message": "Verwende Slot 1 und einen 3POS-Schalter auf CH5, um zwischen Pitch/Roll P, I und D zu wählen, und einen weiteren 3POS-Schalter auf CH6, um den Wert beim Halten nach oben oder unten zu erhöhen oder zu verringern."
+    },
+    "adjustmentsExample2": {
+        "message": "Verwende Slot 2 und einen 3POS-Schalter auf CH8, um die Rate-Profil-Auswahl über denselben 3POS-Schalter auf demselben Kanal zu aktivieren."
+    },
+    "adjustmentsColumnEnable": {
+        "message": "Wenn aktiviert"
+    },
+    "adjustmentsColumnUsingSlot": {
+        "message": "mit Slot"
+    },
+    "adjustmentsColumnWhenChannel": {
+        "message": "wenn Kanal"
+    },
+    "adjustmentsColumnIsInRange": {
+        "message": "im Bereich liegt"
+    },
+    "adjustmentsColumnThenApplyFunction": {
+        "message": "dann anwenden"
+    },
+    "adjustmentsColumnViaChannel": {
+        "message": "über Kanal"
+    },
+    "adjustmentsSlot0": {
+        "message": "Slot 1"
+    },
+    "adjustmentsSlot1": {
+        "message": "Slot 2"
+    },
+    "adjustmentsSlot2": {
+        "message": "Slot 3"
+    },
+    "adjustmentsSlot3": {
+        "message": "Slot 4"
+    },
+    "adjustmentsMin": {
+        "message": "Min"
+    },
+    "adjustmentsMax": {
+        "message": "Max"
+    },
+    "adjustmentsGroupRates": {
+        "message": "Rates & Expo"
+    },
+    "adjustmentsGroupPIDTuning": {
+        "message": "PID-Tuning"
+    },
+    "adjustmentsGroupNavigationFlight": {
+        "message": "Navigation und Flug"
+    },
+    "adjustmentsGroupMisc": {
+        "message": "Sonstiges"
+    },
+    "adjustmentsFunction0": {
+        "message": "Keine Änderungen"
+    },
+    "adjustmentsFunction1": {
+        "message": "RC Rate Anpassung"
+    },
+    "adjustmentsFunction2": {
+        "message": "RC Expo Anpassung"
+    },
+    "adjustmentsFunction3": {
+        "message": "Throttle Expo Anpassung"
+    },
+    "adjustmentsFunction4": {
+        "message": "Pitch & Roll Rate Anpassung"
+    },
+    "adjustmentsFunction5": {
+        "message": "Yaw Rate Anpassung"
+    },
+    "adjustmentsFunction6": {
+        "message": "Pitch & Roll P Anpassung"
+    },
+    "adjustmentsFunction7": {
+        "message": "Pitch & Roll I Anpassung"
+    },
+    "adjustmentsFunction8": {
+        "message": "Pitch & Roll D"
+    },
+    "adjustmentsFunction9": {
+        "message": "Pitch & Roll CD/FF Anpassung"
+    },
+    "adjustmentsFunction10": {
+        "message": "Pitch P Anpassung"
+    },
+    "adjustmentsFunction11": {
+        "message": "Pitch I Anpassung"
+    },
+    "adjustmentsFunction12": {
+        "message": "Pitch D Anpassung"
+    },
+    "adjustmentsFunction13": {
+        "message": "Pitch CD/FF Anpassung"
+    },
+    "adjustmentsFunction14": {
+        "message": "Roll P Anpassung"
+    },
+    "adjustmentsFunction15": {
+        "message": "Roll I Anpassung"
+    },
+    "adjustmentsFunction16": {
+        "message": "Roll D Anpassung"
+    },
+    "adjustmentsFunction17": {
+        "message": "Roll CD/FF Anpassung"
+    },
+    "adjustmentsFunction18": {
+        "message": "Yaw P Anpassung"
+    },
+    "adjustmentsFunction19": {
+        "message": "Yaw I Anpassung"
+    },
+    "adjustmentsFunction20": {
+        "message": "Yaw D Anpassung"
+    },
+    "adjustmentsFunction21": {
+        "message": "Yaw CD/FF Anpassung"
+    },
+    "adjustmentsFunction22": {
+        "message": "Rate-Profil-Auswahl"
+    },
+    "adjustmentsFunction23": {
+        "message": "Pitch Rate"
+    },
+    "adjustmentsFunction24": {
+        "message": "Roll Rate"
+    },
+    "adjustmentsFunction25": {
+        "message": "RC Yaw Expo Anpassung"
+    },
+    "adjustmentsFunction26": {
+        "message": "Manuelle RC Expo Anpassung"
+    },
+    "adjustmentsFunction27": {
+        "message": "Manuelle RC Yaw Expo Anpassung"
+    },
+    "adjustmentsFunction28": {
+        "message": "Manuelle Pitch & Roll Rate Anpassung"
+    },
+    "adjustmentsFunction29": {
+        "message": "Manuelle Roll Rate Anpassung"
+    },
+    "adjustmentsFunction30": {
+        "message": "Manuelle Pitch Rate Anpassung"
+    },
+    "adjustmentsFunction31": {
+        "message": "Manuelle Yaw Rate Anpassung"
+    },
+    "adjustmentsFunction32": {
+        "message": "Navigation FW Cruise Throttle Anpassung"
+    },
+    "adjustmentsFunction33": {
+        "message": "Navigation FW Pitch To Throttle Anpassung"
+    },
+    "adjustmentsFunction34": {
+        "message": "Board Roll Alignment Anpassung"
+    },
+    "adjustmentsFunction35": {
+        "message": "Board Pitch Alignment Anpassung"
+    },
+    "adjustmentsFunction36": {
+        "message": "Level P Anpassung"
+    },
+    "adjustmentsFunction37": {
+        "message": "Level I Anpassung"
+    },
+    "adjustmentsFunction38": {
+        "message": "Level D Anpassung"
+    },
+    "adjustmentsFunction39": {
+        "message": "Pos XY P Anpassung"
+    },
+    "adjustmentsFunction40": {
+        "message": "Pos XY I Anpassung"
+    },
+    "adjustmentsFunction41": {
+        "message": "Pos XY D Anpassung"
+    },
+    "adjustmentsFunction42": {
+        "message": "Pos Z P Anpassung"
+    },
+    "adjustmentsFunction43": {
+        "message": "Pos Z I Anpassung"
+    },
+    "adjustmentsFunction44": {
+        "message": "Pos Z D Anpassung"
+    },
+    "adjustmentsFunction45": {
+        "message": "Heading P Anpassung"
+    },
+    "adjustmentsFunction46": {
+        "message": "Vel XY P Anpassung"
+    },
+    "adjustmentsFunction47": {
+        "message": "Vel XY I Anpassung"
+    },
+    "adjustmentsFunction48": {
+        "message": "Vel XY D Anpassung"
+    },
+    "adjustmentsFunction49": {
+        "message": "Vel Z P Anpassung"
+    },
+    "adjustmentsFunction50": {
+        "message": "Vel Z I Anpassung"
+    },
+    "adjustmentsFunction51": {
+        "message": "Vel Z D Anpassung"
+    },
+    "adjustmentsFunction52": {
+        "message": "FW Min-Throttle Down-Pitch-Winkel Anpassung"
+    },
+    "adjustmentsFunction53": {
+        "message": "VTX Power Level Anpassung"
+    },
+    "adjustmentsFunction54": {
+        "message": "Thrust PID Attenuation (TPA) Anpassung"
+    },
+    "adjustmentsFunction55": {
+        "message": "TPA Breakpoint Anpassung"
+    },
+    "adjustmentsFunction56": {
+        "message": "Control Smoothness Anpassung"
+    },
+    "adjustmentsFunction57": {
+        "message": "Fixed Wing TPA Zeitkonstante"
+    },
+    "adjustmentsFunction58": {
+        "message": "Fixed Wing Level Trim"
+    },
+    "adjustmentsFunction59": {
+        "message": "Multi-Mission-Index Anpassung"
+    },
+    "adjustmentsFunction60": {
+        "message": "Fixed Wing Höhensteuerungs-Reaktion Anpassung"
+    },
+    "adjustmentsSave": {
+        "message": "Speichern"
+    },
+    "adjustmentsEepromSaved": {
+        "message": "EEPROM <span style=\"color: #37a8db\">gespeichert</span>: Adjustments"
+    },
+    "programmingEepromSaved": {
+        "message": "EEPROM <span style=\"color: #37a8db\">gespeichert</span>: Programming"
+    },
+    "servosChangeDirection": {
+        "message": "Richtung im Sender entsprechend anpassen"
+    },
+    "servosName": {
+        "message": "Name"
+    },
+    "servosMid": {
+        "message": "MID"
+    },
+    "servosMin": {
+        "message": "MIN"
+    },
+    "servosMax": {
+        "message": "MAX"
+    },
+    "servosReverse": {
+        "message": "Umkehren"
+    },
+    "servoOutput": {
+        "message": "Ausgang"
+    },
+    "servosRate": {
+        "message": "Rate (%)"
+    },
+    "servosLiveMode": {
+        "message": "Live-Modus aktivieren"
+    },
+    "servosButtonSave": {
+        "message": "Speichern"
+    },
+    "servosNormal": {
+        "message": "Normal"
+    },
+    "servoEmptyTableInfo": {
+        "message": "Keine Servos konfiguriert. Füge sie über den Mixer-Tab hinzu."
+    },
+    "servosEepromSave": {
+        "message": "EEPROM <span style=\"color: #37a8db\">gespeichert</span>"
+    },
+    "mixerSaved": {
+        "message": "Mixer <span style=\"color: #37a8db\">gespeichert</span>"
+    },
+    "mixerWizard": {
+        "message": "Motor-Mixer-Assistent"
+    },
+    "mixerWizardInfo": {
+        "message": "<ol><li>Propeller entfernen</li><li>LiPo anschließen und im Outputs-Tab alle Motoren testen</li><li>Position jedes Motors notieren (Motor #1 - links oben usw.)</li><li>Tabelle unten ausfüllen</li></ol>"
+    },
+    "gpsHead": {
+        "message": "Position"
+    },
+    "gpsStatHead": {
+        "message": "Statistik"
+    },
+    "gpsMapHead": {
+        "message": "Aktuelle GPS-Position"
+    },
+    "gpsMapMessage1": {
+        "message": "Bitte überprüfe deine Internetverbindung"
+    },
+    "gpsMapMessage2": {
+        "message": "Warte auf GPS 3D-Fix…"
+    },
+    "gpsFix": {
+        "message": "Fix-Typ:"
+    },
+    "gpsFix2D": {
+        "message": "<span class=\"fix2d\">2D</span>"
+    },
+    "gpsFix3D": {
+        "message": "<span class=\"fix3d\">3D</span>"
+    },
+    "gpsFixNone": {
+        "message": "<span class=\"fixnone\">Keiner</span>"
+    },
+    "gpsAltitude": {
+        "message": "Höhe:"
+    },
+    "gpsLat": {
+        "message": "Breitengrad:"
+    },
+    "gpsLon": {
+        "message": "Längengrad:"
+    },
+    "gpsSpeed": {
+        "message": "Geschwindigkeit:"
+    },
+    "gpsSats": {
+        "message": "Sats:"
+    },
+    "gpsDistToHome": {
+        "message": "Entfernung zu Home:"
+    },
+    "gpsHDOP": {
+        "message": "HDOP:"
+    },
+    "gpsTotalMessages": {
+        "message": "Nachrichten gesamt:"
+    },
+    "gpsMessageRate": {
+        "message": "Aktualisierungszeit:"
+    },
+    "gpsErrors": {
+        "message": "Fehler:"
+    },
+    "gpsTimeouts": {
+        "message": "Timeouts:"
+    },
+    "gpsEPH": {
+        "message": "EPH:"
+    },
+    "gpsEPV": {
+        "message": "EPV:"
+    },
+    "gpsSignalStr": {
+        "message": "Signalstärke"
+    },
+    "gpsPort": {
+        "message": "Serieller Port"
+    },
+    "gpsBaud": {
+        "message": "Baudrate"
+    },
+    "magnetometerHead": {
+        "message": "Ausrichtungswerkzeug"
+    },
+    "magnetometerHelp": {
+        "message": "1. Richte die Orientierung des Flight Controllers passend zur physischen Einbaulage im Modell aus <u>entsprechend dem \"direction\"-Pfeil auf dem Flight Controller</u>.<br/>2. Passe das Magnetometer-Modell, den Magnetometer-Chip oder die Orientierung der Magnetometer-Achsen an die physische Einbaulage im Modell an.<br/><strong>Hinweis:</strong> Das Magnetometer-Orientierungs-Preset (align_mag) ist relativ zum FC. Richte den FC zuerst aus (align_board_pitch, align_board_roll, align_board_yaw).<br/>Wird kein Preset verwendet (Orientierung über align_mag_roll, align_mag_pitch und align_mag_yaw gesetzt), ist die Magnetometer-Orientierung unabhängig."
+    },
+    "magnetometerOrientationPreset": {
+        "message": "Orientierungs-Preset (align_mag). Relativ zur FC-Orientierung"
+    },
+    "boardInfo": {
+        "message": "1. Wähle die Ausrichtung des Flight Controllers<br>(align_board_roll, align_board_pitch, align_board_yaw)"
+    },
+    "magnetometerInfo": {
+        "message": "2. Wähle ein Preset (align_mag) oder erstelle eine eigene Konfiguration mit den Schiebereglern<br>(align_mag_roll, align_mag_pitch, align_mag_yaw)"
+    },
+    "magnetometerElementToShow": {
+        "message": "Anzuzeigendes Element: Magnetometer-Modell, Chip oder Achsen"
+    },
+    "magnetometerAxes": {
+        "message": "XYZ (Magnetometer-Achsen)"
+    },
+    "axisTableTitleAxis": {
+        "message": "Achse"
+    },
+    "axisTableTitleValue": {
+        "message": "Wert [Grad]"
+    },
+    "configurationSensorMagPreset": {
+        "message": "Ausrichtung wird festgelegt durch: PRESET (align_mag)"
+    },
+    "configurationSensorMagAngles": {
+        "message": "Ausrichtung wird festgelegt durch: ANGLES (align_mag_roll, align_mag_pitch, align_mag_yaw)"
+    },
+    "configurationMagnetometerHelp": {
+        "message": "<strong>Hinweis:</strong> Denke daran, einen seriellen Port (über den Ports-Tab) zu konfigurieren, wenn du das Magnetometer-Feature nutzt."
+    },
+    "magnetometerStatHead": {
+        "message": "Mag-Statistik"
+    },
+    "tabMAGNETOMETER": {
+        "message": "Ausrichtungs-Tool"
+    },
+    "motors": {
+        "message": "Motoren"
+    },
+    "servos": {
+        "message": "Servos"
+    },
+    "motorsMaster": {
+        "message": "Master"
+    },
+    "motorsNotice": {
+        "message": "<strong>Hinweis zum Motor-Testmodus:</strong><br />Das Bewegen der Schieberegler lässt die Motoren <strong>anlaufen</strong>.<br />Um Verletzungen zu vermeiden, <strong style=\"color: red\">entferne ALLE Propeller</strong>, bevor du diese Funktion nutzt.<br />"
+    },
+    "motorsEnableControl": {
+        "message": "Ich verstehe die Risiken, die Propeller sind entfernt - Motorsteuerung aktivieren."
+    },
+    "sensorsInfo": {
+        "message": "Bedenke, dass schnelle Aktualisierungsraten und das gleichzeitige Rendern mehrerer Graphen ressourcenintensiv sind und deinen Akku schneller leeren, wenn du einen Laptop verwendest.<br />Wir empfehlen, nur Graphen für die Sensoren zu rendern, die dich interessieren, und dabei sinnvolle Aktualisierungsraten zu verwenden."
+    },
+    "sensorsRefresh": {
+        "message": "Aktualisierung:"
+    },
+    "sensorsScale": {
+        "message": "Skalierung:"
+    },
+    "cliInfo": {
+        "message": "<strong>Hinweis</strong>: Das Verlassen des CLI-Tabs oder das Drücken von Disconnect sendet <strong>automatisch</strong> \"<strong>exit</strong>\" an das Board. Mit der aktuellen Firmware führt das zu einem <span style=\"color: red\">Neustart</span> des Controllers und nicht gespeicherte Änderungen gehen <span style=\"color: red\">verloren</span>."
+    },
+    "cliInputPlaceholder": {
+        "message": "Schreibe deinen Befehl hier"
+    },
+    "cliEnter": {
+        "message": "CLI-Modus erkannt"
+    },
+    "cliReboot": {
+        "message": "CLI-Neustart erkannt"
+    },
+    "cliDocsBtn": {
+        "message": "CLI-Befehls-Dokumentation"
+    },
+    "cliSaveToFileBtn": {
+        "message": "In Datei speichern"
+    },
+    "cliSaveToFileFailed": {
+        "message": "Speichern der CLI-Ausgabe in Datei fehlgeschlagen"
+    },
+    "cliSaveToFileAborted": {
+        "message": "Speichern der CLI-Ausgabe in Datei abgebrochen"
+    },
+    "cliSaveToFileCompleted": {
+        "message": "CLI-Ausgabe erfolgreich in Datei gespeichert"
+    },
+    "cliClearOutputHistoryBtn": {
+        "message": "Bildschirm leeren"
+    },
+    "cliCopyToClipboardBtn": {
+        "message": "In Zwischenablage kopieren"
+    },
+    "cliExitBtn": {
+        "message": "Beenden"
+    },
+    "cliSaveSettingsBtn": {
+        "message": "Einstellungen speichern"
+    },
+    "cliMscBtn": {
+        "message": "Blackbox (MSC)"
+    },
+    "cliDiffAllBtn": {
+        "message": "Diff All"
+    },
+    "cliCommandsHelp": {
+        "message": "Tippe oder füge Befehle in das Feld links ein. Mit den Pfeiltasten nach oben und unten kannst du zuvor eingegebene Befehle abrufen. Tippe 'help' oder klicke auf dieses Symbol für weitere Infos."
+    },
+    "cliCopySuccessful": {
+        "message": "Kopiert!"
+    },
+    "cliLoadFromFileBtn": {
+        "message": "Aus Datei laden"
+    },
+    "cliConfirmSnippetDialogTitle": {
+        "message": "Geladene Befehle prüfen"
+    },
+    "cliConfirmSnippetNote": {
+        "message": "<strong>Hinweis</strong>: Du kannst die Befehle vor der Ausführung prüfen und bearbeiten."
+    },
+    "cliConfirmSnippetBtn": {
+        "message": "Ausführen"
+    },
+    "loggingNote": {
+        "message": "Daten werden <span style=\"color: red\">nur</span> in diesem Tab geloggt. Das Verlassen des Tabs <span style=\"color: red\">bricht</span> das Logging ab und die Anwendung kehrt in ihren normalen <strong>\"Configurator\"</strong>-Zustand zurück.<br /> Du kannst die globale Aktualisierungsrate frei wählen, die Daten werden aus Performance-Gründen jede <strong>1</strong> Sekunde in die Logdatei geschrieben."
+    },
+    "loggingSamplesSaved": {
+        "message": "Gespeicherte Samples:"
+    },
+    "loggingLogSize": {
+        "message": "Log-Größe:"
+    },
+    "loggingButtonLogFile": {
+        "message": "Logdatei auswählen"
+    },
+    "loggingStart": {
+        "message": "Logging starten"
+    },
+    "loggingStop": {
+        "message": "Logging stoppen"
+    },
+    "loggingBack": {
+        "message": "Logging verlassen / Disconnect"
+    },
+    "loggingErrorNotConnected": {
+        "message": "Du musst zuerst <strong>verbinden</strong>"
+    },
+    "loggingErrorLogFile": {
+        "message": "Bitte wähle eine Logdatei"
+    },
+    "loggingErrorOneProperty": {
+        "message": "Bitte wähle mindestens eine Eigenschaft zum Loggen"
+    },
+    "loggingAutomaticallyRetained": {
+        "message": "Vorherige Logdatei automatisch geladen: <strong>$1</strong>"
+    },
+    "blackboxNotSupported": {
+        "message": "Die Firmware deines Flight Controllers unterstützt kein Blackbox-Logging oder die Blackbox-Funktion ist nicht aktiviert"
+    },
+    "blackboxConfiguration": {
+        "message": "Blackbox-Konfiguration"
+    },
+    "blackboxButtonSave": {
+        "message": "Speichern und Neustarten"
+    },
+    "serialLogging": {
+        "message": "Externes serielles Logging-Gerät"
+    },
+    "serialLoggingSupportedNote": {
+        "message": "Du kannst über einen seriellen Port auf ein externes Logging-Gerät (z. B. einen OpenLog oder kompatiblen Klon) loggen. Konfiguriere den Port im Ports-Tab."
+    },
+    "onboardLoggingFlashLogger": {
+        "message": "Onboard-Dataflash-Chip"
+    },
+    "OnboardSDCard": {
+        "message": "Onboard-SD-Karte"
+    },
+    "sdcardNote": {
+        "message": "Flugaufzeichnungen können auf dem Onboard-SD-Kartenslot deines Flight Controllers gespeichert werden."
+    },
+    "dataflashNote": {
+        "message": "Flugaufzeichnungen können auf dem Onboard-Dataflash-Chip deines Flight Controllers gespeichert werden."
+    },
+    "dataflashNotPresentNote": {
+        "message": "Dein Flight Controller verfügt über keinen kompatiblen Dataflash-Chip."
+    },
+    "dataflashFirmwareUpgradeRequired": {
+        "message": "Dataflash benötigt Firmware &gt;= 1.8.0."
+    },
+    "dataflashButtonSaveFile": {
+        "message": "Flash in Datei speichern..."
+    },
+    "dataflashButtonErase": {
+        "message": "Flash löschen"
+    },
+    "dataflashConfirmEraseTitle": {
+        "message": "Dataflash-Löschung bestätigen"
+    },
+    "dataflashConfirmEraseNote": {
+        "message": "Dies löscht alle Blackbox-Logs oder anderen Daten im Dataflash und dauert etwa 20 Sekunden. Bist du sicher?"
+    },
+    "dataflashEraseing": {
+        "message": "Löschung läuft, bitte warten..."
+    },
+    "dataflashSavingTitle": {
+        "message": "Dataflash wird in Datei gespeichert"
+    },
+    "dataflashSavingNote": {
+        "message": "Das Speichern kann einige Minuten dauern, bitte warten."
+    },
+    "dataflashSavingNoteAfter": {
+        "message": "Speichern abgeschlossen! Drücke \"Ok\", um fortzufahren."
+    },
+    "dataflashButtonSaveCancel": {
+        "message": "Abbrechen"
+    },
+    "dataflashButtonSaveDismiss": {
+        "message": "Ok"
+    },
+    "dataflashButtonEraseConfirm": {
+        "message": "Ja, Dataflash löschen"
+    },
+    "dataflashButtonEraseCancel": {
+        "message": "Abbrechen"
+    },
+    "dataflashFileWriteFailed": {
+        "message": "Schreiben in die ausgewählte Datei fehlgeschlagen. Sind die Berechtigungen für diesen Ordner in Ordnung?"
+    },
+    "firmwareFlasherReleaseSummaryHead": {
+        "message": "Release-Info"
+    },
+    "firmwareFlasherReleaseName": {
+        "message": "Name/Version:"
+    },
+    "firmwareFlasherReleaseVersionUrl": {
+        "message": "Release-Seite besuchen."
+    },
+    "firmwareFlasherReleaseNotes": {
+        "message": "Release Notes:"
+    },
+    "firmwareFlasherReleaseDate": {
+        "message": "Datum:"
+    },
+    "firmwareFlasherReleaseStatus": {
+        "message": "Status:"
+    },
+    "firmwareFlasherReleaseTarget": {
+        "message": "Target:"
+    },
+    "firmwareFlasherReleaseFile": {
+        "message": "Binary:"
+    },
+    "firmwareFlasherReleaseStatusReleaseCandidate": {
+        "message": "<span style=\"color: red\">WICHTIG: Dieser Firmware-Release ist aktuell als Release Candidate markiert. Bitte melde alle Probleme umgehend.</span>"
+    },
+    "firmwareFlasherReleaseFileUrl": {
+        "message": "Manuell herunterladen."
+    },
+    "firmwareFlasherTargetWarning": {
+        "message": "<span style=\"color: red\">WICHTIG</span>: Stelle sicher, dass du eine für dein Target passende Datei flashst. Das Flashen eines Binary für das falsche Target kann <span style=\"color: red\">schlimme</span> Folgen haben."
+    },
+    "firmwareFlasherPath": {
+        "message": "Pfad:"
+    },
+    "firmwareFlasherSize": {
+        "message": "Größe:"
+    },
+    "firmwareFlasherStatus": {
+        "message": "Status:"
+    },
+    "firmwareFlasherProgress": {
+        "message": "Fortschritt:"
+    },
+    "firmwareFlasherLoadFirmwareFile": {
+        "message": "Bitte lade eine Firmware-Datei"
+    },
+    "firmwareFlasherNoReboot": {
+        "message": "Keine Reboot-Sequenz"
+    },
+    "firmwareFlasherOnlineSelectBoardDescription": {
+        "message": "Wähle dein Board, um verfügbare Online-Firmware-Releases zu sehen - Wähle die passende Firmware für dein Board. Beachte, dass <strong>Auto-select Target</strong> nur für INAV-Firmwares 5.0 und neuer funktioniert."
+    },
+    "firmwareFlasherOnlineSelectFirmwareVersionDescription": {
+        "message": "Wähle die Firmware-Version für dein Board.<br />Hinweis: Auch wenn du mit diesem Configurator verschiedene Firmware-Versionen flashen kannst, solltest du beim Einrichten des Flight Controllers die Haupt- und Nebenversionsnummern von Firmware und Configurator aufeinander abstimmen."
+    },
+    "firmwareFlasherNoRebootDescription": {
+        "message": "Aktivieren, wenn du deinen FC mit gebrückten Bootloader-Pins eingeschaltet oder den BOOT-Knopf deines FC gedrückt gehalten hast."
+    },
+    "firmwareFlasherFlashOnConnect": {
+        "message": "Beim Verbinden flashen"
+    },
+    "firmwareFlasherFlashOnConnectDescription": {
+        "message": "Versucht das Board automatisch zu flashen (ausgelöst durch einen neu erkannten seriellen Port)."
+    },
+    "firmwareFlasherFullChipErase": {
+        "message": "Vollständige Chip-Löschung"
+    },
+    "firmwareFlasherFullChipEraseDescription": {
+        "message": "Löscht alle aktuell auf dem Board gespeicherten Konfigurationsdaten."
+    },
+    "firmwareFlasherFlashDevelopmentFirmware": {
+        "message": "Development-Firmware verwenden"
+    },
+    "firmwareFlasherFlashDevelopmentFirmwareDescription": {
+        "message": "Flasht die neueste (ungetestete) Development-Firmware."
+    },
+    "firmwareFlasherManualBaud": {
+        "message": "Manuelle Baudrate"
+    },
+    "firmwareFlasherManualBaudDescription": {
+        "message": "Manuelle Auswahl der Baudrate für Boards, die die Standardgeschwindigkeit nicht unterstützen, oder zum Flashen über Bluetooth.<br /><span style=\"color: red\">Hinweis:</span> Wird beim Flashen über USB DFU nicht verwendet"
+    },
+    "firmwareFlasherShowDevelopmentReleases": {
+        "message": "Instabile Releases anzeigen"
+    },
+    "firmwareFlasherShowDevelopmentReleasesDescription": {
+        "message": "Zeigt Release Candidates und Development-Releases an."
+    },
+    "firmwareFlasherOptionLabelSelectFirmware": {
+        "message": "Firmware / Board wählen"
+    },
+    "firmwareFlasherOptionLabelSelectBoard": {
+        "message": "Board wählen"
+    },
+    "firmwareFlasherOptionLabelSelectFirmwareVersion": {
+        "message": "Firmware-Version wählen"
+    },
+    "firmwareFlasherOptionLabelSelectFirmwareVersionFor": {
+        "message": "Firmware-Version wählen für"
+    },
+    "firmwareFlasherButtonAutoSelect": {
+        "message": "Auto-select Target"
+    },
+    "firmwareFlasherButtonLoadLocal": {
+        "message": "Firmware laden [Lokal]"
+    },
+    "firmwareFlasherButtonLoadOnline": {
+        "message": "Firmware laden [Online]"
+    },
+    "firmwareFlasherButtonLoading": {
+        "message": "Lädt..."
+    },
+    "firmwareFlasherFlashFirmware": {
+        "message": "Firmware flashen"
+    },
+    "firmwareFlasherGithubInfoHead": {
+        "message": "GitHub Firmware-Info"
+    },
+    "firmwareFlasherCommiter": {
+        "message": "Committer:"
+    },
+    "firmwareFlasherDate": {
+        "message": "Datum:"
+    },
+    "firmwareFlasherHash": {
+        "message": "Hash:"
+    },
+    "firmwareFlasherUrl": {
+        "message": "Auf GitHub gehen, um diesen Commit zu prüfen..."
+    },
+    "firmwareFlasherMessage": {
+        "message": "Nachricht:"
+    },
+    "firmwareFlasherWarningHead": {
+        "message": "Warnung"
+    },
+    "firmwareFlasherWarningText": {
+        "message": "Bitte versuche <span style=\"color: red\">nicht</span>, <strong>Nicht-iNAV</strong>-Hardware mit diesem Firmware-Flasher zu flashen.<br /><span style=\"color: red\">Trenne</span> das Board <strong>nicht</strong> und <strong>schalte</strong> deinen Computer <span style=\"color: red\">nicht aus</span> während des Flashens.<br /><br /><strong>Hinweis: </strong>Der STM32-Bootloader ist im ROM gespeichert und kann nicht gebrickt werden.<br /><!--strong>Hinweis: </strong><span style=\"color: red\">Auto-Connect</span> ist im Firmware-Flasher immer deaktiviert.<br / --><strong>Hinweis: </strong>Stelle sicher, dass du ein Backup hast; einige Upgrades/Downgrades löschen deine Konfiguration.<br /><strong>Hinweis:</strong> Falls du Probleme beim Flashen hast, trenne zuerst alle Kabel von deinem FC, starte neu, aktualisiere Chrome und die Treiber.<br /><strong>Hinweis:</strong> Beim Flashen von Boards mit direkt angeschlossenen USB-Buchsen (Matek H743-SLIM, Holybro Kakute usw.) stelle sicher, dass du den Abschnitt USB-Flashing im INAV-Handbuch gelesen und die korrekte Software und Treiber installiert hast"
+    },
+    "firmwareFlasherRecoveryHead": {
+        "message": "<strong>Recovery / Verbindung verloren<strong>"
+    },
+    "firmwareFlasherRecoveryText": {
+        "message": "Falls du die Verbindung zu deinem Board verloren hast, befolge diese Schritte, um sie wiederherzustellen: <ul><li>Ausschalten</li><li>'Keine Reboot-Sequenz' aktivieren, 'Vollständige Chip-Löschung' aktivieren.</li><li>Die BOOT-Pins brücken oder den BOOT-Knopf halten.</li><li>Einschalten (die Activity-LED blinkt bei korrekter Ausführung NICHT).</li><li>Alle STM32-Treiber und falls nötig Zadig installieren (siehe Abschnitt <a href=\"https://github.com/iNavFlight/inav/blob/master/docs/USB%20Flashing.md\"target=\"_blank\">USB Flashing</a> im INAV-Handbuch).</li><li>Configurator schließen, alle laufenden Chrome-Instanzen schließen, alle Chrome-Apps schließen, Configurator neu starten.</li><li>BOOT-Knopf loslassen, falls dein FC einen hat.</li><li>Mit der korrekten Firmware flashen (mit manueller Baudrate, falls im Handbuch deines FC angegeben).</li><li>Ausschalten.</li><li>BOOT-Brücke entfernen.</li><li>Einschalten (die Activity-LED sollte blinken).</li><li>Normal verbinden.</li></ul>"
+    },
+    "firmwareFlasherButtonLeave": {
+        "message": "Firmware-Flasher verlassen"
+    },
+    "firmwareFlasherFirmwareNotLoaded": {
+        "message": "Firmware nicht geladen"
+    },
+    "firmwareFlasherHexCorrupted": {
+        "message": "HEX-Datei scheint beschädigt zu sein"
+    },
+    "firmwareFlasherRemoteFirmwareLoaded": {
+        "message": "<span style=\"color: #37a8db\">Remote-Firmware geladen, bereit zum Flashen</span>"
+    },
+    "firmwareFlasherFailedToLoadOnlineFirmware": {
+        "message": "Laden der Remote-Firmware fehlgeschlagen"
+    },
+    "ledStripHelp": {
+        "message": "Der Flight Controller kann Farben und Effekte einzelner LEDs auf einem Strip steuern.<br />Konfiguriere die LEDs im Raster, lege die Verdrahtungsreihenfolge fest und bringe die LEDs entsprechend den Rasterpositionen an deinem Modell an. LEDs ohne Verdrahtungsnummer werden nicht gespeichert.<br />Doppelklicke auf eine Farbe, um die HSV-Werte zu bearbeiten."
+    },
+    "ledStripButtonSave": {
+        "message": "Speichern"
+    },
+    "ledStripEepromSaved": {
+        "message": "EEPROM <span style=\"color: #37a8db\">gespeichert</span>: LED"
+    },
+    "controlAxisRoll": {
+        "message": "Roll [A]"
+    },
+    "controlAxisPitch": {
+        "message": "Pitch [E]"
+    },
+    "controlAxisYaw": {
+        "message": "Yaw [R]"
+    },
+    "controlAxisThrottle": {
+        "message": "Throttle [T]"
+    },
+    "controlAxisMotor": {
+        "message": "Motor"
+    },
+    "radioChannelShort": {
+        "message": "CH "
+    },
+    "configHelp2": {
+        "message": "Beliebige Board-Rotation in Grad, um eine seitliche / über Kopf / gedrehte usw. Montage zu ermöglichen. Bei externen Sensoren verwende die Sensor-Ausrichtungen (Gyro, Acc, Mag), um die Sensorposition unabhängig von der Board-Orientierung festzulegen. "
+    },
+    "failsafeFeaturesHelpOld": {
+        "message": "Die Failsafe-Konfiguration hat sich erheblich geändert. Verwende die neueste INAV-Version"
+    },
+    "failsafePaneTitleOld": {
+        "message": "Receiver-Failsafe"
+    },
+    "failsafeFeatureItemOld": {
+        "message": "Failsafe-Einstellungen bei RX-Signalverlust"
+    },
+    "failsafeThrottleItemOld": {
+        "message": "Failsafe-Throttle"
+    },
+    "failsafeFeaturesHelpNew": {
+        "message": "Failsafe hat zwei Stufen. <strong>Stufe 1</strong> wird ausgelöst, wenn ein Flugkanal eine ungültige Pulsdauer hat, der Receiver den Failsafe-Modus meldet oder gar kein Signal vom Receiver kommt. Die Channel-Fallback-Einstellungen werden auf <span style=\"color: red\">alle Kanäle</span> angewendet und es bleibt eine kurze Zeit zur Wiederherstellung. <strong>Stufe 2</strong> wird ausgelöst, wenn die Fehlerbedingung länger als die konfigurierte Wartezeit anhält, während das Modell <span style=\"color: red\">armed</span> ist. Alle Kanäle verbleiben dann auf der angewendeten Channel-Fallback-Einstellung, sofern nicht von der gewählten Prozedur überschrieben. <br /><strong>Hinweis:</strong> Vor dem Eintritt in Stufe 1 werden die Channel-Fallback-Einstellungen auch auf einzelne Funkkanäle mit ungültigen Pulsen angewendet."
+    },
+    "failsafePulsrangeTitle": {
+        "message": "Einstellungen für den gültigen Pulsbereich"
+    },
+    "failsafePulsrangeHelp": {
+        "message": "Pulse, die kürzer als das Minimum oder länger als das Maximum sind, gelten als ungültig und lösen die Anwendung der Channel-Fallback-Einstellungen für Funkkanäle bzw. den Eintritt in Stufe 1 für Flugkanäle aus"
+    },
+    "failsafeRxMinUsecItem": {
+        "message": "Minimale Dauer"
+    },
+    "failsafeRxMaxUsecItem": {
+        "message": "Maximale Dauer"
+    },
+    "failsafeChannelFallbackSettingsTitle": {
+        "message": "Channel-Fallback-Einstellungen"
+    },
+    "failsafeChannelFallbackSettingsHelp": {
+        "message": "Diese Einstellungen werden auf ungültige einzelne Funkkanäle oder beim Eintritt in Stufe 1 auf alle Kanäle angewendet. <strong>Hinweis:</strong> Werte werden in Schritten von 25 µs gespeichert, kleine Änderungen verschwinden daher"
+    },
+    "failsafeChannelFallbackSettingsAuto": {
+        "message": "<strong>Auto</strong> bedeutet Roll, Pitch und Yaw auf Mitte und Throttle niedrig. <strong>Hold</strong> bedeutet, den letzten gültig empfangenen Wert zu halten"
+    },
+    "failsafeChannelFallbackSettingsHold": {
+        "message": "<strong>Hold</strong> bedeutet, den letzten gültig empfangenen Wert zu halten. <strong>Set</strong> bedeutet, der hier angegebene Wert wird verwendet"
+    },
+    "failsafeStageTwoSettingsTitle": {
+        "message": "Einstellungen"
+    },
+    "failsafeFeatureItem": {
+        "message": "Aktiviert"
+    },
+    "failsafeFeatureHelp": {
+        "message": "<strong>Hinweis:</strong> Wenn Stufe 2 DEAKTIVIERT ist, wird für alle Flugkanäle (Roll, Pitch, Yaw und Throttle) die Fallback-Einstellung <strong>Auto</strong> anstelle der Benutzereinstellungen verwendet."
+    },
+    "failsafeDelayItem": {
+        "message": "Wartezeit für die Aktivierung nach Signalverlust [in Decisekunden (ds): 1 = 0,1 Sek.]"
+    },
+    "failsafeDelayHelp": {
+        "message": "Zeit, die Stufe 1 auf eine Wiederherstellung wartet"
+    },
+    "failsafeThrottleItem": {
+        "message": "Throttle-Wert während der Landung"
+    },
+    "failsafeOffDelayItem": {
+        "message": "Verzögerung bis zum Abschalten der Motoren während Failsafe [in Decisekunden (ds): 1 = 0,1 Sek.]"
+    },
+    "failsafeOffDelayHelp": {
+        "message": "Zeit im Landemodus, bis die Motoren abgeschaltet und das Modell disarmed wird"
+    },
+    "failsafeSubTitle1": {
+        "message": "Prozedur"
+    },
+    "failsafeProcedureItemSelect1": {
+        "message": "Landen"
+    },
+    "failsafeProcedureItemSelect2": {
+        "message": "Abwerfen"
+    },
+    "failsafeProcedureItemSelect3": {
+        "message": "RTH"
+    },
+    "failsafeProcedureItemSelect4": {
+        "message": "Nichts tun"
+    },
+    "failsafeKillSwitchItem": {
+        "message": "Failsafe Kill Switch (Modell bei Failsafe sofort disarmen)"
+    },
+    "failsafeKillSwitchHelp": {
+        "message": "Aktiviere diese Option, damit der im Modes-Tab konfigurierte Failsafe-Schalter als direkter Kill Switch wirkt und die gewählte Failsafe-Prozedur umgeht. <strong>Hinweis:</strong> Das Armen ist blockiert, solange der Failsafe Kill Switch in der ON-Position steht"
+    },
+    "failsafeUseMinimumDistanceItem": {
+        "message": "Alternative Mindestabstands-Failsafe-Prozedur verwenden, wenn nah an Home"
+    },
+    "failsafeUseMinimumDistanceHelp": {
+        "message": "Aktiviere diese Option, wenn du ein alternatives Failsafe-Verhalten brauchst, wenn das Modell nah an Home ist. Der Autor dieser Funktion hat z. B. ein Flugzeug, das bei der Landung Failsafe auslöst, wenn die Tragflächen abfallen, sodass das normalerweise im Flug gewünschte RTH-Failsafe-Verhalten dann nicht mehr erwünscht ist."
+    },
+    "failsafeMinDistanceItem": {
+        "message": "Failsafe-Mindestabstand"
+    },
+    "failsafeMinDistanceHelp": {
+        "message": "Das Modell verwendet das alternative Failsafe-Verhalten, wenn es zwischen 0 und diesem Mindestabstand (in Zentimetern) von Home entfernt ist. Bei z. B. 2000 Zentimetern (20 Meter) und einem Modell auf 13 Metern wird die Mindestabstands-Failsafe-Prozedur befolgt. Auf 25 Metern wird die normale Failsafe-Prozedur befolgt. Bei 0 wird stets die normale Failsafe-Prozedur verwendet. "
+    },
+    "failsafeMinDistanceProcedureItem": {
+        "message": "Failsafe-Mindestabstand-Prozedur"
+    },
+    "failsafeMinDistanceProcedureHelp": {
+        "message": "Dies ist die Failsafe-Prozedur, die befolgt wird, wenn das Modell näher als der Failsafe-Mindestabstand an Home ist."
+    },
+    "mainHelpArmed": {
+        "message": "Motor-Armen"
+    },
+    "mainHelpFailsafe": {
+        "message": "Failsafe-Modus"
+    },
+    "mainHelpLink": {
+        "message": "Serial-Link-Status"
+    },
+    "warning": {
+        "message": "Warnung"
+    },
+    "escProtocol": {
+        "message": "ESC-Protokoll"
+    },
+    "escRefreshRate": {
+        "message": "ESC-Refresh-Rate"
+    },
+    "escProtocolHelp": {
+        "message": "Der ESC muss das gewählte Protokoll unterstützen. Ändere dies nur, wenn du weißt, dass der ESC es unterstützt!"
+    },
+    "escRefreshRatelHelp": {
+        "message": "Der ESC muss die Refresh-Rate unterstützen. Ändere dies nur, wenn du weißt, dass der ESC sie unterstützt!"
+    },
+    "servoRefreshRate": {
+        "message": "Servo-Refresh-Rate"
+    },
+    "servoRefreshRatelHelp": {
+        "message": "Das Servo muss die Refresh-Rate unterstützen. Ändere dies nur, wenn du weißt, dass das Servo sie unterstützt. Eine zu hohe Refresh-Rate kann Servos beschädigen!"
+    },
+    "logPwmOutputDisabled": {
+        "message": "Der PWM-Ausgang ist deaktiviert. Motoren und Servos funktionieren nicht. Aktiviere ihn im <u>Outputs</u>-Tab!"
+    },
+    "configurationGyroSyncTitle": {
+        "message": "Looptime mit Gyroskop synchronisieren"
+    },
+    "configurationGyroLpfTitle": {
+        "message": "Gyroskop-LPF-Grenzfrequenz"
+    },
+    "configurationGyroSyncDenominator": {
+        "message": "Gyroskop-Teiler"
+    },
+    "yawJumpPreventionLimit": {
+        "message": "Yaw-Sprung-Verhinderung"
+    },
+    "yawJumpPreventionLimitHelp": {
+        "message": "Verhindert Yaw-Sprünge bei Yaw-Stopps und schnellen YAW-Eingaben. Zum Deaktivieren auf 500 setzen. Passe dies an, wenn dein Modell 'ausbricht'. Höhere Werte erhöhen die YAW-Autorität, können aber bei untermotorisierten UAVs Roll/Pitch-Instabilität verursachen. Niedrigere Werte machen Yaw-Anpassungen sanfter, können aber dazu führen, dass das UAV den Kurs nicht halten kann"
+    },
+    "yawPLimit": {
+        "message": "Yaw P Limit"
+    },
+    "yawPLimitHelp": {
+        "message": "Begrenzer für den Yaw-P-Term. Eine Erhöhung verbessert die Yaw-Autorität, kann aber Instabilität bei ROLL und PITCH verursachen."
+    },
+    "tabFiltering": {
+        "message": "Filterung"
+    },
+    "gyroLpfCutoffFrequency": {
+        "message": "Gyro LPF Grenzfrequenz"
+    },
+    "gyroLpfCutoffFrequencyHelp": {
+        "message": "Softwarebasierter Filter zur Entfernung mechanischer Vibrationen aus dem Gyro-Signal. Der Wert ist die Grenzfrequenz (Hz). Für größere Frames mit größeren Props einen niedrigeren Wert setzen. Ein zu hoher Wert kann Motoren und ESCs überhitzen."
+    },
+    "accLpfCutoffFrequency": {
+        "message": "Accelerometer LPF Grenzfrequenz"
+    },
+    "yawLpfCutoffFrequency": {
+        "message": "Yaw LPF Grenzfrequenz"
+    },
+    "yawLpfCutoffFrequencyHelp": {
+        "message": "Grenzfrequenz des Yaw-P-Term-LPF"
+    },
+    "rollPitchItermIgnoreRate": {
+        "message": "Roll/Pitch I-Term Ignore Rate"
+    },
+    "rollPitchItermIgnoreRateHelp": {
+        "message": "Der PID-I-Term wird oberhalb dieser Drehrate ignoriert. Das verhindert die Akkumulation des I-Terms während Manövern"
+    },
+    "yawItermIgnoreRate": {
+        "message": "Yaw I-Term Ignore Rate"
+    },
+    "yawItermIgnoreRateHelp": {
+        "message": "Der PID-I-Term wird oberhalb dieser Drehrate ignoriert. Das verhindert die Akkumulation des I-Terms während Manövern"
+    },
+    "axisAccelerationLimitRollPitch": {
+        "message": "Roll/Pitch Beschleunigungslimit"
+    },
+    "axisAccelerationLimitRollPitchHelp": {
+        "message": "Dies ist die maximale Winkelbeschleunigung, die der Pilot vom UAV anfordern darf. Das UAV sollte diese Beschleunigung erreichen können. Als Faustregel gilt: Je größer das UAV, desto geringere Beschleunigung verträgt es"
+    },
+    "axisAccelerationLimitYaw": {
+        "message": "Yaw Beschleunigungslimit"
+    },
+    "axisAccelerationLimitYawHelp": {
+        "message": "Dies ist die maximale Winkelbeschleunigung, die der Pilot vom UAV anfordern darf. Das UAV sollte diese Beschleunigung erreichen können. Als Faustregel gilt: Je größer das UAV, desto geringere Beschleunigung verträgt es"
+    },
+    "pidTuningTPAHelp": {
+        "message": "Throttle PID Attenuation-Faktor. Die PID-Gains werden linear reduziert, beginnend bei 0 am TPA Breakpoint (Throttle) bis zum TPA-Faktor bei Vollgas"
+    },
+    "pidTuningTPABreakPointHelp": {
+        "message": "Throttle PID Attenuation beginnt, wenn die Throttle-Position diesen Wert überschreitet. "
+    },
+    "configurationAsyncMode": {
+        "message": "Asynchroner Modus"
+    },
+    "configurationGyroFrequencyTitle": {
+        "message": "Gyroskop-Task-Frequenz"
+    },
+    "configurationAccelerometerFrequencyTitle": {
+        "message": "Beschleunigungssensor-Task-Frequenz"
+    },
+    "configurationAttitudeFrequencyTitle": {
+        "message": "Attitude-Task-Frequenz"
+    },
+    "configurationGyroLpfHelp": {
+        "message": "Hardwarebasierte Grenzfrequenz für das Gyroskop. Generell ist ein größerer Wert besser, macht das UAV aber empfindlicher für Vibrationen"
+    },
+    "configurationAsyncModeHelp": {
+        "message": "Siehe Firmware-Dokumentation „Looptime“ für Details"
+    },
+    "configurationGyroFrequencyHelp": {
+        "message": "Generell ist ein höherer Wert besser, macht das UAV aber empfindlicher für Vibrationen. Sollte über der Frequenz der „Flight Controller Loop Time“ gehalten werden. Der maximal sinnvolle Wert ist hardwareabhängig. Zu hoch eingestellt, läuft das Board möglicherweise nicht korrekt. Beobachte die CPU-Auslastung."
+    },
+    "configurationAccelerometerFrequencyHelp": {
+        "message": "Für Acro-Zwecke kann dieser Wert unter den Standard gesenkt werden"
+    },
+    "configurationAttitudeFrequencyHelp": {
+        "message": "Für Acro-Zwecke kann dieser Wert unter den Standard gesenkt werden"
+    },
+    "configurationLoopTimeHelp": {
+        "message": "Generell ist ein höherer Wert besser. Bei asynchronem Gyroskop sollte er unter der Gyro-Update-Frequenz gehalten werden. Der maximal sinnvolle Wert ist hardwareabhängig. Zu hoch eingestellt, läuft das Board möglicherweise nicht korrekt. Beobachte die CPU-Auslastung."
+    },
+    "tabOSD": {
+        "message": "OSD"
+    },
+    "configurationSensors": {
+        "message": "Sensoren & Busse"
+    },
+    "sensorAccelerometer": {
+        "message": "Beschleunigungssensor"
+    },
+    "sensorMagnetometer": {
+        "message": "Magnetometer"
+    },
+    "sensorBarometer": {
+        "message": "Barometer"
+    },
+    "sensorPitot": {
+        "message": "Pitotrohr"
+    },
+    "sensorRangefinder": {
+        "message": "Rangefinder"
+    },
+    "sensorOpflow": {
+        "message": "Optical Flow"
+    },
+    "manualEnablingTemplate": {
+        "message": "Zum Aktivieren über die CLI den Befehl <strong>feature {name}</strong> verwenden"
+    },
+    "armingFailureReasonTitle": {
+        "message": "Pre-Arming-Checks"
+    },
+    "BLOCKED_UAV_NOT_LEVEL": {
+        "message": "UAV ist waagerecht"
+    },
+    "BLOCKED_SENSORS_CALIBRATING": {
+        "message": "Laufzeit-Kalibrierung"
+    },
+    "BLOCKED_SYSTEM_OVERLOADED": {
+        "message": "CPU-Last"
+    },
+    "BLOCKED_NAVIGATION_SAFETY": {
+        "message": "Navigation ist sicher"
+    },
+    "BLOCKED_COMPASS_NOT_CALIBRATED": {
+        "message": "Kompass kalibriert"
+    },
+    "BLOCKED_ACCELEROMETER_NOT_CALIBRATED": {
+        "message": "Beschleunigungssensor kalibriert"
+    },
+    "BLOCKED_HARDWARE_FAILURE": {
+        "message": "Hardware-Zustand"
+    },
+    "BLOCKED_INVALID_SETTING": {
+        "message": "Einstellungen validiert"
+    },
+    "armingCheckPass": {
+        "message": "<div class=\"checkspass\"></div>"
+    },
+    "armingCheckFail": {
+        "message": "<div class=\"checksfail\"></div>"
+    },
+    "calibrationHead1": {
+        "message": "Accelerometer-Kalibrierung"
+    },
+    "calibrationHead2": {
+        "message": "Accelerometer-Werte"
+    },
+    "calibrationHead3": {
+        "message": "Level-Kalibrierung"
+    },
+    "calibrationHead4": {
+        "message": "Kompass-Kalibrierung"
+    },
+    "calibrationHead5": {
+        "message": "Optic-Flow-Kalibrierung"
+    },
+    "OpflowCalText": {
+        "message": "Nach dem Drücken des Buttons hast du 30 Sekunden Zeit, das Modell in der Luft zu halten und zur Seite zu kippen, ohne es horizontal zu bewegen. Beachte, dass der Optic-Flow-Sensor die Oberfläche jederzeit erfassen muss."
+    },
+    "OpflowCalBtn": {
+        "message": "Optic-Flow-Sensor kalibrieren"
+    },
+    "accZero": {
+        "message": "Acc Zero"
+    },
+    "accGain": {
+        "message": "Acc Gain"
+    },
+    "NoteCalibration": {
+        "message": "Hinweis: Falls die IMU in einem anderen Winkel oder auf der Unterseite des Flight Controllers montiert ist, führe die Kalibrierungsschritte so durch, dass die IMU wie in den Bildern gezeigt ausgerichtet ist, nicht der Quad (sonst funktioniert die Kalibrierung nicht)."
+    },
+    "AccBtn": {
+        "message": "Accelerometer kalibrieren"
+    },
+    "stepTitle1": {
+        "message": "Schritt 1"
+    },
+    "stepTitle2": {
+        "message": "Schritt 2"
+    },
+    "stepTitle3": {
+        "message": "Schritt 3"
+    },
+    "stepTitle4": {
+        "message": "Schritt 4"
+    },
+    "stepTitle5": {
+        "message": "Schritt 5"
+    },
+    "stepTitle6": {
+        "message": "Schritt 6"
+    },
+    "MagXText": {
+        "message": "Zero X"
+    },
+    "MagYText": {
+        "message": "Zero Y"
+    },
+    "MagZText": {
+        "message": "Zero Z"
+    },
+    "MagGainXText": {
+        "message": "Gain X"
+    },
+    "MagGainYText": {
+        "message": "Gain Y"
+    },
+    "MagGainZText": {
+        "message": "Gain Z"
+    },
+    "OpflowScaleText": {
+        "message": "Scale"
+    },
+    "AccResetBtn": {
+        "message": "Accelerometer-Kalibrierung zurücksetzen"
+    },
+    "MagCalText": {
+        "message": "Nach dem Drücken des Buttons hast du 30 Sekunden Zeit, das Modell in der Luft zu halten und so zu drehen, dass jede Seite (vorne, hinten, links, rechts, oben und unten) zur Erde zeigt. Stelle sicher, dass dein Kompass beim Einbau im Modell oder während der Kalibrierung nicht in der Nähe von Magneten oder Elektromagneten ist."
+    },
+    "MagBtn": {
+        "message": "Kompass kalibrieren"
+    },
+    "LevCalText": {
+        "message": "Bitte hier etwas Text einfügen…"
+    },
+    "LevBtn": {
+        "message": "Level-Kalibrierung"
+    },
+    "tabMixer": {
+        "message": "Mixer"
+    },
+    "presetsApplyHeader": {
+        "message": "Warnung"
+    },
+    "presetApplyDescription": {
+        "message": "<p style='color: darkred;'>Stelle sicher, dass der <strong>Mixer</strong> konfiguriert wurde, bevor du Presets anwendest!</p><p>Ein Preset überschreibt ausgewählte Konfigurationswerte einschließlich Mixer, Filterung, PIDs und mehr. Einstellungen wie Flugmodi, Funkeinstellungen, Failsafe und OSD werden nicht geändert. Angewendete Werte sollten <strong>NICHT</strong> als finale Werte betrachtet werden, sondern als Ausgangspunkt für das finale Tuning. <br> Prüfe die neue Konfiguration immer vor dem Fliegen!</p>"
+    },
+    "OK": {
+        "message": "OK"
+    },
+    "accCalibrationStartTitle": {
+        "message": "Accelerometer-Kalibrierung"
+    },
+    "accCalibrationStartBody": {
+        "message": "Bringe den Flight Controller in die im Bild gezeigte Position und drücke dann erneut den <strong>Kalibrieren</strong>-Button. Wiederhole dies für jede der 6 Positionen. Halte ihn während der Kalibrierung stabil."
+    },
+    "accCalibrationStopTitle": {
+        "message": "Kalibrierung abgeschlossen"
+    },
+    "accCalibrationStopBody": {
+        "message": "Accelerometer-Kalibrierung abgeschlossen, prüfe, ob die Werte gespeichert wurden."
+    },
+    "accCalibrationProcessing": {
+        "message": "Wird verarbeitet..."
+    },
+    "tabProgramming": {
+        "message": "Programmierung"
+    },
+    "tabAdvancedTuning": {
+        "message": "Erweitertes Tuning"
+    },
+    "advancedTuningSave": {
+        "message": "Speichern und Neustarten"
+    },
+    "tabAdvancedTuningTitle": {
+        "message": "Erweitertes Tuning"
+    },
+    "tabAdvancedTuningAirplaneTuningTitle": {
+        "message": ": Flächenmodell"
+    },
+    "tabAdvancedTuningMultirotorTuningTitle": {
+        "message": ": Multirotor"
+    },
+    "tabAdvancedTuningGenericTitle": {
+        "message": "Allgemeine Einstellungen"
+    },
+    "presetApplyHead": {
+        "message": "Wendet folgende Einstellungen an:"
+    },
+    "gyroNotchHz1": {
+        "message": "Erste Gyro-Notch-Filter-Frequenz"
+    },
+    "gyroNotchCutoff1": {
+        "message": "Erste Gyro-Notch-Filter Grenzfrequenz"
+    },
+    "gyroNotchHz2": {
+        "message": "Zweite Gyro-Notch-Filter-Frequenz"
+    },
+    "gyroNotchCutoff2": {
+        "message": "Zweite Gyro-Notch-Filter Grenzfrequenz"
+    },
+    "gyroNotchHz1Help": {
+        "message": "Sollte auf die Propeller-Oberschwingungsfrequenz abgestimmt werden. Entspricht meist <i>[Motorfrequenz] * [Anzahl Propellerblätter]</i><br><br>Muss über der Grenzfrequenz liegen<br><br><i>0</i> deaktiviert den Filter"
+    },
+    "gyroNotchHz2Help": {
+        "message": "Sollte auf die Motorfrequenz abgestimmt werden.<br><br>Muss über der Grenzfrequenz und unter der ersten Gyro-Notch-Filter-Frequenz liegen.<br><br><i>0</i> deaktiviert den Filter"
+    },
+    "gyroNotchCutoff1Help": {
+        "message": "Legt das Band des Notch-Filters fest. <br><br>Muss unter der Notch-Filter-Frequenz bleiben."
+    },
+    "gyroNotchCutoff2Help": {
+        "message": "Legt das Band des Notch-Filters fest. <br><br>Muss unter der Notch-Filter-Frequenz bleiben."
+    },
+    "dtermNotchHz": {
+        "message": "D-Term Notch-Filter-Frequenz"
+    },
+    "dtermNotchCutoff": {
+        "message": "D-Term Notch-Filter Grenzfrequenz"
+    },
+    "dtermNotchHzHelp": {
+        "message": "Sollte zwischen der ersten und zweiten Gyro-Notch-Filter-Frequenz liegen<br><br>Muss über der Grenzfrequenz liegen<br><br><i>0</i> deaktiviert den Filter"
+    },
+    "dtermNotchCutoffHelp": {
+        "message": "Legt das Band des Filters fest. <br><br>Muss unter der Notch-Filter-Frequenz bleiben."
+    },
+    "multiRotorNavigationConfiguration": {
+        "message": "Multirotor-Navigationseinstellungen"
+    },
+    "userControlMode": {
+        "message": "Benutzersteuerungs-Modus"
+    },
+    "posholdDefaultSpeed": {
+        "message": "Standard-Navigationsgeschwindigkeit"
+    },
+    "posholdDefaultSpeedHelp": {
+        "message": "Standardgeschwindigkeit während RTH, wird auch für die WP-Navigation verwendet, wenn für den WP-Abschnitt keine Geschwindigkeit gesetzt ist. Begrenzt durch die max. Navigationsgeschwindigkeit"
+    },
+    "posholdMaxSpeed": {
+        "message": "Max. Navigationsgeschwindigkeit"
+    },
+    "posholdMaxManualSpeed": {
+        "message": "Max. CRUISE-Geschwindigkeit"
+    },
+    "posholdMaxManualSpeedHelp": {
+        "message": "Maximale horizontale Geschwindigkeit, die der Pilot bei manueller Steuerung im POSHOLD/CRUISE-Modus erlaubt"
+    },
+    "posholdMaxClimbRate": {
+        "message": "Max. Navigations-Steigrate [cm/s]"
+    },
+    "posholdMaxManualClimbRate": {
+        "message": "Max. ALTHOLD-Steigrate [cm/s]"
+    },
+    "posholdMaxBankAngle": {
+        "message": "Multirotor max. Querneigungswinkel"
+    },
+    "posholdMaxBankAngleHelp": {
+        "message": "Maximaler Querneigungswinkel in Navigationsmodi. Begrenzt durch den maximalen ROLL-Winkel im PID-Tuning-Tab."
+    },
+    "posholdHoverThrottle": {
+        "message": "Hover-Throttle"
+    },
+    "navmcAltholdThrottle": {
+        "message": "Knüppelposition für ALTHOLD-Hover"
+    },
+    "mcWpSlowdown": {
+        "message": "Beim Annähern an Waypoint abbremsen"
+    },
+    "mcWpSlowdownHelp": {
+        "message": "Wenn aktiviert, bremst die NAV-Engine beim Wechsel zum nächsten Waypoint ab. Das priorisiert das Drehen gegenüber der Vorwärtsbewegung. Wenn deaktiviert, fliegt die NAV-Engine weiter zum nächsten Waypoint und dreht dabei."
+    },
+    "positionEstimatorConfiguration": {
+        "message": "Position Estimator"
+    },
+    "w_z_baro_p": {
+        "message": "Vertikale Position Barometer-Gewichtung"
+    },
+    "w_z_gps_p": {
+        "message": "Vertikale Position GPS-Gewichtung"
+    },
+    "w_z_gps_v": {
+        "message": "Vertikale Geschwindigkeit GPS-Gewichtung"
+    },
+    "w_xy_gps_p": {
+        "message": "Horizontale Position GPS-Gewichtung"
+    },
+    "w_xy_gps_v": {
+        "message": "Horizontale Geschwindigkeit GPS-Gewichtung"
+    },
+    "positionEstimatorConfigurationDisclaimer": {
+        "message": "Diese Werte sollten nur sehr vorsichtig geändert werden. In den meisten Fällen müssen sie nicht geändert werden. Nur für fortgeschrittene Nutzer!"
+    },
+    "gps_min_sats": {
+        "message": "Min. GPS-Satelliten für gültigen Fix"
+    },
+    "w_z_baro_p_help": {
+        "message": "Wenn dieser Wert auf <strong>0</strong> gesetzt ist, wird das Barometer nicht für die Höhenberechnung verwendet"
+    },
+    "w_z_gps_p_help": {
+        "message": "Diese Einstellung wird nur verwendet, wenn kein Barometer installiert ist und <strong>inav_use_gps_no_baro</strong> konfiguriert ist."
+    },
+    "wirelessModeSwitch": {
+        "message": "Wireless-Modus"
+    },
+    "rthConfiguration": {
+        "message": "RTH-Einstellungen"
+    },
+    "autoLandingSettings": {
+        "message": "Automatische Landeeinstellungen"
+    },
+    "minRthDistance": {
+        "message": "Min. RTH-Distanz"
+    },
+    "minRthDistanceHelp": {
+        "message": "Wenn das UAV innerhalb dieser Distanz zum Home-Punkt ist, landet es, statt erst RTH durchzuführen und dann zu landen"
+    },
+    "rthClimbFirst": {
+        "message": "Vor RTH steigen"
+    },
+    "rthClimbFirstHelp": {
+        "message": "Bei ON oder ON_FW_SPIRAL steigt das Modell zuerst auf nav_rth_altitude, bevor es Richtung Home dreht. Bei OFF dreht das Modell sofort Richtung Home und steigt unterwegs. Bei Flächenmodellen verwendet ON einen linearen Steigflug, ON_FW_SPIRAL einen kreisenden Steigflug mit der Steigrate aus nav_auto_climb_rate und der Drehrate aus nav_fw_loiter_radius (ON_FW_SPIRAL ist eine Flächenmodell-Einstellung und verhält sich bei einem Multirotor wie ON)."
+    },
+    "rthClimbIgnoreEmergency": {
+        "message": "Steigen unabhängig vom Zustand der Positionssensoren"
+    },
+    "rthAltControlOverride": {
+        "message": "RTH-Höhe und Steig-Einstellung mit Roll/Pitch-Knüppel überschreiben"
+    },
+    "rthAltControlOverrideHELP": {
+        "message": "Wenn aktiviert, kann der Steigflug bei RTH abgebrochen werden, indem man Pitch >1 Sekunde voll nach unten hält, sodass das Modell auf der aktuellen Höhe nach Hause fliegt. Bei Flächenmodellen kann die Einstellung 'Vor RTH steigen' überschrieben werden, indem man Roll >1 Sekunde voll nach links oder rechts hält, sodass das Flugzeug sofort Richtung Home dreht."
+    },
+    "rthTailFirst": {
+        "message": "Heck voran"
+    },
+    "rthAllowLanding": {
+        "message": "Nach RTH landen"
+    },
+    "rthAltControlMode": {
+        "message": "RTH-Höhenmodus"
+    },
+    "rthAbortThreshold": {
+        "message": "RTH-Abbruchschwelle"
+    },
+    "rthAbortThresholdHelp": {
+        "message": "Die RTH-Plausibilitätsprüfung erkennt, wenn die Distanz zu Home während RTH zunimmt. Überschreitet sie den durch diesen Parameter definierten Schwellenwert, geht das UAV statt RTH fortzusetzen in eine Notlandung über. Standard ist 500 m, was für Multirotoren und Flugzeuge sicher genug ist."
+    },
+    "fsMissionDelay": {
+        "message": "Failsafe-Mission-Verzögerung"
+    },
+    "fsMissionDelayHelp": {
+        "message": "Legt eine Verzögerung in Sekunden fest, wie lange INAV warten muss, bevor Failsafe-RTH ausgelöst wird, wenn sich das Modell in einer Waypoint-Mission befindet. -1 deaktiviert Failsafe vollständig [0-600s]"
+    },
+    "drNavigation": {
+        "message": "Dead-Reckoning-Navigation"
+    },
+    "drNavigationHelp": {
+        "message": "Erlaubt INAV, die Navigation (Waypoint, Return to Home, Cruise, Coursehold usw.) bei kurzen GPS-Ausfällen fortzusetzen. Diese Funktion benötigt bei Flächenmodellen einen aktivierten Kompass und Airspeed-Sensor."
+    },
+    "rthAltitude": {
+        "message": "RTH-Höhe"
+    },
+    "rthAltitudeHelp": {
+        "message": "Wird in den RTH-Höhenmodi Extra, Fixed und 'At Least' verwendet"
+    },
+    "rthTrackBack": {
+        "message": "RTH Track-Back-Modus"
+    },
+    "rthTrackBackHelp": {
+        "message": "Wenn aktiviert, folgt das Modell zuerst seinem letzten Pfad rückwärts, bevor es direkt nach Hause fliegt. Flächenmodelle fliegen den Pfad steigend, aber nicht sinkend zurück. Nutzungsmodi für RTH Track Back: OFF = deaktiviert, ON = Normales und Failsafe-RTH, FS = nur Failsafe-RTH."
+    },
+    "rthTrackBackDistance": {
+        "message": "RTH Track-Back-Distanz"
+    },
+    "rthTrackBackDistanceHelp": {
+        "message": "Während Track Back geflogene Distanz. Normales RTH wird ausgeführt, sobald diese gesamte Flugdistanz überschritten ist [m]."
+    },
+    "rthSafeHome": {
+        "message": "Safe-Home-Modus"
+    },
+    "rthSafeHomeHelp": {
+        "message": "Steuert, wann Safehomes verwendet werden. Mögliche Werte sind OFF, RTH und RTH_FS. Siehe Safehome-Dokumentation für weitere Informationen."
+    },
+    "rthSafeHomeDistance": {
+        "message": "Safe-Home Max-Distanz"
+    },
+    "rthSafeHomeDistanceHelp": {
+        "message": "Damit ein Safehome verwendet wird, muss es weniger als diese Distanz [in cm] vom Arming-Punkt entfernt sein."
+    },
+    "navMaxAltitude": {
+        "message": "Max. Höhe für Navigation"
+    },
+    "navMaxAltitudeHelp": {
+        "message": "Maximal erlaubte Höhe (über dem Home-Punkt), die für alle NAV-Modi gilt (einschließlich Altitude Hold). 0 deaktiviert das Limit"
+    },
+    "rthHomeAltitudeLabel": {
+        "message": "RTH Home-Höhe"
+    },
+    "rthHomeAltitudeHelp": {
+        "message": "Wird verwendet, wenn nicht am Home-Punkt gelandet wird. Bei Ankunft an Home kreist das Flugzeug und ändert die Höhe auf die RTH Home-Höhe. Standard ist 0, was die Funktion deaktiviert."
+    },
+    "rthTwoStage": {
+        "message": "Methode der ersten Steigstufe"
+    },
+    "rthTwoStageHelp": {
+        "message": "Gestaffelte Return-To-Home-Funktion, wenn 'Vor RTH steigen' aktiviert ist. Setze die Höhe der ersten Steigstufe auf 0, um das klassische einstufige RTH zu verwenden."
+    },
+    "rthTwoStageAlt": {
+        "message": "Höhe der ersten Steigstufe"
+    },
+    "rthTwoStageAltHelp": {
+        "message": "Höheneinstellung für die erste Stufe des gestaffelten RTH. Auf 0 setzen, um zweistufiges RTH zu deaktivieren [0-65000cm]"
+    },
+    "rthUseLinearDescent": {
+        "message": "Linearen Sinkflug verwenden"
+    },
+    "rthUseLinearDescentHelp": {
+        "message": "Wenn aktiviert, sinkt das Modell auf dem Heimflug-Abschnitt des RTH langsam auf die RTH Home-Höhe."
+    },
+    "rthLinearDescentStart": {
+        "message": "Startdistanz des linearen Sinkflugs"
+    },
+    "rthLinearDescentStartHelp": {
+        "message": "Dies ist die Distanz zum Home-Punkt, ab der der lineare Sinkflug beginnt. Bei 0 beginnt der lineare Sinkflug sofort."
+    },
+    "landMaxAltVspd": {
+        "message": "Das Modell beginnt mit dieser Geschwindigkeit zu sinken, sobald es die <strong>Home</strong>-Position erreicht."
+    },
+    "landMaxAltVspdHelp": {
+        "message": "Nach RTH beginnt das Modell, falls Autolanding aktiviert ist, mit dieser Geschwindigkeit zu sinken, bis es die <strong>Abbremshöhe</strong> erreicht"
+    },
+    "landSlowdownMaxAlt": {
+        "message": "Wenn das Modell auf <i>diese</i> Höhe gesunken ist, beginnt es für die Landung abzubremsen."
+    },
+    "landSlowdownMaxAltHelp": {
+        "message": "Wenn das Modell diese Höhe erreicht, bremst es linear zwischen <strong>Initiale Landegeschwindigkeit</strong> und <strong>Finale Landegeschwindigkeit</strong> ab, um diese bei der <strong>Höhe des Endanflugs</strong> zu erreichen"
+    },
+    "landSlowdownMinAlt": {
+        "message": "Wenn das Modell auf <i>diese</i> Höhe gesunken ist, hat es auf die Aufsetzgeschwindigkeit abgebremst."
+    },
+    "landMinAltVspd": {
+        "message": "Dies ist die Aufsetzgeschwindigkeit."
+    },
+    "landMinAltVspdHelp": {
+        "message": "Die vertikale Soll-Geschwindigkeit des Modells beträgt diesen Wert, wenn es die <strong>Höhe des Endanflugs</strong> erreicht, nachdem es ab der <strong>Abbremshöhe</strong> linear von der <strong>Initialen Landegeschwindigkeit</strong> abgebremst hat"
+    },
+    "emergencyDescentRate": {
+        "message": "Notlande-Geschwindigkeit"
+    },
+    "cruiseThrottle": {
+        "message": "Cruise-Throttle"
+    },
+    "cruiseYawRateLabel": {
+        "message": "Cruise Yaw Rate"
+    },
+    "cruiseYawRateHelp": {
+        "message": "Dies ist die Drehrate in Cruise und 3D Cruise."
+    },
+    "cruiseManualThrottleLabel": {
+        "message": "Manuelle Throttle-Erhöhung erlauben"
+    },
+    "cruiseManualThrottleHelp": {
+        "message": "Wenn aktiviert, kannst du die automatische Throttle-Steuerung in allen Navigationsmodi überschreiben. Du kannst nicht unter den automatischen Throttle-Wert gehen, außer mit Motor-Stopp bei Throttle Null."
+    },
+    "minThrottle": {
+        "message": "Min. Throttle"
+    },
+    "maxThrottle": {
+        "message": "Max. Throttle"
+    },
+    "maxBankAngle": {
+        "message": "Max. Navigations-Querneigungswinkel"
+    },
+    "maxBankAngleHelp": {
+        "message": "Maximaler Querneigungswinkel in Navigationsmodi. Begrenzt durch den maximalen ROLL-Winkel im PID-Tuning-Tab."
+    },
+    "maxClimbAngle": {
+        "message": "Max. Navigations-Steigwinkel"
+    },
+    "maxClimbAngleHelp": {
+        "message": "Maximaler Steigwinkel in Navigationsmodi. Begrenzt durch den maximalen PITCH-Winkel im PID-Tuning-Tab."
+    },
+    "navManualClimbRate": {
+        "message": "Max. Alt-Hold-Steigrate"
+    },
+    "navManualClimbRateHelp": {
+        "message": "Maximale Steig-/Sinkrate, die die Firmware bei der Verarbeitung von Piloteneingaben im ALTHOLD-Steuerungsmodus erlaubt [cm/s]"
+    },
+    "navAutoClimbRate": {
+        "message": "Max. Navigations-Steigrate"
+    },
+    "navAutoClimbRateHelp": {
+        "message": "Maximale Steig-/Sinkrate, die das UAV in Navigationsmodi erreichen darf. [cm/s]"
+    },
+    "maxDiveAngle": {
+        "message": "Max. Navigations-Sturzwinkel"
+    },
+    "maxDiveAngleHelp": {
+        "message": "Maximaler Sturzwinkel in Navigationsmodi. Begrenzt durch den maximalen PITCH-Winkel im PID-Tuning-Tab."
+    },
+    "pitchToThrottle": {
+        "message": "Pitch-zu-Throttle-Verhältnis"
+    },
+    "pitchToThrottleHelp": {
+        "message": "In Navigationsmodi fügt jedes Grad Steigflug dem Cruise-Throttle so viele Einheiten hinzu. Umgekehrt zieht jedes Grad Sinkflug davon ab."
+    },
+    "minThrottleDownPitch": {
+        "message": "Min Throttle Down-Pitch"
+    },
+    "minThrottleDownPitchHelp": {
+        "message": "Automatischer Nick-nach-unten-Winkel, wenn Throttle im Angle-Modus auf 0 ist. Wird progressiv zwischen Cruise-Throttle und Throttle Null angewendet."
+    },
+    "pitchToThrottleSmoothing": {
+        "message": "Throttle-Glättung"
+    },
+    "pitchToThrottleSmoothingHelp": {
+        "message": "Wie sanft der Autopilot den Throttle-Pegel als Reaktion auf Pitch-Winkel-Änderungen anpasst [0-9]."
+    },
+    "pitchToThrottleThreshold": {
+        "message": "Schwelle für sofortige Throttle-Anpassung"
+    },
+    "pitchToThrottleThresholdHelp": {
+        "message": "Der Autopilot passt den Throttle-Pegel ohne Glättung sofort gemäß Pitch-zu-Throttle an, wenn der Pitch-Winkel mehr als so viele Centi-Grad vom gefilterten Wert abweicht."
+    },
+    "loiterRadius": {
+        "message": "Loiter-Radius"
+    },
+    "loiterDirectionLabel": {
+        "message": "Loiter-Richtung"
+    },
+    "loiterDirectionHelp": {
+        "message": "Mit dieser Einstellung kannst du die Loiter-Richtung wählen. Bei Auswahl von YAW kannst du die Loiter-Richtung mit dem Yaw-Knüppel ändern."
+    },
+    "controlSmoothness": {
+        "message": "Control Smoothness"
+    },
+    "controlSmoothnessHelp": {
+        "message": "Wie sanft der Autopilot das Flugzeug steuert, um den Navigationsfehler zu korrigieren [0-9]."
+    },
+    "wpTrackingAccuracy": {
+        "message": "Waypoint-Tracking-Genauigkeit"
+    },
+    "wpTrackingAccuracyHelp": {
+        "message": "Tracking-Deadband - wie genau das Modell einem Waypoint-Track in Metern folgt. Niedrigere Werte tracken genauer, verursachen aber mehr Steuerkorrekturen. 2 ist ein guter Startwert [0-10]."
+    },
+    "wpTrackingAngle": {
+        "message": "Waypoint-Tracking-Winkel"
+    },
+    "wpTrackingAngleHelp": {
+        "message": "Der Winkel, in dem sich das Modell dem Waypoint-Track nähert. Niedrigere Werte verlängern den Anflug, höhere Werte können zu Überschwingen führen. 60° ist ein guter Startwert [30-80]."
+    },
+    "powerConfiguration": {
+        "message": "Einstellungen zur Akku-Schätzung"
+    },
+    "idlePower": {
+        "message": "Idle-Leistung"
+    },
+    "idlePowerHelp": {
+        "message": "Leistungsaufnahme bei Throttle Null, verwendet zur Schätzung der verbleibenden Flugzeit/-distanz in 0,01-W-Einheiten"
+    },
+    "cruisePower": {
+        "message": "Cruise-Leistung"
+    },
+    "cruisePowerHelp": {
+        "message": "Leistungsaufnahme bei Cruise-Throttle, verwendet zur Schätzung der verbleibenden Flugzeit/-distanz in 0,01-W-Einheiten"
+    },
+    "cruiseSpeed": {
+        "message": "Cruise-Geschwindigkeit"
+    },
+    "cruiseSpeedHelp": {
+        "message": "Geschwindigkeit des Flugzeugs/Flügels bei Cruise-Throttle, verwendet zur Schätzung der verbleibenden Flugzeit/-distanz in cm/s"
+    },
+    "rthEnergyMargin": {
+        "message": "RTH-Energiereserve"
+    },
+    "rthEnergyMarginHelp": {
+        "message": "Gewünschte Energiereserve nach der Heimkehr (Prozent der Akku-Energiekapazität). Wird zur Berechnung der verbleibenden Flugzeit/-distanz verwendet."
+    },
+    "generalNavigationSettings": {
+        "message": "Allgemeine Navigationseinstellungen"
+    },
+    "waypointConfiguration": {
+        "message": "Waypoint-Navigationseinstellungen"
+    },
+    "wpLoadBoot": {
+        "message": "Waypoints beim Boot laden"
+    },
+    "wpLoadBootHelp": {
+        "message": "Wenn aktiviert, werden Waypoint-Missionen im EEPROM nach dem Bootvorgang automatisch geladen."
+    },
+    "wpEnforceAlt": {
+        "message": "Höhe am Waypoint erzwingen"
+    },
+    "wpEnforceAltHelp": {
+        "message": "Stellt sicher, dass die Höhe an jedem Waypoint erreicht wird, bevor zum nächsten weitergeflogen wird. Das Modell hält die Position [Loiter bei Flächenmodellen] und steigt/sinkt, bis die Höhe innerhalb des gesetzten Bereichs [1-2000 cm] der Waypoint-Höhe liegt. Auf [0] setzen zum Deaktivieren. Flächenmodelle sollten nicht unter 500 cm gesetzt werden."
+    },
+    "waypointRadius": {
+        "message": "Waypoint-Radius"
+    },
+    "wpRestartMission": {
+        "message": "Waypoint-Mission neu starten"
+    },
+    "wpRestartMissionHelp": {
+        "message": "Legt das Neustartverhalten einer WP-Mission fest, wenn diese mitten in der Mission unterbrochen wird. START vom ersten WP, RESUME vom letzten aktiven WP oder SWITCH zwischen START und RESUME bei jeder erneuten Aktivierung des WP-Modus. SWITCH erlaubt effektiv nur einmaliges Fortsetzen von einem vorherigen Mitten-in-der-Mission-Waypoint, danach startet die Mission vom ersten Waypoint neu."
+    },
+    "wpTurnSmoothing": {
+        "message": "Waypoint-Kurvenglättung"
+    },
+    "wpTurnSmoothingHelp": {
+        "message": "Glättet Kurven während WP-Missionen durch Umschalten auf eine Loiter-Kurve an Waypoints. Bei ON erreicht das Modell den Waypoint während der Kurve. Bei ON-CUT dreht das Modell innerhalb des Waypoints, ohne ihn tatsächlich zu erreichen (schneidet die Ecke ab)."
+    },
+    "navMotorStop": {
+        "message": "Navigation Motor-Stop Override"
+    },
+    "navMotorStopHelp": {
+        "message": "Bei OFF übernimmt das Navigationssystem nicht die Kontrolle über den Motor, wenn der Throttle niedrig ist (Motor stoppt). Bei OFF_ALWAYS übernimmt das Navigationssystem nicht die Kontrolle über den Motor, wenn der Throttle niedrig war, selbst wenn Failsafe ausgelöst wird. Bei AUTO_ONLY übernimmt das Navigationssystem die Kontrolle über den Throttle nur in autonomen Navigationsmodi (NAV WP und NAV RTH). Bei ALL_NAV (Standard) übernimmt das Navigationssystem die Kontrolle über den Motor vollständig und lässt den Motor nie stoppen, selbst wenn der Throttle niedrig ist. Diese Einstellung wirkt sich nur auf NAV-Modi aus, die in Kombination mit MOTOR_STOP die Throttle-Kontrolle übernehmen, und führt bei Flächenmodellen wahrscheinlich zu einem Strömungsabriss, wenn fw_min_throttle_down_pitch nicht korrekt gesetzt oder die Pitch-Schätzung falsch ist und ALL_NAV nicht gewählt wurde."
+    },
+    "soarMotorStop": {
+        "message": "Soaring-Modus Motor-Stop"
+    },
+    "soarMotorStopHelp": {
+        "message": "Stoppt den Motor, wenn der Soaring-Modus aktiviert ist."
+    },
+    "soarPitchDeadband": {
+        "message": "Soaring-Modus Pitch-Deadband"
+    },
+    "soarPitchDeadbandHelp": {
+        "message": "Pitch-Winkel-Deadband bei aktiviertem Soaring-Modus (Grad). Der Angle-Modus ist innerhalb des Deadbands inaktiv, sodass der Pitch beim Soaring frei schweben kann."
+    },
+    "altControlResponse": {
+        "message": "Höhensteuerungs-Reaktionsfaktor"
+    },
+    "altControlResponseHelp": {
+        "message": "Passt die Reaktion der Höhensteuerung von Flächenmodellen bei Annäherung an die Zielhöhe an. Höhere Werte schärfen die Reaktion der Höhensteuerung, können aber bei zu hoher Einstellung übermäßiges Überschwingen oder Pitch-Instabilität verursachen."
+    },
+    "waypointRadiusHelp": {
+        "message": "Legt die Distanz zu einem Waypoint fest, ab der dieser als erreicht gilt."
+    },
+    "waypointSafeDistance": {
+        "message": "Waypoint-Sicherheitsabstand"
+    },
+    "waypointSafeDistanceHelp": {
+        "message": "Der maximale Abstand zwischen dem Home-Punkt und dem ersten Waypoint."
+    },
+    "fixedWingNavigationConfiguration": {
+        "message": "Fixed Wing Navigationseinstellungen"
+    },
+    "fixedWingLandingConfiguration": {
+        "message": "Fixed Wing Landeeinstellungen"
+    },
+    "MissionPlannerOnlyOneLandWp": {
+        "message": "Du kannst nur einen LAND-Waypoint pro Mission setzen."
+    },
+    "fwLandApproachLength": {
+        "message": "Länge des Endanflugs"
+    },
+    "fwLandApproachLengthHelp": {
+        "message": "Länge des Endanflugs, umfasst auch die Gleit- und Interception-Phase. Dies ist die Länge vom Safe-Home-Punkt bis zum letzten Wendepunkt."
+    },
+    "fwLandFinalApproachPitch2throttle": {
+        "message": "Modifikator für Pitch-zu-Throttle-Verhältnis im Endanflug"
+    },
+    "fwLandFinalApproachPitch2throttleHelp": {
+        "message": "Dieser Wert wird während des Endanflugs mit dem Wert \"Pitch-zu-Throttle-Verhältnis\" multipliziert. Erlaubt eine Reduzierung der Geschwindigkeit."
+    },
+    "fwLandGlideAlt": {
+        "message": "Anfangshöhe der Gleitphase"
+    },
+    "fwLandGlideAltHelp": {
+        "message": "Auf dieser Höhe (gemessen ab der Höhe des Landepunkts) wird der Motor abgeschaltet und das Modell gleitet von hier."
+    },
+    "fwLandFlareAlt": {
+        "message": "Anfangshöhe der Flare-Phase"
+    },
+    "fwLandFlareAltHelp": {
+        "message": "Auf dieser Höhe (gemessen ab der Höhe des Landepunkts) wird die letzte Phase der Landung ausgeführt."
+    },
+    "fwLandGlidePitch": {
+        "message": "Pitch-Wert für Gleitphase"
+    },
+    "fwLandGlidePitchHelp": {
+        "message": "Dieser Pitch-Winkel wird während der Gleitphase gehalten."
+    },
+    "fwLandFlarePitch": {
+        "message": "Pitch-Wert für Flare-Phase"
+    },
+    "fwLandFlarePitchHelp": {
+        "message": "Dieser Pitch-Winkel wird während der Flare-Phase gehalten."
+    },
+    "fwLandMaxTailwind": {
+        "message": "Max. Rückenwind"
+    },
+    "fwLandMaxTailwindHelp": {
+        "message": "Dieser Wert wird verwendet, wenn keine Landung gegen den Wind möglich ist. Windgeschwindigkeiten unter diesem Wert werden ignoriert (Ungenauigkeiten in der INAV-Windmessung)."
+    },
+    "osd_unsupported_msg1": {
+        "message": "Dein Flight Controller reagiert nicht auf OSD-Befehle. Das bedeutet wahrscheinlich, dass er kein integriertes OSD hat."
+    },
+    "osd_unsupported_msg2": {
+        "message": "Beachte, dass einige Flight Controller ein integriertes <a href=\"https://www.youtube.com/watch?v=ikKH_6SQ-Tk\" target=\"_blank\">MinimOSD</a> haben, das mit <a href=\"https://github.com/ShikOfTheRa/scarab-osd/releases/latest\" target=\"_blank\">scarab-osd</a> geflasht und konfiguriert werden kann. Das MinimOSD kann jedoch nicht über diese Oberfläche konfiguriert werden."
+    },
+    "osd_elements": {
+        "message": "Elemente"
+    },
+    "osd_preview_title": {
+        "message": "Vorschau <span>(zum Verschieben ziehen)</span>"
+    },
+    "osd_preview_title_drag": {
+        "message": ""
+    },
+    "osd_video_format": {
+        "message": "Videoformat"
+    },
+    "osd_craft_name": {
+        "message": "Modellname"
+    },
+    "osd_pilot_name": {
+        "message": "Pilotenname"
+    },
+    "osdElement_POWER_SUPPLY_IMPEDANCE": {
+        "message": "Versorgungs-Impedanz"
+    },
+    "osdElement_REMAINING_FLIGHT_TIME": {
+        "message": "Verbleibende Flugzeit"
+    },
+    "osdElement_REMAINING_FLIGHT_DISTANCE": {
+        "message": "Verbleibende Flugdistanz"
+    },
+    "osdElement_THROTTLE_GAUGE": {
+        "message": "Throttle-Anzeige"
+    },
+    "osdElement_THROTTLE_POSITION": {
+        "message": "Throttle-Position"
+    },
+    "osdElement_SCALED_THROTTLE_POSITION": {
+        "message": "Skalierte Throttle-Position"
+    },
+    "osdElement_CRAFT_NAME": {
+        "message": "Modellname"
+    },
+    "osdElement_PILOT_NAME": {
+        "message": "Pilotenname"
+    },
+    "osdElement_PILOT_LOGO": {
+        "message": "Piloten-Logo"
+    },
+    "osdElement_FLYMODE": {
+        "message": "Flugmodus"
+    },
+    "osdElement_HEADING": {
+        "message": "Kurs"
+    },
+    "osdElement_HEADING_GRAPH": {
+        "message": "Kurs-Diagramm"
+    },
+    "osdElement_AIR_SPEED": {
+        "message": "Luftgeschwindigkeit"
+    },
+    "osdElement_MIN_GROUND_SPEED": {
+        "message": "Min. Geschwindigkeit über Grund"
+    },
+    "osdElement_GLIDE_TIME": {
+        "message": "Gleitzeit"
+    },
+    "osdElement_GLIDE_RANGE": {
+        "message": "Gleitreichweite"
+    },
+    "osdElement_MISSION_INFO": {
+        "message": "Mission-Info"
+    },
+    "osdElement_VERSION": {
+        "message": "Version"
+    },
+    "osdElement_MULTI FUNCTION STATUS": {
+        "message": "Multifunktions-Status"
+    },
+    "osdElement_BLACKBOX": {
+        "message": "Blackbox"
+    },
+    "osdElement_ALTITUDE": {
+        "message": "Höhe"
+    },
+    "osdElement_VARIO": {
+        "message": "Vario"
+    },
+    "osdElement_ONTIME": {
+        "message": "Betriebszeit"
+    },
+    "osdElement_FLYTIME": {
+        "message": "Flugzeit"
+    },
+    "osdElement_CROSSHAIRS": {
+        "message": "Fadenkreuz"
+    },
+    "osdElement_ARTIFICIAL_HORIZON": {
+        "message": "Künstlicher Horizont"
+    },
+    "osdElement_HORIZON_SIDEBARS": {
+        "message": "Horizont-Seitenbalken"
+    },
+    "osdElement_PITCH_ANGLE": {
+        "message": "Pitch-Winkel"
+    },
+    "osdElement_ROLL_ANGLE": {
+        "message": "Roll-Winkel"
+    },
+    "osdElement_CURRENT_DRAW": {
+        "message": "Stromaufnahme"
+    },
+    "osdElement_WH_DRAWN": {
+        "message": "Verbrauchte Wh"
+    },
+    "osdElement_POWER": {
+        "message": "Leistung"
+    },
+    "osdElement_CLIMB_EFFICIENCY": {
+        "message": "Steig-Effizienz"
+    },
+    "osdElement_LONGITUDE": {
+        "message": "Längengrad"
+    },
+    "osdElement_LATITUDE": {
+        "message": "Breitengrad"
+    },
+    "osdElement_DIRECTION_TO_HOME": {
+        "message": "Richtung zu Home"
+    },
+    "osdElement_HOME_HEADING_ERROR": {
+        "message": "Home-Kurs-Fehler"
+    },
+    "osdElement_DISTANCE_TO_HOME": {
+        "message": "Entfernung zu Home"
+    },
+    "osdElement_ODOMETER": {
+        "message": "Gesamtstrecke"
+    },
+    "osdElement_COURSE_HOLD_ERROR": {
+        "message": "Course-Hold-Fehler"
+    },
+    "osdElement_COURSE_HOLD_ADJUSTMENT": {
+        "message": "Course-Hold-Korrektur"
+    },
+    "osdElement_GROUND COURSE": {
+        "message": "Bodenkurs"
+    },
+    "osdElement_ADSB_WARNING_MESSAGE": {
+        "message": "ADS-B Warnmeldung"
+    },
+    "osdElement_ADSB_INFO": {
+        "message": "ADS-B Info"
+    },
+    "osdElement_CROSS TRACK ERROR": {
+        "message": "Querabweichung"
+    },
+    "osdElement_RX_POWER_DOWNLINK": {
+        "message": "RX Power Downlink"
+    },
+    "osdElement_RX_BAND": {
+        "message": "RX-Band"
+    },
+    "osdElement_RX_MODE": {
+        "message": "RX-Modus"
+    },
+    "osdElement_CUSTOM_ELEMENT_1": {
+        "message": "Benutzerelement 1"
+    },
+    "osdElement_CUSTOM_ELEMENT_2": {
+        "message": "Benutzerelement 2"
+    },
+    "osdElement_CUSTOM_ELEMENT_3": {
+        "message": "Benutzerelement 3"
+    },
+    "osdElement_CUSTOM_ELEMENT_4": {
+        "message": "Benutzerelement 4"
+    },
+    "osdElement_CUSTOM_ELEMENT_5": {
+        "message": "Benutzerelement 5"
+    },
+    "osdElement_CUSTOM_ELEMENT_6": {
+        "message": "Benutzerelement 6"
+    },
+    "osdElement_CUSTOM_ELEMENT_7": {
+        "message": "Benutzerelement 7"
+    },
+    "osdElement_CUSTOM_ELEMENT_8": {
+        "message": "Benutzerelement 8"
+    },
+    "osdElement_HEADING_P": {
+        "message": "Heading P"
+    },
+    "osdElement_BOARD_ALIGNMENT_ROLL": {
+        "message": "Board-Ausrichtung Roll"
+    },
+    "osdElement_BOARD_ALIGNMENT_PITCH": {
+        "message": "Board-Ausrichtung Pitch"
+    },
+    "osdElement_THROTTLE_EXPO": {
+        "message": "Throttle Expo"
+    },
+    "osdElement_STABILIZED.RC_EXPO": {
+        "message": "Stabilized.rc Expo"
+    },
+    "osdElement_STABILIZED.RC_YAW_EXPO": {
+        "message": "Stabilized.rc Yaw Expo"
+    },
+    "osdElement_STABILIZED.PITCH_RATE": {
+        "message": "Stabilized.pitch Rate"
+    },
+    "osdElement_STABILIZED.ROLL_RATE": {
+        "message": "Stabilized.roll Rate"
+    },
+    "osdElement_STABILIZED.YAW_RATE": {
+        "message": "Stabilized.yaw Rate"
+    },
+    "osdElement_MANUAL_RC_EXPO": {
+        "message": "Manual Rc Expo"
+    },
+    "osdElement_MANUAL_RC_YAW_EXPO": {
+        "message": "Manual Rc Yaw Expo"
+    },
+    "osdElement_MANUAL_PITCH_RATE": {
+        "message": "Manual Pitch Rate"
+    },
+    "osdElement_MANUAL_ROLL_RATE": {
+        "message": "Manual Roll Rate"
+    },
+    "osdElement_MANUAL_YAW_RATE": {
+        "message": "Manual Yaw Rate"
+    },
+    "osdElement_NAV_FW_CRUISE_THROTTLE": {
+        "message": "Nav Fw Cruise Throttle"
+    },
+    "osdElement_NAV_FW_PITCH_TO_THROTTLE": {
+        "message": "Nav Fw Pitch to Throttle"
+    },
+    "osdElement_FW_MIN_THROTTLE_DOWN_PITCH_ANGLE": {
+        "message": "Fw Min Throttle Down Pitch Angle"
+    },
+    "osdElement_THRUST_PID_ATTENUATION": {
+        "message": "Thrust Pid Attenuation"
+    },
+    "osdElement_CONTROL_SMOOTHNESS": {
+        "message": "Control Smoothness"
+    },
+    "osdElement_TPA_TIME_CONSTANT": {
+        "message": "Tpa Time Constant"
+    },
+    "osdElement_FW_LEVEL_TRIM": {
+        "message": "Fw Level Trim"
+    },
+    "osdElement_MISSION_INDEX": {
+        "message": "Mission-Index"
+    },
+    "osdElement_FW_ALT_CONTROL_RESPONSE": {
+        "message": "Fw Alt Control Response"
+    },
+    "osdElement_PILOT_LOGO_HELP": {
+        "message": "Zeigt dein kleines Pilotenlogo im OSD an der von dir gewählten Position. Dies erfordert eine eigene Font mit deinem Pilotenlogo."
+    },
+    "osd_use_pilot_logo": {
+        "message": "Pilotenlogo verwenden"
+    },
+    "osd_use_large_pilot_logo_help": {
+        "message": "Verwende dein großes Pilotenlogo mit/anstelle des INAV-Logos. Dies erfordert eine eigene Font mit deinem Pilotenlogo. Es wird auf dem Arming-Bildschirm angezeigt."
+    },
+    "osd_units": {
+        "message": "Einheiten"
+    },
+    "osd_main_voltage_decimals": {
+        "message": "Nachkommastellen Spannung"
+    },
+    "osd_decimals_altitude": {
+        "message": "Nachkommastellen Höhe"
+    },
+    "osd_decimals_distance": {
+        "message": "Nachkommastellen Distanz"
+    },
+    "osd_mah_precision": {
+        "message": "mAh-Genauigkeit"
+    },
+    "osd_coordinate_digits": {
+        "message": "Koordinaten-Stellen"
+    },
+    "osd_plus_code_digits": {
+        "message": "Plus-Code-Stellen"
+    },
+    "osd_plus_code_short": {
+        "message": "Plus-Code führende Stellen entfernen"
+    },
+    "osd_esc_rpm_precision": {
+        "message": "ESC RPM-Genauigkeit"
+    },
+    "osd_esc_rpm_precision_help": {
+        "message": "Die Anzahl der in der RPM-Anzeige gezeigten Stellen. Ist die RPM höher als die Anzahl der Stellen, wird sie in Tausend RPM mit so vielen Nachkommastellen wie erlaubt angezeigt."
+    },
+    "osd_crosshairs_style": {
+        "message": "Fadenkreuz-Stil"
+    },
+    "osd_horizon_offset": {
+        "message": "AHI- & HUD-Offset"
+    },
+    "osd_horizon_offset_help": {
+        "message": "Verschiebt HUD und AHI im OSD nach oben oder unten, um sie an den tatsächlichen Horizont anzugleichen. Der AHI kann je nach Kamerawinkel im Flug zu hoch oder zu niedrig erscheinen. <span style='color:red;'>HINWEIS: </span> Dies funktioniert nicht mit dem Pixel-OSD. Verwende dafür den Befehl `osd_ahi_vertical_offset` in der CLI."
+    },
+    "osd_left_sidebar_scroll": {
+        "message": "Linke Sidebar Scroll"
+    },
+    "osd_right_sidebar_scroll": {
+        "message": "Rechte Sidebar Scroll"
+    },
+    "osd_crsf_lq_format": {
+        "message": "Crossfire LQ-Format"
+    },
+    "osd_sidebar_scroll_arrows": {
+        "message": "Sidebar-Scroll-Pfeile"
+    },
+    "osd_home_position_arm_screen": {
+        "message": "Home-Position auf Arming-Bildschirm"
+    },
+    "osd_hud_settings": {
+        "message": "Heads-up-Display-Einstellungen"
+    },
+    "osd_custom_element_settings": {
+        "message": "Eigene OSD-Elemente"
+    },
+    "osd_custom_element_settings_HELP": {
+        "message": "Ausführliche Details zur Verwendung eigener OSD-Elemente. Klicke auf dieses ?"
+    },
+    "osd_custom_element_settings_icons_HELP": {
+        "message": "Die Icon-Nummern findest du über diesen Hilfe-Button."
+    },
+    "custom_element": {
+        "message": "Eigenes Element"
+    },
+    "osd_hud_settings_HELP": {
+        "message": "In diesem Abschnitt kannst du das Verhalten der HUD-Elemente anpassen."
+    },
+    "osd_hud_radar_disp": {
+        "message": "Maximale Anzahl an Radar-Elementen auf dem Bildschirm."
+    },
+    "osd_hud_radar_disp_help": {
+        "message": "Wird für INAV Radar/FormationFlight verwendet. 0 deaktiviert diese Funktion."
+    },
+    "osd_hud_radar_range_min": {
+        "message": "Minimale Radar-Reichweite"
+    },
+    "osd_hud_radar_range_min_help": {
+        "message": "Radar-Modelle, die näher als dieser Wert sind, werden im HUD nicht angezeigt."
+    },
+    "osd_hud_radar_range_max": {
+        "message": "Maximale Radar-Reichweite"
+    },
+    "osd_hud_radar_range_max_help": {
+        "message": "Radar-Modelle, die weiter als dieser Wert entfernt sind, werden im HUD nicht angezeigt."
+    },
+    "osd_hud_wp_disp": {
+        "message": "Maximale Anzahl an Waypoint-Elementen auf dem Bildschirm."
+    },
+    "osd_hud_wp_disp_help": {
+        "message": "Anzahl der auf dem Bildschirm anzuzeigenden Waypoints. 0 deaktiviert diese Funktion."
+    },
+    "osd_camera_uptilt": {
+        "message": "Kamera-Uptilt"
+    },
+    "osd_camera_uptilt_help": {
+        "message": "Legt den Kamera-Uptilt für die FPV-Kamera in Grad fest, positiv ist nach oben, negativ nach unten, relativ zur Horizontalen. Wird für die korrekte Anzeige von HUD-Elementen und AHI verwendet (wenn mit osd_ahi_camera_uptilt_comp=ON aktiviert)."
+    },
+    "osd_camera_fov_h": {
+        "message": "Kamera horizontales FOV"
+    },
+    "osd_camera_fov_h_help": {
+        "message": "Horizontales Sichtfeld der Kamera in Grad. Wird zur Berechnung der Position von Elementen in der HUD-Anzeige verwendet."
+    },
+    "osd_camera_fov_v": {
+        "message": "Kamera vertikales FOV"
+    },
+    "osd_camera_fov_v_help": {
+        "message": "Vertikales Sichtfeld der Kamera in Grad. Wird zur Berechnung der Position von Elementen in der HUD-Anzeige verwendet."
+    },
+    "osd_alarms": {
+        "message": "Alarme"
+    },
+    "osdLayoutDefault": {
+        "message": "Standard-Layout"
+    },
+    "osdLayoutAlternative": {
+        "message": "Alternatives Layout #$1"
+    },
+    "osdUnitImperial": {
+        "message": "Imperial"
+    },
+    "osdUnitMetric": {
+        "message": "Metrisch"
+    },
+    "osdUnitMetricMPH": {
+        "message": "Metrisch + MPH"
+    },
+    "osdUnitMetricMPHTip": {
+        "message": "Verwendet metrische Einheiten außer für die Geschwindigkeit, die in Meilen pro Stunde angezeigt wird."
+    },
+    "osdUnitUK": {
+        "message": "UK"
+    },
+    "osdUnitUKTip": {
+        "message": "Verwendet imperiale Einheiten außer für die Temperatur, die in Celsius angezeigt wird."
+    },
+    "osdUnitGA": {
+        "message": "General Aviation"
+    },
+    "osdUnitGATip": {
+        "message": "Verwendet GA-Standardeinheiten (nicht-SI): Nautische Meilen, Fuß, Knoten, Celsius."
+    },
+    "osd_rssi_alarm": {
+        "message": "RSSI (%)"
+    },
+    "osdAlarmBATT_CAP": {
+        "message": "Verbrauchte Akku-Kapazität"
+    },
+    "osdAlarmBATT_CAP_HELP": {
+        "message": "Die Anzeige der verbrauchten Akku-Kapazität (entnommene mAh) blinkt, wenn die insgesamt verbrauchten mAh diesen Wert überschreiten. Erfordert einen Stromsensor. Null deaktiviert diesen Alarm."
+    },
+    "osd_time_alarm": {
+        "message": "Flugzeit (Minuten)"
+    },
+    "osd_alt_alarm": {
+        "message": "Höhe"
+    },
+    "osd_dist_alarm": {
+        "message": "Distanz"
+    },
+    "osdAlarmDIST_HELP": {
+        "message": "Die Anzeige der Distanz zu Home blinkt, wenn die Distanz diesen Wert überschreitet. Null deaktiviert diesen Alarm."
+    },
+    "osd_neg_alt_alarm": {
+        "message": "Negative Höhe"
+    },
+    "osdAlarmMAX_NEG_ALTITUDE_HELP": {
+        "message": "Die Höhenanzeige blinkt, wenn die Höhe negativ ist und ihr Absolutwert größer als dieser Alarm ist. Nützlich beim Start von erhöhten Orten. Null deaktiviert diesen Alarm."
+    },
+    "osd_airspeed_min_alarm": {
+        "message": "Minimale Airspeed"
+    },
+    "osd_airspeed_min_alarm_HELP": {
+        "message": "Die Airspeed-Anzeige blinkt, wenn die Airspeed unter diesem Schwellenwert liegt. Null deaktiviert diesen Alarm."
+    },
+    "osd_airspeed_max_alarm": {
+        "message": "Maximale Airspeed"
+    },
+    "osd_airspeed_max_alarm_HELP": {
+        "message": "Die Airspeed-Anzeige blinkt, wenn die Airspeed über diesem Schwellenwert liegt. Null deaktiviert diesen Alarm."
+    },
+    "osd_gforce_alarm": {
+        "message": "g-Kraft"
+    },
+    "osdAlarmGFORCE_HELP": {
+        "message": "Das g-Kraft-Element beginnt zu blinken, wenn dieser Wert überschritten wird"
+    },
+    "osd_gforce_axis_alarm_min": {
+        "message": "g-Kraft Achse min"
+    },
+    "osdAlarmGFORCE_AXIS_MIN_HELP": {
+        "message": "Die Achsen-g-Kraft-Elemente beginnen zu blinken, wenn dieser Wert unterschritten wird"
+    },
+    "osd_gforce_axis_alarm_max": {
+        "message": "g-Kraft Achse max"
+    },
+    "osdAlarmGFORCE_AXIS_MAX_HELP": {
+        "message": "Die Achsen-g-Kraft-Elemente beginnen zu blinken, wenn dieser Wert überschritten wird"
+    },
+    "osdAlarmADSB_MAX_DISTANCE_WARNING": {
+        "message": "Distanz in Metern, ab der ein ADSB-Flugzeug angezeigt wird"
+    },
+    "osdAlarmADSB_MAX_DISTANCE_ALERT": {
+        "message": "Distanz, innerhalb der ADSB-Daten zur Annäherungswarnung blinken"
+    },
+    "osd_current_alarm": {
+        "message": "Strom (A)"
+    },
+    "osdAlarmCURRENT_HELP": {
+        "message": "Das Stromaufnahme-Element beginnt zu blinken, wenn der Verbrauch diesen Wert überschreitet. Null deaktiviert diesen Alarm."
+    },
+    "osd_imu_temp_alarm_min": {
+        "message": "Minimale IMU-Temperatur"
+    },
+    "osd_imu_temp_alarm_max": {
+        "message": "Maximale IMU-Temperatur"
+    },
+    "osd_baro_temp_alarm_min": {
+        "message": "Minimale Baro-Temperatur"
+    },
+    "osd_baro_temp_alarm_max": {
+        "message": "Maximale Baro-Temperatur"
+    },
+    "osd_esc_temp_alarm_min": {
+        "message": "Minimale ESC-Temperatur"
+    },
+    "osd_esc_temp_alarm_max": {
+        "message": "Maximale ESC-Temperatur"
+    },
+    "osd_snr_alarm": {
+        "message": "SNR-Alarmschwelle"
+    },
+    "osdalarmSNR_HELP": {
+        "message": "SNR wird nur unterhalb dieses Werts angezeigt. 0 dB (Verhältnis 1:1) bedeutet, dass das empfangene Signal dem Grundrauschen entspricht."
+    },
+    "osd_link_quality_alarm": {
+        "message": "Link-Quality-Alarm"
+    },
+    "osdalarmLQ_HELP": {
+        "message": "Für Crossfire 70 % verwenden. Für Tracer 50 % verwenden."
+    },
+    "osd_rssi_dbm_alarm": {
+        "message": "RSSI-dBm-Alarm"
+    },
+    "osd_adsb_distance_warning": {
+        "message": "ADSB-Distanzwarnung"
+    },
+    "osd_adsb_distance_alert": {
+        "message": "ADSB-Distanzalarm"
+    },
+    "osd_rssi_dbm_alarm_HELP": {
+        "message": "Die RSSI-Anzeige blinkt unterhalb dieses Werts. Bereich: [-130,0]. Null deaktiviert diesen Alarm."
+    },
+    "osdGroupGeneral": {
+        "message": "Allgemein"
+    },
+    "osdGroupAltitude": {
+        "message": "Höhe"
+    },
+    "osdGroupTimers": {
+        "message": "Timer"
+    },
+    "osdGroupGForce": {
+        "message": "g-Kraft"
+    },
+    "osdGroupTemperature": {
+        "message": "Temperatur"
+    },
+    "osdGroupAttitude": {
+        "message": "Lage"
+    },
+    "osdGroupCurrentMeter": {
+        "message": "Strommessung"
+    },
+    "osdGroupGPS": {
+        "message": "GPS"
+    },
+    "osdGroupPowerLimits": {
+        "message": "Leistungslimits"
+    },
+    "osdGroupPIDs": {
+        "message": "Per RC anpassbare Werte"
+    },
+    "osdGroupPIDOutputs": {
+        "message": "PID-Controller-Ausgänge"
+    },
+    "osdGroupVTX": {
+        "message": "VTX"
+    },
+    "osdGroupRx": {
+        "message": "RX-Statistik"
+    },
+    "osdGroupMapsAndRadars": {
+        "message": "Karten & Radar"
+    },
+    "osdGroupMapsAndRadars_HELP": {
+        "message": "Auf Karten & Radar können zusätzliche Elemente platziert werden, solange sie keinen der in der Vorschau sichtbaren Kartenteile überlappen."
+    },
+    "osdElement_ONTIME_FLYTIME": {
+        "message": "On Time / Fly Time"
+    },
+    "osdElement_RSSI_VALUE": {
+        "message": "RSSI (Signalstärke)"
+    },
+    "osdElement_RSSI_VALUE_HELP": {
+        "message": "Zeigt die Qualität des vom RC-Sender empfangenen Signals (je höher, desto besser)."
+    },
+    "osdElement_MAIN_BATT_VOLTAGE": {
+        "message": "Akku-Spannung"
+    },
+    "osdElement_SAG_COMP_MAIN_BATT_VOLTAGE": {
+        "message": "Sag-kompensierte Akku-Spannung"
+    },
+    "osdElement_SAG_COMP_MAIN_BATT_VOLTAGE_HELP": {
+        "message": "Berechnete Spannung, die der Akku ohne Last haben sollte (simuliert einen idealen Akku)"
+    },
+    "osdElement_MESSAGES": {
+        "message": "Systemnachrichten"
+    },
+    "osdElement_MESSAGES_HELP": {
+        "message": "Zeigt verschiedene Systemnachrichten wie Warnungen, Hardware-Fehler und erweiterte Details des aktuellen Flugmodus (z. B. AUTOTUNE- und AUTOTRIM-Modi sowie RTH-Stufen)."
+    },
+    "osdElement_MAIN_BATT_CELL_VOLTAGE": {
+        "message": "Akku-Zellenspannung"
+    },
+    "osdElement_SAG_COMP_MAIN_BATT_CELL_VOLTAGE": {
+        "message": "Sag-kompensierte Akku-Zellenspannung"
+    },
+    "osdElement_SAG_COMP_MAIN_BATT_CELL_VOLTAGE_HELP": {
+        "message": "Berechnete durchschnittliche Zellenspannung, die der Akku ohne Last haben sollte (simuliert einen idealen Akku)"
+    },
+    "osdElement_MAIN_BATT_REMAINING_PERCENTAGE": {
+        "message": "Verbleibende Akku-Kapazität in Prozent"
+    },
+    "osdElement_MAIN_BATT_REMAINING_CAPACITY": {
+        "message": "Verbleibende Akku-Kapazität"
+    },
+    "osdElement_REMAINING_FLIGHT_TIME_HELP": {
+        "message": "Geschätzte verbleibende Flugzeit, bevor das Modell zurückkehren muss, basierend auf der verbleibenden Akku-Energie, der durchschnittlichen Leistung und der Distanz zu Home (nur Flächenmodelle, bitte lies die Dokumentation)"
+    },
+    "osdElement_REMAINING_FLIGHT_DISTANCE_HELP": {
+        "message": "Geschätzte verbleibende Flugdistanz, bevor das Modell zurückkehren muss, basierend auf der verbleibenden Akku-Energie, der durchschnittlichen Leistung und der Distanz zu Home (nur Flächenmodelle, bitte lies die Dokumentation)"
+    },
+    "osdElement_MAIN_BATT_CELL_VOLTAGE_HELP": {
+        "message": "Zeigt die durchschnittliche Zellenspannung des Hauptakkus"
+    },
+    "osdElement_MAH_DRAWN": {
+        "message": "Entnommene mAh"
+    },
+    "osdElement_EFFICIENCY_MAH": {
+        "message": "Effizienz mAh/km"
+    },
+    "osdElement_EFFICIENCY_WH": {
+        "message": "Effizienz Wh/km"
+    },
+    "osdElement_PLIMIT_REMAINING_BURST_TIME": {
+        "message": "Verbleibende Burst-Zeit"
+    },
+    "osdElement_PLIMIT_ACTIVE_CURRENT_LIMIT": {
+        "message": "Aktives Stromlimit"
+    },
+    "osdElement_PLIMIT_ACTIVE_POWER_LIMIT": {
+        "message": "Aktives Leistungslimit"
+    },
+    "osdElement_THROTTLE_POSITION_HELP": {
+        "message": "Zeigt die Throttle-Knüppelposition in Flugmodi, in denen <i>diese</i> den Throttle-Ausgang steuert. In Navigationsmodi zeigt es den von INAV vorgegebenen Throttle-Wert."
+    },
+    "osdElement_SCALED_THROTTLE_POSITION_HELP": {
+        "message": "Zeigt die Throttle-Knüppelposition in Flugmodi, in denen <i>diese</i> den Throttle-Ausgang steuert. In Navigationsmodi zeigt es den von INAV vorgegebenen Throttle-Wert. Dieser Throttle ist auf Basis von Idle-Throttle und Max-Throttle skaliert."
+    },
+    "osdElement_GPS_SPEED": {
+        "message": "Ground Speed"
+    },
+    "osdElement_GPS_SPEED_HELP": {
+        "message": "Zeigt die GPS-Geschwindigkeit über Grund."
+    },
+    "osdElement_GPS_MAX_SPEED": {
+        "message": "GPS-Maximalgeschwindigkeit"
+    },
+    "osdElement_GPS_MAX_SPEED_HELP": {
+        "message": "Zeigt die höchste GPS-Geschwindigkeit über Grund."
+    },
+    "osdElement_MSL_ALTITUDE": {
+        "message": "MSL-Höhe"
+    },
+    "osdElement_MSL_ALTITUDE_HELP": {
+        "message": "Höhe über dem mittleren Meeresspiegel"
+    },
+    "osdElement_3D_SPEED": {
+        "message": "3D-Geschwindigkeit"
+    },
+    "osdElement_3D_SPEED_HELP": {
+        "message": "Zeigt die 3D-Geschwindigkeit unter Berücksichtigung von horizontaler und vertikaler Geschwindigkeit."
+    },
+    "osdElement_3D_MAX_SPEED": {
+        "message": "3D-Maximalgeschwindigkeit"
+    },
+    "osdElement_3D_MAX_SPEED_HELP": {
+        "message": "Zeigt die höchste 3D-Geschwindigkeit unter Berücksichtigung von horizontaler und vertikaler Geschwindigkeit."
+    },
+    "osdElement_AIR_MAX_SPEED": {
+        "message": "Maximale Air Speed"
+    },
+    "osdElement_AIR_MAX_SPEED_HELP": {
+        "message": "Zeigt die höchste Air Speed."
+    },
+    "osdElement_GPS_SATS": {
+        "message": "GPS-Satelliten"
+    },
+    "osdElement_GPS_SATS_HELP": {
+        "message": "Zeigt die Anzahl der vom GPS-Empfänger erfassten Satelliten."
+    },
+    "osdElement_GPS_HDOP": {
+        "message": "GPS HDOP"
+    },
+    "osdElement_GPS_HDOP_HELP": {
+        "message": "Zeigt die horizontale Genauigkeitsabschwächung (HDOP) des GPS. Je niedriger, desto genauer der GPS-Fix."
+    },
+    "osdElement_PLUS_CODE": {
+        "message": "Plus Code (Breitengrad + Längengrad)"
+    },
+    "osdElement_PLUS_CODE_HELP": {
+        "message": "Plus Codes kodieren Breiten- und Längengrad in einem einzigen Wert, der direkt in Google Maps eingegeben werden kann. Er bietet dieselbe Genauigkeit wie Breiten- und Längengrad, benötigt aber weniger Platz auf dem Bildschirm."
+    },
+    "osdElement_AZIMUTH": {
+        "message": "Azimut"
+    },
+    "osdElement_AZIMUTH_HELP": {
+        "message": "Der Azimut ist die Richtung des Modells in Bezug auf den Home-Punkt. Nützlich, um das Modell auf dem richtigen Kurs zu halten oder es vor einer fest ausgerichteten Richtantenne zu halten."
+    },
+    "osdElement_TRIP_DIST": {
+        "message": "Reisedistanz"
+    },
+    "osdElement_VARIO_HELP": {
+        "message": "Zeigt die vertikale Geschwindigkeit mit Auf- oder Ab-Pfeilen. Jeder Pfeil steht für 10 cm (~4 Zoll) pro Sekunde."
+    },
+    "osdElement_VERTICAL_SPEED_INDICATOR": {
+        "message": "Vertikalgeschwindigkeits-Anzeige"
+    },
+    "osdElement_VERTICAL_SPEED_INDICATOR_HELP": {
+        "message": "Zeigt die Vertikalgeschwindigkeit als Zahl an"
+    },
+    "osdElement_G_FORCE": {
+        "message": "g-Kraft"
+    },
+    "osdElement_G_FORCE_HELP": {
+        "message": "Zeigt die g-Kraft unter Berücksichtigung aller Achsen"
+    },
+    "osdElement_G_FORCE_X": {
+        "message": "Längs-g-Kraft im Body Frame (X)"
+    },
+    "osdElement_G_FORCE_X_HELP": {
+        "message": "Zeigt die g-Kraft in der X-Achse (längs)"
+    },
+    "osdElement_G_FORCE_Y": {
+        "message": "Quer-g-Kraft im Body Frame (Y)"
+    },
+    "osdElement_G_FORCE_Y_HELP": {
+        "message": "Zeigt die g-Kraft in der Y-Achse (quer)"
+    },
+    "osdElement_G_FORCE_Z": {
+        "message": "Vertikale g-Kraft im Body Frame (Z)"
+    },
+    "osdElement_G_FORCE_Z_HELP": {
+        "message": "Zeigt die g-Kraft in der Z-Achse (vertikal)"
+    },
+    "osdElement_ROLL_PIDS": {
+        "message": "Roll PIDs"
+    },
+    "osdElement_PITCH_PIDS": {
+        "message": "Pitch PIDs"
+    },
+    "osdElement_YAW_PIDS": {
+        "message": "Yaw PIDs"
+    },
+    "osdElement_ONTIME_FLYTIME_HELP": {
+        "message": "Zeigt \"On Time\" im disarmed Zustand und \"Fly Time\" im armed Zustand."
+    },
+    "osdElement_RTC_TIME": {
+        "message": "Uhrzeit"
+    },
+    "osdElement_RTC_TIME_HELP": {
+        "message": "Zeigt die aktuelle Uhrzeit, abgerufen vom GPS oder über das Funkgerät gesetzt."
+    },
+    "osdElement_RC_SOURCE": {
+        "message": "RC-Quelle"
+    },
+    "osdElement_RC_SOURCE_HELP": {
+        "message": "Zeigt die aktuelle RC-Quelle, STD oder MSP (nützlich bei Verwendung von MSP-Override)"
+    },
+    "osdElement_VTX_POWER": {
+        "message": "Video-TX Power Level"
+    },
+    "osdElement_VTX_POWER_HELP": {
+        "message": "Zeigt das aktuelle VTX Power Level. Blinkt, wenn die entsprechende RC-Anpassung ausgewählt ist"
+    },
+    "osdElement_ESC_RPM": {
+        "message": "Motor-RPM aus ESC-Telemetrie"
+    },
+    "osdElement_GLIDESLOPE": {
+        "message": "Gleitpfad"
+    },
+    "osdElement_GLIDESLOPE_HELP": {
+        "message": "Horizontale Distanz, die pro Einheit verlorener Höhe zurückgelegt wird"
+    },
+    "osdElement_PAN_SERVO_CENTRED": {
+        "message": "Pan-Servo zentriert"
+    },
+    "osdElement_PAN_SERVO_CENTRED_HELP": {
+        "message": "Zeigt an, ob das Pan-Servo zentriert (0) oder versetzt (Pfeile) ist. Prüfe die <b>osd_pan_servo_</b>-Einstellungen zur Konfiguration des Pan-Servos."
+    },
+    "osdElement_VTX_CHANNEL": {
+        "message": "Video-TX Band und Kanal"
+    },
+    "osdElement_VTX_CHANNEL_HELP": {
+        "message": "Zeigt das aktuelle Band und den Kanal des VTX. Erfordert entweder einen VTX mit SmartAudio oder Tramp oder einen im Flight Controller integrierten VTX."
+    },
+    "osdElement_RSSI_DBM": {
+        "message": "RX RSSI in dBm"
+    },
+    "osdElement_LQ_UPLINK": {
+        "message": "RX Uplink-Quality %"
+    },
+    "osdElement_LQ_UPLINK_HELP": {
+        "message": "Bei Verwendung von CRSF die Einstellung Crossfire LQ-Format zur Auswahl des Formattyps nutzen."
+    },
+    "osdElement_LQ_DOWNLINK": {
+        "message": "RX Downlink-Quality %"
+    },
+    "osdElement_SNR_DB": {
+        "message": "RX Uplink-SNR in dB"
+    },
+    "osdElement_SNR_DB_HELP": {
+        "message": "Wird nur angezeigt, wenn der SNR unter die Alarmschwelle fällt. Bei 0 dB entspricht der empfangene Signalpegel dem Grundrauschen."
+    },
+    "osdElement_TX_POWER_UPLINK": {
+        "message": "TX-Leistung in mW"
+    },
+    "osdElement_OSD_RX_POWER_DOWNLINK": {
+        "message": "RX-Leistung in mW"
+    },
+    "osdElement_MAP_NORTH": {
+        "message": "Karte (Oben ist Norden)"
+    },
+    "osdElement_MAP_TAKEOFF": {
+        "message": "Karte (Oben ist die Startrichtung)"
+    },
+    "osdElement_RADAR": {
+        "message": "Radar"
+    },
+    "osdElement_MAP_SCALE": {
+        "message": "Kartenmaßstab"
+    },
+    "osdElement_MAP_SCALE_HELP": {
+        "message": "Maßstab der aktuell angezeigten Karte/des Radars."
+    },
+    "osdElement_MAP_REFERENCE": {
+        "message": "Kartenreferenz"
+    },
+    "osdElement_MAP_REFERENCE_HELP": {
+        "message": "Referenz (Richtung, die nach oben zeigt) der aktuellen Karte. N für Norden und T für Startrichtung."
+    },
+    "osdElement_FORMATION_FLIGHT": {
+        "message": "INAV Radar fixed"
+    },
+    "osdElement_FORMATION_FLIGHT_HELP": {
+        "message": "Das nächstgelegene Modell aus INAV Radar/Formation Flight"
+    },
+    "osdElement_WIND_SPEED_HORIZONTAL": {
+        "message": "Horizontale Windgeschwindigkeit"
+    },
+    "osdElement_WIND_SPEED_HORIZONTAL_HELP": {
+        "message": "Zeigt die geschätzte horizontale Windgeschwindigkeit und -richtung."
+    },
+    "osdElement_WIND_SPEED_VERTICAL": {
+        "message": "Vertikale Windgeschwindigkeit"
+    },
+    "osdElement_WIND_SPEED_VERTICAL_HELP": {
+        "message": "Zeigt die geschätzte vertikale Windgeschwindigkeit und -richtung (auf oder ab)."
+    },
+    "osdElement_ACTIVE_PROFILE": {
+        "message": "Aktives Profil anzeigen"
+    },
+    "osdElement_LEVEL_PIDS": {
+        "message": "Level PIDs"
+    },
+    "osdElement_POS_XY_PIDS": {
+        "message": "Position XY PIDs"
+    },
+    "osdElement_POS_Z_PIDS": {
+        "message": "Position Z PIDs"
+    },
+    "osdElement_VEL_XY_PIDS": {
+        "message": "Velocity XY PIDs"
+    },
+    "osdElement_VEL_Z_PIDS": {
+        "message": "Velocity Z PIDs"
+    },
+    "osdElement_FW_ALT_PID_OUTPUTS": {
+        "message": "FW Höhen-PID-Controller-Ausgänge"
+    },
+    "osdElement_FW_POS_PID_OUTPUTS": {
+        "message": "FW Positions-PID-Controller-Ausgänge"
+    },
+    "osdElement_MC_VEL_X_PID_OUTPUTS": {
+        "message": "MC Velocity-X PID-Controller-Ausgänge"
+    },
+    "osdElement_MC_VEL_Y_PID_OUTPUTS": {
+        "message": "MC Velocity-Y PID-Controller-Ausgänge"
+    },
+    "osdElement_MC_VEL_Z_PID_OUTPUTS": {
+        "message": "MC Velocity-Z PID-Controller-Ausgänge"
+    },
+    "osdElement_MC_POS_XYZ_P_OUTPUTS": {
+        "message": "MC Position-XYZ P-Controller-Ausgänge"
+    },
+    "osdElement_IMU_TEMPERATURE": {
+        "message": "IMU-Temperatur"
+    },
+    "osdElement_IMU_TEMPERATURE_HELP": {
+        "message": "Temperatur der IMU"
+    },
+    "osdElement_BARO_TEMPERATURE": {
+        "message": "Baro-Temperatur"
+    },
+    "osdElement_BARO_TEMPERATURE_HELP": {
+        "message": "Temperatur des Barometers"
+    },
+    "osdElement_ESC_TEMPERATURE": {
+        "message": "ESC-Temperatur"
+    },
+    "osdElement_ESC_TEMPERATURE_HELP": {
+        "message": "Temperatur des ESC, aus DSHOT-Telemetrie gelesen"
+    },
+    "osdGroupSwitchIndicators": {
+        "message": "Schalter-Anzeigen"
+    },
+    "osdElement_SWITCH_INDICATOR_0": {
+        "message": "Schalter-Anzeige 1"
+    },
+    "osdElement_SWITCH_INDICATOR_1": {
+        "message": "Schalter-Anzeige 2"
+    },
+    "osdElement_SWITCH_INDICATOR_2": {
+        "message": "Schalter-Anzeige 3"
+    },
+    "osdElement_SWITCH_INDICATOR_3": {
+        "message": "Schalter-Anzeige 4"
+    },
+    "osd_pan_servo_settings": {
+        "message": "Pan-Servo OSD-Einstellungen"
+    },
+    "osd_pan_servo_settings_HELP": {
+        "message": "In diesem Abschnitt wird die Pan-Servo-Offset-Funktion aktiviert und konfiguriert. Sie sorgt dafür, dass OSD-Elemente wie der Home-Pfeil und POIs in die korrekte Richtung zeigen, auch wenn du die Kamera geschwenkt hast."
+    },
+    "osdPanServoIndex": {
+        "message": "Pan-Servo-Ausgang"
+    },
+    "osdPanServoIndex_HELP": {
+        "message": "Setze dies auf die Ausgangsnummer des Pan-Servos, wie in der Mixer-Ausgangstabelle gezeigt. Zum Beispiel Ausgang S6."
+    },
+    "osdPanServoRangeDecadegrees": {
+        "message": "Gesamter Bewegungsbereich des Pan-Servos in Grad"
+    },
+    "osdPanServoRangeDecadegrees_HELP": {
+        "message": "Drehbereich des Pan-Servos in Grad. Ein Servo mit 180 Grad Drehung benötigt hier typischerweise 180. Ein negativer Wert kehrt die Richtung um."
+    },
+    "osdPanServoIndicatorShowDegrees": {
+        "message": "Offset-Grad neben der Pan-Anzeige zeigen"
+    },
+    "osdPanServoOffcentreWarning": {
+        "message": "Off-Center-Warnung"
+    },
+    "osdPanServoOffcentreWarning_HELP": {
+        "message": "Grad beiderseits der Pan-Servo-Mitte, in denen angenommen wird, dass die Kamera nach vorne zeigen soll, aber nicht bei 0 steht. Liegt sie länger als 10 Sekunden in diesem Bereich und nicht bei 0, blinkt das Pan-Servo-Offset-OSD-Element. 0 deaktiviert die Warnung."
+    },
+    "osdGroupOSDCustomElements": {
+        "message": "Eigene OSD-Elemente"
+    },
+    "osdGroupGVars": {
+        "message": "Globale Variablen"
+    },
+    "osdElement_GVAR_0": {
+        "message": "Globale Variable 0"
+    },
+    "osdElement_GVAR_1": {
+        "message": "Globale Variable 1"
+    },
+    "osdElement_GVAR_2": {
+        "message": "Globale Variable 2"
+    },
+    "osdElement_GVAR_3": {
+        "message": "Globale Variable 3"
+    },
+    "osdElement_SENSOR1_TEMPERATURE": {
+        "message": "Temperatursensor 1"
+    },
+    "osdElement_SENSOR2_TEMPERATURE": {
+        "message": "Temperatursensor 2"
+    },
+    "osdElement_SENSOR3_TEMPERATURE": {
+        "message": "Temperatursensor 3"
+    },
+    "osdElement_SENSOR4_TEMPERATURE": {
+        "message": "Temperatursensor 4"
+    },
+    "osdElement_SENSOR5_TEMPERATURE": {
+        "message": "Temperatursensor 5"
+    },
+    "osdElement_SENSOR6_TEMPERATURE": {
+        "message": "Temperatursensor 6"
+    },
+    "osdElement_SENSOR7_TEMPERATURE": {
+        "message": "Temperatursensor 7"
+    },
+    "osdElement_SENSOR8_TEMPERATURE": {
+        "message": "Temperatursensor 8"
+    },
+    "osdSettingMainVoltageDecimals": {
+        "message": "Nachkommastellen Hauptspannung"
+    },
+    "osdElement_OSD_RANGEFINDER": {
+        "message": "Rangefinder-Distanz"
+    },
+    "osdElement_COURSE_NEXT_GEOZONE": {
+        "message": "Kurs zur nächsten Geozone"
+    },
+    "osdElement_HOR_DIST_TO_NEXT_GEOZONE": {
+        "message": "Horizontale Distanz zur nächsten Geozone"
+    },
+    "osdElement_VERT_DIST_TO_NEXT_GEOZONE": {
+        "message": "Vertikale Distanz zur nächsten Geozone"
+    },
+    "osdSettingPLUS_CODE_DIGITS_HELP": {
+        "message": "Genauigkeit am Äquator: 10=13,9x13,9 m; 11=2,8x3,5 m; 12=56x87 cm; 13=11x22 cm."
+    },
+    "osdSettingPLUS_CODE_SHORT_HELP": {
+        "message": "Das Entfernen von 2, 4 und 6 führenden Stellen erfordert einen Referenzort innerhalb von ~800 km, ~40 km bzw. ~2 km, um die ursprünglichen Koordinaten wiederherzustellen."
+    },
+    "osdSettingCRSF_LQ_FORMAT_HELP": {
+        "message": "TYPE1 zeigt LQ% wie von TBS-Hardware verwendet. TYPE2 zeigt RF-Profil-Modi (2=150 Hz, 1=50 Hz, 0=4 Hz Update-Raten) und LQ % [0..100%]. Tracer zeigt RFMode 1 (1=250 Hz) und LQ % [0..100%]."
+    },
+    "osd_video_show_guides": {
+        "message": "Vorschau-Hilfslinien anzeigen"
+    },
+    "osd_video_HELP": {
+        "message": "Für HD: rote Linien zeigen den 4:3-Bildschirm, HDZero: innerhalb der blauen Box bleiben für eine höhere Bildwiederholrate, AUTO/PAL: grüne Linie ist die NTSC-Grenze."
+    },
+    "osd_dji_HD_FPV": {
+        "message": "DJI HD FPV"
+    },
+    "osd_dji_hide_unsupported": {
+        "message": "Nicht unterstützte Elemente ausblenden"
+    },
+    "osd_dji_ESC_temp": {
+        "message": "Quelle der <i>ESC-Temperatur</i>"
+    },
+    "osd_dji_RSSI_source": {
+        "message": "Quelle des <i>RSSI</i>"
+    },
+    "osd_dji_GPS_source": {
+        "message": "Quelle der <i>GPS-Geschwindigkeit</i>"
+    },
+    "osd_dji_speed_source": {
+        "message": "Quelle der <i>3D-Geschwindigkeit</i>"
+    },
+    "osd_dji_use_craft_name_elements": {
+        "message": "Modellname für Nachrichten und zusätzliche Elemente verwenden.</span><br/>Elemente in <span class=\"blue\">blau</span> erscheinen im Modellnamen."
+    },
+    "osd_dji_adjustments": {
+        "message": "Adjustments im Modellnamen anzeigen"
+    },
+    "osd_dji_cn_alternating_duration": {
+        "message": "Wechseldauer des Modellnamens (in 1/10 Sek.)"
+    },
+    "osd_switch_indicator_settings": {
+        "message": "Schalter-Anzeige-Einstellungen"
+    },
+    "osd_switch_indicator_settings_HELP": {
+        "message": "Es wird empfohlen, die eigenen OSD-Elemente als Ersatz für Schalter-Anzeigen zu verwenden. Sie sind deutlich mächtiger. Klicke, um ein Beispiel zu sehen."
+    },
+    "osd_switch_indicators_align_left": {
+        "message": "Schalternamen links von den Schaltern ausrichten"
+    },
+    "osdSwitchInd0": {
+        "message": "Schalter 1"
+    },
+    "osdSwitchInd1": {
+        "message": "Schalter 2"
+    },
+    "osdSwitchInd2": {
+        "message": "Schalter 3"
+    },
+    "osdSwitchInd3": {
+        "message": "Schalter 4"
+    },
+    "osd_font_default": {
+        "message": "Default"
+    },
+    "osd_font_vision": {
+        "message": "Vision"
+    },
+    "osd_font_impact": {
+        "message": "Impact"
+    },
+    "osd_font_impact_mini": {
+        "message": "Impact mini"
+    },
+    "osd_font_clarity": {
+        "message": "Clarity"
+    },
+    "osd_font_clarity_medium": {
+        "message": "Clarity medium"
+    },
+    "osd_font_bold": {
+        "message": "Bold"
+    },
+    "osd_font_large": {
+        "message": "Large"
+    },
+    "osd_font_load_file": {
+        "message": "Font-Datei öffnen"
+    },
+    "osd_font_upload": {
+        "message": "Font hochladen"
+    },
+    "osd_font_manager": {
+        "message": "Analog-Font-Manager"
+    },
+    "uploadingCharacters": {
+        "message": "Wird hochgeladen..."
+    },
+    "uploadedCharacters": {
+        "message": "$1 Zeichen hochgeladen"
+    },
+    "portsIdentifier": {
+        "message": "Identifier"
+    },
+    "portsConfiguration": {
+        "message": "Daten"
+    },
+    "portsTelemetryOut": {
+        "message": "Telemetrie"
+    },
+    "portsSerialRx": {
+        "message": "RX"
+    },
+    "portColumnSensors": {
+        "message": "Sensoren"
+    },
+    "portsPeripherals": {
+        "message": "Peripheriegeräte"
+    },
+    "appUpdateNotificationHeader": {
+        "message": "Neue Configurator-Version verfügbar."
+    },
+    "appUpdateNotificationDescription": {
+        "message": "Bitte besuche die <a href=\"https://github.com/iNavFlight/inav-configurator/releases\" target=\"_blank\">Website</a>, um die Release Notes zu lesen und herunterzuladen."
+    },
+    "closeUpdateBtn": {
+        "message": "Schließen"
+    },
+    "downloadUpdatesBtn": {
+        "message": "Neue App herunterladen"
+    },
+    "tabMissionControl": {
+        "message": "Mission Control"
+    },
+    "loadMissionButton": {
+        "message": "Mission vom FC laden"
+    },
+    "saveMissionButton": {
+        "message": "Mission auf FC speichern"
+    },
+    "loadEepromMissionButton": {
+        "message": "EEPROM-Mission laden"
+    },
+    "saveEepromMissionButton": {
+        "message": "EEPROM-Mission speichern"
+    },
+    "loadFileMissionButton": {
+        "message": "Datei laden"
+    },
+    "saveFileMissionButton": {
+        "message": "Datei speichern"
+    },
+    "missionSettingsSave": {
+        "message": "Speichern"
+    },
+    "missionSettingsCancel": {
+        "message": "Abbrechen"
+    },
+    "editPointHead": {
+        "message": "Punkt bearbeiten"
+    },
+    "editPointButtonSave": {
+        "message": "Speichern"
+    },
+    "editPointButtonRemove": {
+        "message": "Entfernen"
+    },
+    "removeAllPointButtonSave": {
+        "message": "Alle Punkte entfernen"
+    },
+    "missionTotalInformationHead": {
+        "message": "Gesamtinformationen"
+    },
+    "missionTotalInfoFilenameLoaded": {
+        "message": "Geladene Datei:"
+    },
+    "missionTotalInfoDistance": {
+        "message": "Distanz (m):"
+    },
+    "missionTotalInfoAvailablePoints": {
+        "message": "Verfügbare Punkte"
+    },
+    "missionTotalInfoMissionValid": {
+        "message": "Mission gültig"
+    },
+    "missionDefaultPointAlt": {
+        "message": "Höhe (cm): "
+    },
+    "missionDefaultPointSpeed": {
+        "message": "Geschwindigkeit (cm/s): "
+    },
+    "missionDefaultSafeRangeSH": {
+        "message": "Radius (m): "
+    },
+    "missionMultiMissionsInfo": {
+        "message": "Missions-Info:"
+    },
+    "missionMultiActiveMission": {
+        "message": "Aktive Mission:"
+    },
+    "missionMultiMissionNo": {
+        "message": "Mission Nr."
+    },
+    "missionMultiUpdateAll": {
+        "message": "Alle aktualisieren"
+    },
+    "missionMultiAddNewMission": {
+        "message": "Neue Mission hinzufügen"
+    },
+    "missionEllipsoidEarthDEMModel": {
+        "message": "Ellipsoid statt SL-DEM verwenden: "
+    },
+    "SafehomeLegend": {
+        "message": "Legende: "
+    },
+    "SafehomeMaxDistance": {
+        "message": "Max. Distanz (m):"
+    },
+    "SafehomeSafeRadius": {
+        "message": "Sicherer Radius (m):"
+    },
+    "SafehomeFwAppraoch": {
+        "message": "FW-Anflug:"
+    },
+    "safehomeEdit": {
+        "message": "Safehome bearbeiten"
+    },
+    "missionTitleHide": {
+        "message": "Ausblenden"
+    },
+    "missionTitleCancel": {
+        "message": "Abbrechen"
+    },
+    "missionTitleSave": {
+        "message": "Speichern"
+    },
+    "missionTitlRemove": {
+        "message": "Entfernen"
+    },
+    "missionTitleLoadMissionFile": {
+        "message": "Missionsdatei laden"
+    },
+    "missionTitleSaveMissionFile": {
+        "message": "Missionsdatei speichern"
+    },
+    "missionTitleLoadMissionFromFC": {
+        "message": "Mission vom FC laden"
+    },
+    "missionTitleSaveMissionToFC": {
+        "message": "Mission auf FC speichern"
+    },
+    "missionTitleLoadEepromMission": {
+        "message": "EEPROM-Mission laden"
+    },
+    "missionTitleSaveEepromMission": {
+        "message": "EEPROM-Mission speichern"
+    },
+    "missionTitleDelete": {
+        "message": "Löschen"
+    },
+    "missionTitleRemoveAll": {
+        "message": "Alle entfernen"
+    },
+    "missionTitleSetActive": {
+        "message": "Aktiv setzen"
+    },
+    "missionTitleUpdateAll": {
+        "message": "Alle aktualisieren"
+    },
+    "missionTitleAdd": {
+        "message": "Hinzufügen"
+    },
+    "missionTitleMoveToCenterView": {
+        "message": "in Bildmitte verschieben"
+    },
+    "missionTitleSaveEepromSafehome": {
+        "message": "EEPROM-Safehome speichern"
+    },
+    "missionTitleLoadEepromSafehome": {
+        "message": "EEPROM-Safehome laden"
+    },
+    "missionTitlEditMission": {
+        "message": "Mission bearbeiten"
+    },
+    "MissionPlannerFwLAndingAltitudeChangeReset": {
+        "message": "Höhe unter minimaler Landehöhe. Änderung ignoriert"
+    },
+    "missionWpType": {
+        "message": "Typ:"
+    },
+    "missionWpLat": {
+        "message": "Lat:"
+    },
+    "missionWpLon": {
+        "message": "Lon:"
+    },
+    "missionSeaLevelRef": {
+        "message": "Meeresspiegel-Ref.: "
+    },
+    "missionElevation": {
+        "message": "Geländehöhe (m):"
+    },
+    "missionNA": {
+        "message": "k. A."
+    },
+    "missionGroundDist": {
+        "message": "Grd-Dist. (m):"
+    },
+    "missionParameter1": {
+        "message": "Parameter 1:"
+    },
+    "missionParameter2": {
+        "message": "Parameter 2:"
+    },
+    "missionUserActions": {
+        "message": "User Actions:"
+    },
+    "missionFwLandingSettings": {
+        "message": "Fixed Wing Landeeinstellungen:"
+    },
+    "missionFwApproachAlt": {
+        "message": "Anflughöhe: (cm):"
+    },
+    "missionFwLandAlt": {
+        "message": "Landehöhe: (cm):"
+    },
+    "missionFwApproachDir": {
+        "message": "Anflugrichtung:"
+    },
+    "missionFwLandHeading1": {
+        "message": "Heading 1: (Grad):"
+    },
+    "missionFwLandHeading2": {
+        "message": "Heading 2: (Grad):"
+    },
+    "missionExclusive": {
+        "message": "Excl."
+    },
+    "missionRTHsettingsTitle": {
+        "message": "RTH-Einstellungen"
+    },
+    "missionDefaultSettingsHead": {
+        "message": "Standardeinstellungen"
+    },
+    "missionDefaultElevationHead": {
+        "message": "Höhenprofil"
+    },
+    "missionHomeHead": {
+        "message": "Take-Off Home"
+    },
+    "missionSafehomeHead": {
+        "message": "Safe-Home-Manager"
+    },
+    "missionSafehomeAvailableSafehomes": {
+        "message": "Verfügbare Safehomes:"
+    },
+    "missionSafehomeMaxSafehomesReached": {
+        "message": "Maximale Anzahl an Safehomes erreicht."
+    },
+    "missionGeozoneHead": {
+        "message": "Geozones"
+    },
+    "missionGeozoneEdit": {
+        "message": "Geozone $1 bearbeiten"
+    },
+    "missionGeozoneSaveAndReboot": {
+        "message": "EEPROM-Geozones speichern und neu starten"
+    },
+    "missionGeozoneLoad": {
+        "message": "EEPROM-Geozones laden"
+    },
+    "missionGeozone": {
+        "message": "-Geozone "
+    },
+    "missionGezoneType": {
+        "message": "Typ"
+    },
+    "missionGezoneShape": {
+        "message": "Form"
+    },
+    "missionGeozoneTypePolygon": {
+        "message": "Polygon"
+    },
+    "missionGeozoneTypeCircular": {
+        "message": "Kreisförmig"
+    },
+    "missionGeozoneMaxZonesReached": {
+        "message": "Maximale Anzahl an Geozones erreicht."
+    },
+    "missionGeozoneMaxVerticesReached": {
+        "message": "Maximale Anzahl an Geozone-Eckpunkten erreicht."
+    },
+    "missionGeozoneWarning": {
+        "message": "Mindestens eine Mission und eine Geozone sind konfiguriert. Bitte stelle sicher, dass die Mission die Geozone nicht verletzt."
+    },
+    "geozoneEdit": {
+        "message": "Geozone bearbeiten "
+    },
+    "geozoneShape": {
+        "message": "Form"
+    },
+    "geozoneInclusive": {
+        "message": "Inklusiv"
+    },
+    "geozoneExcusive": {
+        "message": "Exklusiv"
+    },
+    "geozoneMinAlt": {
+        "message": "Min. Höhe (cm):"
+    },
+    "geozoneMaxAlt": {
+        "message": "Max. Höhe (cm):"
+    },
+    "geozoneInfiniteAlt": {
+        "message": "0 = Unbegrenzte Höhe"
+    },
+    "geozoneAction": {
+        "message": "Aktion:"
+    },
+    "geozoneActionNone": {
+        "message": "Keine"
+    },
+    "geozoneActionAvoid": {
+        "message": "Vermeiden"
+    },
+    "geozoneActionPosHold": {
+        "message": "Pos. Hold"
+    },
+    "geozoneActionRTH": {
+        "message": "RTH"
+    },
+    "geozoneRadius": {
+        "message": "Radius (cm):"
+    },
+    "geozoneVerices": {
+        "message": "Eckpunkte:"
+    },
+    "": {
+        "message": ""
+    },
+    "featureGEOZONE": {
+        "message": "Geozone"
+    },
+    "geozone": {
+        "message": "Geozone"
+    },
+    "featureGEOZONETip": {
+        "message": "Virtuelle Begrenzungen für geografische Bereiche (auch Geofence genannt) mit automatisch ausgelösten Aktionen, wenn die Begrenzungen verletzt werden."
+    },
+    "GeozoneSettings": {
+        "message": "Geozone-Einstellungen"
+    },
+    "geozoneDetectionDistance": {
+        "message": "Erkennungsdistanz"
+    },
+    "geozoneDetectionDistanceHelp": {
+        "message": "Distanz, ab der eine Geozone erkannt wird"
+    },
+    "geozoneAvoidAltitudeRange": {
+        "message": "Ausweich-Höhenbereich"
+    },
+    "geozoneAvoidAltitudeRangeHelp": {
+        "message": "Höhenbereich, in dem versucht wird, einer Geozone nach oben auszuweichen"
+    },
+    "geozoneSafeAltitudeDistance": {
+        "message": "Sicherheitsabstand zur Höhe"
+    },
+    "geozoneSafeAltitudeDistanceHelp": {
+        "message": "Vertikaler Abstand, der zu den oberen und unteren Grenzen der Zone eingehalten werden muss."
+    },
+    "geozoneSafehomeAsInclusive": {
+        "message": "Safehome als inklusiv"
+    },
+    "geozoneSafehomeAsInclusiveHelp": {
+        "message": "Das nächstgelegene Safehome als inklusive Geozone behandeln"
+    },
+    "geozoneSafehomeZoneAction": {
+        "message": "Safehome-Zonenaktion"
+    },
+    "geozoneSafehomeZoneActionHelp": {
+        "message": "Fence-Aktion für die Safehome-Zone"
+    },
+    "geozoneMrStopDistance": {
+        "message": "Multirotor-Stoppdistanz"
+    },
+    "geozoneMrStopDistanceHelp": {
+        "message": "Distanz, in der Multirotoren vor der Grenze stoppen"
+    },
+    "geozoneNoWayHomeAction": {
+        "message": "Aktion bei fehlendem Heimweg"
+    },
+    "geozoneNoWayHomeActionHelp": {
+        "message": "Aktion, wenn RTH bei aktiven Geozones keinen Kurs nach Hause berechnen kann. RTH: Zur Heimat zurückkehren und alle Geozones ignorieren."
+    },
+    "missionGeozoneReboot": {
+        "message": "Möchtest du speichern und neu starten?"
+    },
+    "missionGeozoneAvailableZones": {
+        "message": "Verfügbare Geozones:"
+    },
+    "missionGeozoneAvailableVertices": {
+        "message": "Verfügbare Eckpunkte:"
+    },
+    "geozoneInvalidzone": {
+        "message": "Ungültige Geozone(n) erkannt:"
+    },
+    "geozoneInvalidLat": {
+        "message": "Ungültiger Breitengrad"
+    },
+    "geozoneInvalidLon": {
+        "message": "Ungültiger Längengrad"
+    },
+    "gezoneInvalidReasonNotCC": {
+        "message": "Nicht gegen den Uhrzeigersinn"
+    },
+    "gezoneInvalidReasonComplex": {
+        "message": "Komplex"
+    },
+    "gezoneInvalidReasonMinMaxAlt": {
+        "message": "Max. Höhe <= Min. Höhe"
+    },
+    "geozoneUnableToSave": {
+        "message": "Geozones können nicht gespeichert werden: Ungültige Zonen"
+    },
+    "missionMultiMissionHead": {
+        "message": "Multi-Missionen"
+    },
+    "missionTemplateHead": {
+        "message": "Missionsvorlage"
+    },
+    "missionActionMenuHead": {
+        "message": "Aktionsmenü"
+    },
+    "useOnlyStandalone": {
+        "message": "Eigenständige Anwendung verwenden.<br> Bitte besuche die <a href=\"https://github.com/iNavFlight/inav-configurator/releases\" target=\"_blank\">Website</a>, um die Release Notes zu lesen und herunterzuladen."
+    },
+    "eeprom_load_ok": {
+        "message": "EEPROM <span style=\"color: #37a8db\">geladen</span>"
+    },
+    "confirm_delete_all_points": {
+        "message": "Möchtest du wirklich alle Punkte löschen?"
+    },
+    "confirm_delete_point_with_options": {
+        "message": "Möchtest du diesen Waypoint mit Non-Geo-Optionen (JUMP/SET_HEAD/RTH) wirklich löschen? \nFalls ja, werden auch die angehängten Non-Geo-Optionen entfernt!"
+    },
+    "confirm_multimission_file_load": {
+        "message": "Dies ist eine Multi-Missions-Datei. Das Laden überschreibt die aktuelle Multi-Mission.\nFortfahren?"
+    },
+    "confirm_overwrite_multimission_file_load_option": {
+        "message": "Dies überschreibt die aktuelle Multi-Mission.\nFortfahren?"
+    },
+    "multimission_active_index_saved_eeprom": {
+        "message": "Aktiver Missions-Index gespeichert"
+    },
+    "no_waypoints_to_load": {
+        "message": "Keine Waypoints zum Laden!"
+    },
+    "no_waypoints_to_save": {
+        "message": "Keine Waypoints zum Speichern!"
+    },
+    "mixerThrottleWarning": {
+        "message": "Warnung: Wert außerhalb des normalen Betriebsbereichs."
+    },
+    "servoMixer": {
+        "message": "Servo-Mixer"
+    },
+    "servoMixerDelete": {
+        "message": "Löschen"
+    },
+    "servoMixerAdd": {
+        "message": "Neue Mixer-Regel hinzufügen"
+    },
+    "platformType": {
+        "message": "Plattformtyp"
+    },
+    "platformConfiguration": {
+        "message": "Plattform-Konfiguration"
+    },
+    "output_modeTitle": {
+        "message": "Ausgangsmodus"
+    },
+    "mixerPreset": {
+        "message": "Mixer-Preset"
+    },
+    "mixerNotLoaded": {
+        "message": "Mixer nicht geladen.<br />Klicke auf <b>Laden und anwenden</b> oder <b>Mixer laden</b>, um den ausgewählten Mixer zu verwenden.<br />Oder klicke auf <b>Mixer aktualisieren</b>, um deinen aktuellen Mixer zu verwenden."
+    },
+    "mixerLoadPresetRules": {
+        "message": "Mixer laden"
+    },
+    "mixerRefreshCurrentRules": {
+        "message": "Mixer aktualisieren"
+    },
+    "mixerLoadAndApplyPresetRules": {
+        "message": "Laden und anwenden"
+    },
+    "mixerApplyModalTitle": {
+        "message": "Bestätigen"
+    },
+    "mixerButtonSaveAndReboot": {
+        "message": "Speichern und Neustarten"
+    },
+    "mixerApplyDescription": {
+        "message": "Diese Aktion überschreibt alle aktuellen Mixer-Einstellungen und ersetzt sie durch Standardwerte. Es gibt keine 'Rückgängig'-Option!"
+    },
+    "mixerWizardModalTitle": {
+        "message": "Quadcopter Mixer Wizard"
+    },
+    "mixerWizardModalApply": {
+        "message": "Anwenden"
+    },
+    "motorWizard0": {
+        "message": "Hinten-Rechts"
+    },
+    "motorWizard1": {
+        "message": "Vorne-Rechts"
+    },
+    "motorWizard2": {
+        "message": "Hinten-Links"
+    },
+    "motorWizard3": {
+        "message": "Vorne-Links"
+    },
+    "mixerWizardMotorPosition": {
+        "message": "Motorposition"
+    },
+    "mixerWizardMotorIndex": {
+        "message": "Motor-Index"
+    },
+    "mixerWizardLocateInfo": {
+        "message": "Klicke einen Motor an, um ihn zu identifizieren"
+    },
+    "mixerWizardLocateHint": {
+        "message": "Anklicken, damit dieser Motor piept und zuckt"
+    },
+    "mixerWizardIntro": {
+        "message": "Dieser Assistent hilft dir zu identifizieren, welcher Motor an welchem Ausgang hängt. Der Assistent aktiviert jeden Motor nacheinander — klicke dort, wo du eine Bewegung siehst."
+    },
+    "mixerWizardStep1": {
+        "message": "Aus Sicherheitsgründen alle Propeller entfernen"
+    },
+    "mixerWizardStep2": {
+        "message": "Akku anschließen, um die ESCs zu versorgen"
+    },
+    "mixerWizardStep3": {
+        "message": "Stelle sicher, dass du alle Motoren sehen/hören kannst"
+    },
+    "mixerWizardLocating": {
+        "message": "Motor"
+    },
+    "mixerWizardClickPosition": {
+        "message": "Klicke dorthin, wo sich dieser Motor bewegt."
+    },
+    "mixerWizardComplete": {
+        "message": "Alle Motoren identifiziert! Klicke auf „Übernehmen“, um die Motorzuordnung zu speichern."
+    },
+    "mixerWizardStart": {
+        "message": "Assistent starten"
+    },
+    "mixerWizardStop": {
+        "message": "Not-Stopp"
+    },
+    "settings": {
+        "message": "Einstellungen"
+    },
+    "decimals": {
+        "message": "Nachkommastellen"
+    },
+    "motorMixer": {
+        "message": "Motor-Mixer"
+    },
+    "servo": {
+        "message": "Servo"
+    },
+    "input": {
+        "message": "Eingang"
+    },
+    "fixedValue": {
+        "message": "Fester Wert (µs)"
+    },
+    "weight": {
+        "message": "Gewichtung (%)"
+    },
+    "speed": {
+        "message": "Geschwindigkeit (10µs/s)"
+    },
+    "mixerPresetTitle": {
+        "message": "Mixer-Preset"
+    },
+    "fcFirmwareUpdateRequired": {
+        "message": "Die Firmware des Flight Controllers muss auf die neueste Version aktualisiert werden, um diese Funktion zu nutzen"
+    },
+    "mixerNotConfigured": {
+        "message": "Mixer nicht konfiguriert. Richte ihn im <u>Mixer</u>-Tab ein!"
+    },
+    "confirm_reset_settings": {
+        "message": "Möchtest du wirklich alle Einstellungen zurücksetzen?\nACHTUNG: Alle Einstellungen gehen verloren! Du musst das gesamte Modell danach neu einrichten!"
+    },
+    "confirm_select_defaults": {
+        "message": "Dies erlaubt die Auswahl neuer Standardwerte für alle Einstellungen. Bestehendes PID-Tuning und andere Einstellungen können verloren gehen!\nMöchtest du fortfahren?"
+    },
+    "confirm_reset_pid": {
+        "message": "Dies setzt alle PID-Einstellungen auf die Firmware-Standardwerte zurück und speichert.\nMöchtest du fortfahren?"
+    },
+    "mappingTableOutput": {
+        "message": "Ausgang (Timer)"
+    },
+    "mappingTableFunction": {
+        "message": "Funktion"
+    },
+    "mappingTableTitle": {
+        "message": "Output-Mapping"
+    },
+    "NONE": {
+        "message": "Keine"
+    },
+    "DEFAULT": {
+        "message": "Standard"
+    },
+    "AIRCRAFT": {
+        "message": "Modell"
+    },
+    "ALTITUDE": {
+        "message": "Höhe"
+    },
+    "GROUND_SPEED": {
+        "message": "Geschwindigkeit über Grund"
+    },
+    "HOME_DISTANCE": {
+        "message": "Distanz zu Home"
+    },
+    "brakingSpeedThreshold": {
+        "message": "Min. Geschwindigkeitsschwelle"
+    },
+    "brakingSpeedThresholdTip": {
+        "message": "Das Bremsen wird nur aktiviert, wenn die tatsächliche Geschwindigkeit über der Schwelle liegt"
+    },
+    "brakingDisengageSpeed": {
+        "message": "Brems-Lösegeschwindigkeit"
+    },
+    "brakingDisengageSpeedTip": {
+        "message": "Das Bremsen endet, wenn die Geschwindigkeit unter diesen Wert fällt"
+    },
+    "brakingTimeout": {
+        "message": "Max. Bremsdauer"
+    },
+    "brakingTimeoutTip": {
+        "message": "Sicherheitsmaßnahme. Dies ist die längste Zeitspanne, die das Bremsen aktiv sein kann."
+    },
+    "brakingBoostFactor": {
+        "message": "Boost-Faktor"
+    },
+    "brakingBoostFactorTip": {
+        "message": "Legt fest, wie stark der Brems-Boost ist. 100 % bedeutet, dass die Navigations-Engine die Querneigungsgeschwindigkeit und -beschleunigung verdoppeln darf"
+    },
+    "brakingBoostTimeout": {
+        "message": "Max. Brems-Boost-Dauer"
+    },
+    "brakingBoostTimeoutTip": {
+        "message": "Sicherheitsmaßnahme. Dies ist die längste Zeitspanne, die der Brems-Boost aktiv sein kann."
+    },
+    "brakingBoostSpeedThreshold": {
+        "message": "Boost min. Geschwindigkeitsschwelle"
+    },
+    "brakingBoostSpeedThresholdTip": {
+        "message": "Der Brems-Boost wird nur aktiviert, wenn die tatsächliche Geschwindigkeit über der Schwelle liegt"
+    },
+    "brakingBoostDisengageSpeed": {
+        "message": "Brems-Boost-Lösegeschwindigkeit"
+    },
+    "brakingBoostDisengageSpeedTip": {
+        "message": "Der Brems-Boost endet, wenn die Geschwindigkeit unter diesen Wert fällt"
+    },
+    "brakingBankAngle": {
+        "message": "Max. Querneigungswinkel"
+    },
+    "brakingBankAngleTip": {
+        "message": "Maximal erlaubter Querneigungswinkel während der Bremsphase"
+    },
+    "multirotorBrakingConfiguration": {
+        "message": "Konfiguration des Multirotor-Bremsmodus"
+    },
+    "mapProvider": {
+        "message": "Karten-Anbieter"
+    },
+    "proxyURL": {
+        "message": "MapProxy-URL"
+    },
+    "proxyLayer": {
+        "message": "MapProxy-Layer"
+    },
+    "accNotchHz": {
+        "message": "Acc. Notch-Filter-Frequenz"
+    },
+    "accNotchHzHelp": {
+        "message": "Erlaubt das Setzen eines einzelnen Notch-Filters für die Accelerometer-Auslesung. Sollte wie der Gyro-Notch konfiguriert werden, falls das Accelerometer eine Rauschspitze oberhalb des Acc.-LPF-Filters aufzeichnet"
+    },
+    "accNotchCutoff": {
+        "message": "Acc. Notch-Filter Grenzfrequenz"
+    },
+    "accNotchCutoffHelp": {
+        "message": "Sollte unter der Acc.-Notch-Filter-Frequenz bleiben"
+    },
+    "gyroStage2LpfCutoffFrequency": {
+        "message": "Gyro Stage 2 LPF Grenzfrequenz"
+    },
+    "gyroStage2LpfCutoffFrequencyHelp": {
+        "message": "Gyro-Tiefpassfilter der zweiten Stufe, ein Äquivalent zum Betaflight-Nicht-Kalman-Stage2-Filter. Er muss über dem Gyro-LPF der ersten Stufe eingestellt werden. Für 5- und 6-Zoll-Miniquads bedeutet das meist über 150 Hz. 7-Zoll-Quads über 125 Hz."
+    },
+    "escProtocolNotAdvised": {
+        "message": "Dieses ESC-Protokoll wird nicht empfohlen, Verwendung auf eigenes Risiko"
+    },
+    "escProtocolExperimental": {
+        "message": "Experimentelles ESC-Protokoll, Verwendung auf eigenes Risiko"
+    },
+    "looptimeNotAdvised": {
+        "message": "Die PID-Loop könnte instabil sein, wenn GPS verwendet wird"
+    },
+    "gyroLpfSuggestedMessage": {
+        "message": "Dies ist die empfohlene Einstellung für alle Multirotoren mit Propellergröße unter 8 Zoll. Prüfe nach dem ersten Flug immer die Motortemperatur"
+    },
+    "gyroLpfNotAdvisedMessage": {
+        "message": "Es wird empfohlen, eine höhere Grenzfrequenz zu wählen"
+    },
+    "gyroLpfNotFlyableMessage": {
+        "message": "Diese Einstellung macht das UAV vermutlich unfliegbar"
+    },
+    "gyroLpfWhyNotHigherMessage": {
+        "message": "Falls die Motoren nicht überhitzen, versuche stattdessen 256 Hz"
+    },
+    "gyroLpfWhyNotSlightlyHigherMessage": {
+        "message": "Falls keine Vibrationsprobleme bestehen und die Motoren nicht überhitzen, versuche stattdessen 188 Hz"
+    },
+    "tabLogicConditions": {
+        "message": "Logic Conditions"
+    },
+    "logicId": {
+        "message": "#"
+    },
+    "logicEnabled": {
+        "message": "Aktiviert"
+    },
+    "logicOperation": {
+        "message": "Operation"
+    },
+    "logicOperandA": {
+        "message": "Operand A"
+    },
+    "logicOperandB": {
+        "message": "Operand B"
+    },
+    "logicFlags": {
+        "message": "Flags"
+    },
+    "logicStatus": {
+        "message": "Status"
+    },
+    "logicSave": {
+        "message": "Speichern"
+    },
+    "logicClose": {
+        "message": "Schließen"
+    },
+    "logicActivator": {
+        "message": "Active"
+    },
+    "save": {
+        "message": "Speichern"
+    },
+    "copy": {
+        "message": "Kopieren"
+    },
+    "paste": {
+        "message": "Einfügen"
+    },
+    "clear": {
+        "message": "Leeren"
+    },
+    "active": {
+        "message": "Aktiv"
+    },
+    "itermRelax": {
+        "message": "Iterm Relax"
+    },
+    "itermRelaxHelp": {
+        "message": "Legt die Aktivierung des Iterm-Relax-Algorithmus fest. PR bedeutet aktiv auf Roll- und Pitch-Achse. PRY ist auch auf Yaw aktiv."
+    },
+    "dterm_lpf_type": {
+        "message": "D-Term LPF-Typ"
+    },
+    "dterm_lpf_type_help": {
+        "message": "BIQUAD bietet bessere Rauschunterdrückung, dafür eine höhere Verzögerung. PT1 hat geringere Unterdrückung, bietet aber geringere Verzögerung."
+    },
+    "dterm_lpf2_type": {
+        "message": "D-Term Stage 2 LPF-Typ"
+    },
+    "dterm_lpf2_type_help": {
+        "message": "BIQUAD bietet bessere Rauschunterdrückung, dafür eine höhere Verzögerung. PT1 hat geringere Unterdrückung, bietet aber geringere Verzögerung."
+    },
+    "dterm_lpf2_hz": {
+        "message": "D-Term Stage 2 LPF Grenzfrequenz"
+    },
+    "dterm_lpf2_hz_help": {
+        "message": "Tiefpass-Grenzfrequenz für den D-Term auf ROLL- und PITCH-Achse. 0 bedeutet, der Filter ist deaktiviert"
+    },
+    "tabFilteringAdvanced": {
+        "message": "Weitere Filter"
+    },
+    "gps_map_center": {
+        "message": "Zentrieren"
+    },
+    "ouptputsConfiguration": {
+        "message": "Konfiguration"
+    },
+    "vtxDisclaimer": {
+        "message": "Verwende nur Bänder, Kanäle und Leistungsstufen, die an deinem Flugort legal sind! Beachte stets das VTX-Handbuch und die lokalen Vorschriften!"
+    },
+    "defaultsDialogTitle": {
+        "message": "Standardwerte"
+    },
+    "defaultsDialogInfo": {
+        "message": "Der INAV Configurator möchte wissen, welche Art von UAV du konfigurierst. Auf Basis dieser Information passt er einige Standardwerte an, um die beste Flugleistung freizuschalten. "
+    },
+    "defaultsDialogInfo2": {
+        "message": "Vermeide es, die gesamte PID- und Filterkonfiguration blind aus der vorherigen INAV-Version wiederherzustellen. Das beste Ergebnis erzielst du, indem du von den Standardwerten aus neu tunst!"
+    },
+    "throttleIdle": {
+        "message": "Motors IDLE power [%]"
+    },
+    "throttleIdleDigitalInfo": {
+        "message": "Bei digitalen Protokollen kann IDLE sogar bis auf 5-7 % gesenkt werden, ohne dass die Motoren in der Luft stoppen. Falls eine Drohne nach dem Herunterziehen des Throttles wackelt, versuche IDLE zu erhöhen, um dieses Verhalten wegzutunen."
+    },
+    "throttleIdleAnalogInfo": {
+        "message": "Bei analogen Protokollen kann IDLE unter 10 % gesenkt werden, wenn die Motoren ruckelfrei laufen. Falls eine Drohne nach dem Herunterziehen des Throttles wackelt, versuche IDLE zu erhöhen, um dieses Verhalten wegzutunen."
+    },
+    "motor_poles": {
+        "message": "Anzahl der Motorpole (Anzahl der Magnete)"
+    },
+    "motorStopWarning": {
+        "message": "Sollte bei Flugzeugen, Rovern und Booten aktiviert werden. Sollte bei Multirotoren nicht aktiviert werden! Bei Multirotoren stoppen die Motoren nicht, wenn Airmode aktiv ist."
+    },
+    "reversibleEscWarning": {
+        "message": "Bei Verwendung umkehrbarer Motoren die Motor-IDLE-Leistung auf 0 % setzen"
+    },
+    "dynamic_gyro_notch_enabled_help": {
+        "message": "Der Matrix-Gyro-Filter ist die neue Generation dynamischer Gyro-Notches in INAV. Es wird empfohlen, ihn bei allen Multirotor-Builds auf F4- und F7-Flight-Controllern zu aktivieren."
+    },
+    "globalFunctions": {
+        "message": "Globale Funktionen"
+    },
+    "functionId": {
+        "message": "#"
+    },
+    "functionEnabled": {
+        "message": "Aktiviert"
+    },
+    "functionLogicId": {
+        "message": "Aktivierungs-Logic-Condition"
+    },
+    "functionAction": {
+        "message": "Aktion"
+    },
+    "functionOperand": {
+        "message": "Operand"
+    },
+    "functionFlags": {
+        "message": "Flags"
+    },
+    "configurationI2cSpeed": {
+        "message": "I2C-Geschwindigkeit"
+    },
+    "configurationI2cSpeedHelp": {
+        "message": "Die I2C-Geschwindigkeit sollte auf dem höchsten Wert gehalten werden, bei dem alle angeschlossenen Geräte funktionieren. Der Standard von 400 kHz ist ein sicherer Wert; bei Multirotoren wird empfohlen, auf 800 kHz zu wechseln."
+    },
+    "i2cSpeedSuggested800khz": {
+        "message": "Bitte auf 800 kHz umstellen, falls die angeschlossene Hardware dies erlaubt"
+    },
+    "i2cSpeedTooLow": {
+        "message": "Diese I2C-Geschwindigkeit ist zu niedrig!"
+    },
+    "configurationVoltageMeterType": {
+        "message": "Spannungsmesser-Typ"
+    },
+    "configurationCurrentMeterType": {
+        "message": "Strommesser-Typ"
+    },
+    "MissionPlannerJumpSettingsCheck": {
+        "message": "JUMP-Einstellungen fehlerhaft: Prüfe sie erneut! \nWird auf WP 1 gezwungen!"
+    },
+    "MissionPlannerJump2SettingsCheck": {
+        "message": "JUMP-Einstellungen fehlerhaft: Wiederholungen dürfen 10 nicht überschreiten! \nPrüfe sie erneut! Wird auf 0 Wiederholungen gezwungen!"
+    },
+    "MissionPlannerJump3SettingsCheck": {
+        "message": "JUMP-Einstellungen fehlerhaft: Sprung zu einem POI nicht möglich! \nWird auf WP 1 gezwungen!"
+    },
+    "MissionPlannerHeadSettingsCheck": {
+        "message": "Heading-Wert ist fehlerhaft: Prüfe ihn erneut! Wird daher standardmäßig auf -1 gezwungen!"
+    },
+    "MissionPlannerRTHSettingsCheck": {
+        "message": "RTH-Option ist fehlerhaft: Sollte 0 oder 1 sein. Prüfe sie erneut! \nWird standardmäßig auf 0 gezwungen, d. h. kein LAND nach RTH!"
+    },
+    "MissionPlannerJumpTargetRemoval": {
+        "message": "Du kannst keinen Waypoint entfernen, der als JUMP-Ziel definiert ist! \nDu musst zuerst das Ziel an dem Waypoint entfernen, der den JUMP auslöst."
+    },
+    "MissionPlannerAltitudeChangeReset": {
+        "message": "Höhe unter Bodenniveau. Änderung ignoriert"
+    },
+    "SafehomeSelected": {
+        "message": ""
+    },
+    "SafehomeId": {
+        "message": "#"
+    },
+    "SafehomeEnabled": {
+        "message": "Aktiviert"
+    },
+    "SafehomeLon": {
+        "message": "Lon"
+    },
+    "SafehomeLat": {
+        "message": "Lat"
+    },
+    "SafehomeAlt": {
+        "message": "Höhe"
+    },
+    "WaypointOptionSelected": {
+        "message": "+"
+    },
+    "WaypointOptionId": {
+        "message": "#"
+    },
+    "WaypointOptionAction": {
+        "message": "Typ"
+    },
+    "WaypointOptionP1": {
+        "message": "P1"
+    },
+    "WaypointOptionP2": {
+        "message": "P2"
+    },
+    "pidId": {
+        "message": "#"
+    },
+    "pidEnabled": {
+        "message": "Aktiviert"
+    },
+    "pidSetpoint": {
+        "message": "Sollwert"
+    },
+    "pidMeasurement": {
+        "message": "Messwert"
+    },
+    "pidP": {
+        "message": "P-Gain"
+    },
+    "pidI": {
+        "message": "I-Gain"
+    },
+    "pidD": {
+        "message": "D-Gain"
+    },
+    "pidFF": {
+        "message": "FF-Gain"
+    },
+    "pidOutput": {
+        "message": "Ausgang"
+    },
+    "reset": {
+        "message": "Reset"
+    },
+    "illegalStateRestartRequired": {
+        "message": "Ungültiger Zustand. Neustart erforderlich."
+    },
+    "motor_direction_inverted": {
+        "message": "Normale Motorrichtung / Props-in-Konfiguration"
+    },
+    "motor_direction_isInverted": {
+        "message": "Umgekehrte Motorrichtung / Props-out-Konfiguration"
+    },
+    "motor_direction_inverted_hint": {
+        "message": "Aktivieren, wenn die Motorrichtung umgekehrt ist und die Propeller in entgegengesetzter Richtung montiert sind."
+    },
+    "mixer_control_profile_linking": {
+        "message": "Control Profile verwendet denselben Index wie das Mixer-Profil"
+    },
+    "mixer_control_profile_linking_hint": {
+        "message": "mixer_control_profile_linking: Auf beiden Mixer-Profilen aktivieren, wenn das Umschalten des Control Profiles durch das Umschalten des Mixer-Profiles erfolgen soll (empfohlen bei VTOL-/gemischten Plattform-Setups)"
+    },
+    "blackboxFields": {
+        "message": "Blackbox-Felder"
+    },
+    "BLACKBOX_FEATURE_NAV_ACC": {
+        "message": "Navigations-Accelerometer"
+    },
+    "BLACKBOX_FEATURE_NAV_POS": {
+        "message": "Navigations-Positionsschätzung"
+    },
+    "BLACKBOX_FEATURE_NAV_PID": {
+        "message": "Navigations-PID"
+    },
+    "BLACKBOX_FEATURE_MAG": {
+        "message": "Magnetometer"
+    },
+    "BLACKBOX_FEATURE_ACC": {
+        "message": "Accelerometer"
+    },
+    "BLACKBOX_FEATURE_ATTITUDE": {
+        "message": "Lage"
+    },
+    "BLACKBOX_FEATURE_RC_DATA": {
+        "message": "RC-Daten"
+    },
+    "BLACKBOX_FEATURE_RC_COMMAND": {
+        "message": "RC-Command"
+    },
+    "BLACKBOX_FEATURE_MOTORS": {
+        "message": "Motorausgang"
+    },
+    "BLACKBOX_FEATURE_GYRO_RAW": {
+        "message": "Gyro RAW (ohne Filterung)"
+    },
+    "BLACKBOX_FEATURE_GYRO_PEAKS_ROLL": {
+        "message": "Gyro Noise-Peak-Frequenz Roll"
+    },
+    "BLACKBOX_FEATURE_GYRO_PEAKS_PITCH": {
+        "message": "Gyro Noise-Peak-Frequenz Pitch"
+    },
+    "BLACKBOX_FEATURE_GYRO_PEAKS_YAW": {
+        "message": "Gyro Noise-Peak-Frequenz Yaw"
+    },
+    "BLACKBOX_FEATURE_SERVOS": {
+        "message": "Servoausgang"
+    },
+    "axisRoll": {
+        "message": "Roll"
+    },
+    "axisPitch": {
+        "message": "Pitch"
+    },
+    "axisYaw": {
+        "message": "Yaw"
+    },
+    "showAdvancedPIDs": {
+        "message": "Erweiterte PID-Controller anzeigen"
+    },
+    "rc_filter_lpf_hz": {
+        "message": "Manueller LPF Hz"
+    },
+    "rc_filter_smoothing_factor": {
+        "message": "Auto-Smoothing-Faktor"
+    },
+    "rc_filter_auto": {
+        "message": "Automatische RC-Glättung verwenden"
+    },
+    "rcSmoothing": {
+        "message": "RC-Glättung"
+    },
+    "throttle_scale": {
+        "message": "Throttle-Skalierung"
+    },
+    "throttle_scale_help": {
+        "message": "Erlaubt die Begrenzung der effektiv an die Motoren geführten Leistung. Throttle-Skalierung 1 bedeutet keine Leistungsbegrenzung. Throttle-Skalierung 0.5 bedeutet, die Throttle-Position wird halbiert, bevor sie an die Motoren weitergegeben wird."
+    },
+    "pidTuning_MatrixFilterType": {
+        "message": "Matrix-Filter-Typ"
+    },
+    "pidTuning_MatrixFilterTypeHelp": {
+        "message": "Legt den Typ des Matrix-Filters fest. Der Standard-2D-Filter wird für die meisten Nutzer empfohlen. 7-Zoll- und größere Quads können vom 3D-Filter profitieren."
+    },
+    "softSerialWarning": {
+        "message": "Es ist nicht ratsam, Softserial für flugkritische Geräte wie GPS oder Receiver oder für Geräte mit hohem Datenaufkommen wie MSP DisplayPort zu verwenden."
+    },
+    "ledStripColorSetupTitle": {
+        "message": "Farbeinrichtung"
+    },
+    "ledStripH": {
+        "message": "H"
+    },
+    "ledStripS": {
+        "message": "S"
+    },
+    "ledStripV": {
+        "message": "V"
+    },
+    "ledStripRemainingText": {
+        "message": "Verbleibend"
+    },
+    "ledStripClearSelectedButton": {
+        "message": "Auswahl leeren"
+    },
+    "ledStripClearAllButton": {
+        "message": "ALLE leeren"
+    },
+    "ledStripFunctionSection": {
+        "message": "LED-Funktionen"
+    },
+    "ledStripFunctionTitle": {
+        "message": "Funktion"
+    },
+    "ledStripFunctionNoneOption": {
+        "message": "Keine"
+    },
+    "ledStripFunctionColorOption": {
+        "message": "Farbe"
+    },
+    "ledStripFunctionModesOption": {
+        "message": "Modi &amp; Orientierung"
+    },
+    "ledStripFunctionArmOption": {
+        "message": "Arm-Status"
+    },
+    "ledStripFunctionBatteryOption": {
+        "message": "Akku"
+    },
+    "ledStripFunctionRSSIOption": {
+        "message": "RSSI"
+    },
+    "ledStripFunctionGPSOption": {
+        "message": "GPS"
+    },
+    "ledStripFunctionRingOption": {
+        "message": "Ring"
+    },
+    "ledStripFunctionChannelOption": {
+        "message": "Kanal"
+    },
+    "ledStripColorModifierTitle": {
+        "message": "Farb-Modifikator"
+    },
+    "ledStripThrottleText": {
+        "message": "Throttle"
+    },
+    "ledStripLarsonscannerText": {
+        "message": "Larson Scanner"
+    },
+    "ledStripBlinkTitle": {
+        "message": "Blinken"
+    },
+    "ledStripBlinkAlwaysOverlay": {
+        "message": "Immer blinken"
+    },
+    "ledStripBlinkLandingOverlay": {
+        "message": "Bei Landung blinken"
+    },
+    "ledStripStrobeText": {
+        "message": "Strobe"
+    },
+    "ledStripEnableStrobeLightEffectText": {
+        "message": "Strobe-Light-Effekt aktivieren"
+    },
+    "ledStripOverlayTitle": {
+        "message": "Overlay"
+    },
+    "ledStripWarningsOverlay": {
+        "message": "Warnungen"
+    },
+    "ledStripIndecatorOverlay": {
+        "message": "Indikator"
+    },
+    "colorBlack": {
+        "message": "schwarz"
+    },
+    "colorWhite": {
+        "message": "weiß"
+    },
+    "colorRed": {
+        "message": "rot"
+    },
+    "colorOrange": {
+        "message": "orange"
+    },
+    "colorYellow": {
+        "message": "gelb"
+    },
+    "colorLimeGreen": {
+        "message": "limettengrün"
+    },
+    "colorGreen": {
+        "message": "grün"
+    },
+    "colorMintGreen": {
+        "message": "mintgrün"
+    },
+    "colorCyan": {
+        "message": "cyan"
+    },
+    "colorLightBlue": {
+        "message": "hellblau"
+    },
+    "colorBlue": {
+        "message": "blau"
+    },
+    "colorDarkViolet": {
+        "message": "dunkelviolett"
+    },
+    "colorMagenta": {
+        "message": "magenta"
+    },
+    "colorDeepPink": {
+        "message": "tiefrosa"
+    },
+    "ledStripSelectChannelFromColorList": {
+        "message": "Kanal aus Farbliste wählen"
+    },
+    "ledStripModeColorsTitle": {
+        "message": "Modus-Farben"
+    },
+    "ledStripModeColorsModeOrientation": {
+        "message": "Orientierung"
+    },
+    "ledStripModeColorsModeHeadfree": {
+        "message": "Headfree"
+    },
+    "ledStripModeColorsModeHorizon": {
+        "message": "Horizon"
+    },
+    "ledStripModeColorsModeAngle": {
+        "message": "Angle"
+    },
+    "ledStripModeColorsModeMag": {
+        "message": "Mag"
+    },
+    "ledStripModeColorsModeBaro": {
+        "message": "Baro"
+    },
+    "ledStripDirN": {
+        "message": "N"
+    },
+    "ledStripDirE": {
+        "message": "O"
+    },
+    "ledStripDirS": {
+        "message": "S"
+    },
+    "ledStripDirW": {
+        "message": "W"
+    },
+    "ledStripDirU": {
+        "message": "U"
+    },
+    "ledStripDirD": {
+        "message": "D"
+    },
+    "ledStripModesOrientationTitle": {
+        "message": "LED-Orientierung und -Farbe"
+    },
+    "ledStripModesSpecialColorsTitle": {
+        "message": "Spezialfarben"
+    },
+    "ledStripModeColorsModeDisarmed": {
+        "message": "Disarmed"
+    },
+    "ledStripModeColorsModeArmed": {
+        "message": "Armed"
+    },
+    "ledStripModeColorsModeAnimation": {
+        "message": "Animation"
+    },
+    "ledStripModeColorsModeBlinkBg": {
+        "message": "Blink-Hintergrund"
+    },
+    "ledStripModeColorsModeGPSNoSats": {
+        "message": "GPS: keine Sats"
+    },
+    "ledStripModeColorsModeGPSNoLock": {
+        "message": "GPS: kein Lock"
+    },
+    "ledStripModeColorsModeGPSLocked": {
+        "message": "GPS: Lock"
+    },
+    "ledStripWiring": {
+        "message": "LED-Strip-Verdrahtung"
+    },
+    "ledStripWiringMode": {
+        "message": "Verdrahtungsreihenfolge-Modus"
+    },
+    "ledStripWiringClearControl": {
+        "message": "Auswahl leeren"
+    },
+    "ledStripWiringClearAllControl": {
+        "message": "GESAMTE Verdrahtung leeren"
+    },
+    "ledStripWiringMessage": {
+        "message": "LEDs ohne Verdrahtungsnummer werden nicht gespeichert."
+    },
+    "mainLogoText": {
+        "message": "CONFIGURATOR"
+    },
+    "mainLogoTextFirmware": {
+        "message": "FC FIRMWARE"
+    },
+    "mainPortOverrideLabel": {
+        "message": "Port: "
+    },
+    "mainManual": {
+        "message": "Handbuch"
+    },
+    "sensorDataFlashNotFound": {
+        "message": "Kein Dataflash-<br>Chip gefunden"
+    },
+    "sensorDataFlashFreeSpace": {
+        "message": "Dataflash: <br />free "
+    },
+    "mixerProfile1": {
+        "message": "Mixer Profile 1"
+    },
+    "mixerProfile2": {
+        "message": "Mixer Profile 2"
+    },
+    "sensorProfile1": {
+        "message": "Control Profile 1"
+    },
+    "sensorProfile2": {
+        "message": "Control Profile 2"
+    },
+    "sensorProfile3": {
+        "message": "Control Profile 3"
+    },
+    "sensorBatteryProfile1": {
+        "message": "Battery Profile 1"
+    },
+    "sensorBatteryProfile2": {
+        "message": "Battery Profile 2"
+    },
+    "sensorBatteryProfile3": {
+        "message": "Battery Profile 3"
+    },
+    "sensorStatusGyro": {
+        "message": "Gyroscope"
+    },
+    "sensorStatusGyroShort": {
+        "message": "Gyro"
+    },
+    "sensorStatusAccel": {
+        "message": "Accelerometer"
+    },
+    "sensorStatusAccelShort": {
+        "message": "Accel"
+    },
+    "sensorStatusMag": {
+        "message": "Magnetometer"
+    },
+    "sensorStatusMagShort": {
+        "message": "Mag"
+    },
+    "sensorStatusBaro": {
+        "message": "Barometer"
+    },
+    "sensorStatusBaroShort": {
+        "message": "Baro"
+    },
+    "sensorStatusGPS": {
+        "message": "GPS"
+    },
+    "sensorStatusGPSShort": {
+        "message": "GPS"
+    },
+    "sensorOpticalFlow": {
+        "message": "Optical flow"
+    },
+    "sensorOpticalFlowShort": {
+        "message": "Flow"
+    },
+    "sensorStatusSonar": {
+        "message": "Sonar / Range finder"
+    },
+    "sensorStatusSonarShort": {
+        "message": "Sonar"
+    },
+    "sensorAirspeed": {
+        "message": "Airspeed"
+    },
+    "sensorAirspeedShort": {
+        "message": "Speed"
+    },
+    "sensorBatteryVoltage": {
+        "message": "Akku-Spannung"
+    },
+    "mainShowLog": {
+        "message": "Log anzeigen"
+    },
+    "mainHideLog": {
+        "message": "Log ausblenden"
+    },
+    "waitingForData": {
+        "message": "Warte auf Daten ..."
+    },
+    "outputStatsTableAcc": {
+        "message": "Acc. Noise RMS"
+    },
+    "outputStatsTableCurrent": {
+        "message": "Strom [A]"
+    },
+    "outputStatsTableVoltage": {
+        "message": "Spannung [V]"
+    },
+    "LogicConditions": {
+        "message": "Logic Conditions"
+    },
+    "PIDControllers": {
+        "message": "PID Controller"
+    },
+    "sensorsGyroSelect": {
+        "message": "Gyroskop"
+    },
+    "sensorsAccelSelect": {
+        "message": "Accelerometer"
+    },
+    "sensorsMagSelect": {
+        "message": "Magnetometer"
+    },
+    "sensorsAltitudeSelect": {
+        "message": "Barometer"
+    },
+    "sensorsSonarSelect": {
+        "message": "Sonar"
+    },
+    "sensorsAirSpeedSelect": {
+        "message": "Air Speed"
+    },
+    "sensorsTemperaturesSelect": {
+        "message": "Temperaturen"
+    },
+    "sensorsDebugSelect": {
+        "message": "Debug"
+    },
+    "sensorsDebugTrace": {
+        "message": "Debug Trace öffnen"
+    },
+    "sensorsGyroscope": {
+        "message": "Gyroskop - deg/s"
+    },
+    "sensorsAccelerometer": {
+        "message": "Accelerometer - g"
+    },
+    "sensorsMagnetometer": {
+        "message": "Magnetometer - Ga"
+    },
+    "sensorsBarometer": {
+        "message": "Barometer - Meter"
+    },
+    "sensorsSonar": {
+        "message": "Sonar - cm"
+    },
+    "sensorsAirspeed": {
+        "message": "Air Speed - cm/s"
+    },
+    "sensorsTemperature0": {
+        "message": "Temperatur 0 - °C"
+    },
+    "sensorsTemperature1": {
+        "message": "Temperatur 1 - °C"
+    },
+    "sensorsTemperature2": {
+        "message": "Temperatur 2 - °C"
+    },
+    "sensorsTemperature3": {
+        "message": "Temperatur 3 - °C"
+    },
+    "sensorsTemperature4": {
+        "message": "Temperatur 4 - °C"
+    },
+    "sensorsTemperature5": {
+        "message": "Temperatur 5 - °C"
+    },
+    "sensorsTemperature6": {
+        "message": "Temperatur 6 - °C"
+    },
+    "sensorsTemperature7": {
+        "message": "Temperatur 7 - °C"
+    },
+    "sensorsTemperatureValue": {
+        "message": "Wert:"
+    },
+    "getRunningOS": {
+        "message": "Läuft - OS: <strong>"
+    },
+    "getConfiguratorVersion": {
+        "message": "Configurator: <strong>"
+    },
+    "loadedReleaseInfo": {
+        "message": "Release-Informationen von GitHub geladen."
+    },
+    "newVersionAvailable": {
+        "message": "Neue Version verfügbar!"
+    },
+    "ReceiveTime": {
+        "message": "Empfangszeit: "
+    },
+    "SendTime": {
+        "message": "Sendezeit: "
+    },
+    "ErrorWritingFile": {
+        "message": "<span style=\"color: red\">Fehler beim Schreiben der Datei</span>"
+    },
+    "FileSaved": {
+        "message": "Datei gespeichert"
+    },
+    "selectedTarget": {
+        "message": "ausgewähltes Target = "
+    },
+    "toggledRCs": {
+        "message": "umgeschaltete RCs"
+    },
+    "noFirmwareSelectedToLoad": {
+        "message": "<b>Keine Firmware zum Laden ausgewählt</b>"
+    },
+    "selectValidSerialPort": {
+        "message": "<span style=\"color: red\">Bitte einen gültigen seriellen Port wählen</span>'"
+    },
+    "writePermissionsForFile": {
+        "message": "Du hast keine <span style=\"color: red\">Schreibrechte</span> für diese Datei"
+    },
+    "automaticTargetSelect": {
+        "message": "Versuche automatische Target-Auswahl"
+    },
+    "notAWAYPOINT": {
+        "message": "Vorherige Auswahl war kein WAYPOINT!"
+    },
+    "startGettingSafehomePoints": {
+        "message": "Beginn des Abrufens der Safehome-Punkte"
+    },
+    "endGettingSafehomePoints": {
+        "message": "Ende des Abrufens der Safehome-Punkte"
+    },
+    "startSendingSafehomePoints": {
+        "message": "Beginn des Sendens der Safehome-Punkte"
+    },
+    "endSendingSafehomePoints": {
+        "message": "Ende des Sendens der Safehome-Punkte"
+    },
+    "startGetPoint": {
+        "message": "Beginn Punkt abrufen"
+    },
+    "startSendPoint": {
+        "message": "Beginn Punkt senden"
+    },
+    "errorReadingFileXml2jsNotFound": {
+        "message": "<span style=\"color: red\">Fehler beim Lesen der Datei (xml2js nicht gefunden)</span>'"
+    },
+    "errorReadingFile": {
+        "message": "<span style=\"color: red\">Fehler beim Lesen der Datei</span>"
+    },
+    "errorParsingFile": {
+        "message": "<span style=\"color: red\">Fehler beim Parsen der Datei</span>"
+    },
+    "loadedSuccessfully": {
+        "message": " wurde erfolgreich geladen!"
+    },
+    "errorWritingFileXml2jsNotFound": {
+        "message": "<span style=\"color: red\">Fehler beim Schreiben der Datei (xml2js nicht gefunden)</span>"
+    },
+    "savedSuccessfully": {
+        "message": " wurde erfolgreich gespeichert!"
+    },
+    "endGetPoint": {
+        "message": "Ende Punkt abrufen"
+    },
+    "endSendPoint": {
+        "message": "Ende Punkt senden"
+    },
+    "osdSettingsSaved": {
+        "message": "OSD-Einstellungen gespeichert"
+    },
+    "osdLayoutInsertedIntoClipboard": {
+        "message": "Layout wurde in die Zwischenablage gespeichert"
+    },
+    "osdLayoutPasteFromClipboard": {
+        "message": "Layout wurde aus der Zwischenablage wiederhergestellt"
+    },
+    "osdClearLayout": {
+        "message": "Layout wurde geleert"
+    },
+    "failedToOpenSerialPort": {
+        "message": "Öffnen des seriellen Ports <span style=\"color: red\">fehlgeschlagen</span>"
+    },
+    "failedToFlash": {
+        "message": "Flashen <span style=\"color: red\">fehlgeschlagen</span>"
+    },
+    "targetPrefetchsuccessful": {
+        "message": "Target-Prefetch erfolgreich: "
+    },
+    "targetPrefetchFail": {
+        "message": "Target-Prefetch nicht möglich: "
+    },
+    "targetPrefetchFailDFU": {
+        "message": "Target-Prefetch nicht möglich: Flight Controller im DFU"
+    },
+    "targetPrefetchFailOld": {
+        "message": "Target-Prefetch nicht möglich: INAV-Firmware zu alt"
+    },
+    "targetPrefetchFailNonINAV": {
+        "message": "Target-Prefetch nicht möglich: Nicht-INAV-Firmware"
+    },
+    "targetPrefetchFailNoPort": {
+        "message": "Target-Prefetch nicht möglich: Kein Port"
+    },
+    "timerOutputs": {
+        "message": "Timer Outputs"
+    },
+    "ezTuneFilterHz": {
+        "message": "Filter Hz"
+    },
+    "ezTuneAxisRatio": {
+        "message": "Achsenverhältnis"
+    },
+    "ezTuneResponse": {
+        "message": "Response"
+    },
+    "ezTuneDamping": {
+        "message": "Damping"
+    },
+    "ezTuneStability": {
+        "message": "Stability"
+    },
+    "ezTuneAggressiveness": {
+        "message": "Aggressiveness"
+    },
+    "ezTuneRate": {
+        "message": "Rate"
+    },
+    "ezTuneExpo": {
+        "message": "Expo"
+    },
+    "ezTuneSnappiness": {
+        "message": "Snappiness"
+    },
+    "ezTuneSnappinessTips": {
+        "message": "Hilft, ein knackiges Knüppelgefühl zu erreichen. Bei jeder schnellen Knüppelbewegung beschleunigt eine hohe Snappiness die Reaktion der Drohne, sowohl beim Beginnen als auch beim Beenden des Manövers. Probiere verschiedene Werte aus, um den passendsten zu finden."
+    },
+    "ezTuneFilterHzTips": {
+        "message": "Legt die Basis-Grenzfrequenz für alle INAV-Gyro- und D-Term-Filter fest. Höhere Werte führen zu geringerer Filterverzögerung und besserer Stabilisierung, lassen aber mehr Rauschen durch die Filter, die Motoren werden heiß und das UAV kann oszillieren und unfliegbar werden. Dein Ziel ist es, diesen Wert so hoch wie möglich zu erhöhen, bevor negative Effekte auftreten. Negative Effekte sind: heiße Motoren, hörbare Oszillationen, schnelles Zittern des UAV, selbstständiges Höhegewinnen. Übliche Startwerte für 'Filter Hz' sind: <strong>3-Zoll-Props</strong>: 90, <strong>5-Zoll-Props</strong>: 110, <strong>7-Zoll-Props</strong>: 90, <strong>10-Zoll-Props</strong>: 75, <strong>12-Zoll-Props</strong>: 60. Nutze Blackbox und Hausverstand, um einen für dein UAV passenden Wert zu finden."
+    },
+    "ezTuneAxisRatioTips": {
+        "message": "Beschreibt die Verteilung von Gewicht/Trägheitsmoment deines UAV. Je länger der Frame (mehr Masse auf der Vorne-Hinten-Achse), desto höher muss das Achsenverhältnis sein. Ein perfekter X-Frame hat Verhältnis 100. Die meisten modernen Frames liegen zwischen 110 und 130. Der Standardwert 110 ist ein guter Startpunkt."
+    },
+    "ezTuneResponseTips": {
+        "message": "Diese Einstellung legt fest, wie schnell das UAV auf Knüppelbewegungen und das Gyro-Signal reagiert. Höhere Werte führen zu schnellerer Reaktion, aber auch zu mehr Überschwingen und Oszillationen. Fühlt sich das UAV träge an oder hat ein langsames Wackeln, erhöhe die Response. Hat es heiße Motoren, oszilliert hörbar, überschwingt oder fühlt sich zu nervös an, verringere die Response. Die meisten modernen Quads mit kräftigen Motoren fliegen am besten mit Response unter 80. Sollte zusammen mit Damping getunt werden. Es ist ein P-Term-Äquivalent."
+    },
+    "ezTuneDampingTips": {
+        "message": "Beschreibt die Stärke einer Kraft, die jeder Änderung der Drehgeschwindigkeit entgegenwirkt. Sie dämpft Roll- und Pitch-Beschleunigung und sorgt für ruhigeren und stabileren Flug. Deine Aufgabe beim Tunen ist herauszufinden, wie weit du sie erhöhen kannst, bevor negative Symptome auftreten: heiße Motoren, hörbare Oszillationen, Überschwingen. Die meisten modernen Quads vertragen 'Damping' bis 150-180. Es ist ein D-Term-Äquivalent."
+    },
+    "ezTuneStabilityTips": {
+        "message": "Legt die Stärke der Langzeit-Stabilisierung fest. Die meisten modernen Quads vertragen 'Stability' sogar bis 120-130. Muss in der Regel gar nicht getunt werden. Leidet das UAV unter starkem Propwash beim vertikalen Sinkflug, kann ein Senken von 'Stability' helfen. Es ist ein I-Term-Äquivalent"
+    },
+    "ezTuneAggressivenessTips": {
+        "message": "Legt fest, wie schnell dein UAV auf schnelle Knüppelbewegungen reagiert. Höhere 'Aggressiveness' sorgt für knackigere schnelle Manöver. Sie beeinflusst nicht die Stabilisierung, nur das Knüppelgefühl. Es ist ein FF-Term-Äquivalent."
+    },
+    "ezTuneRateTips": {
+        "message": "Legt fest, wie schnell dein UAV um die Roll-, Pitch- und Yaw-Achse rotiert. Höhere 'Rate' sorgt für schnellere Rotation. Der Wert 0 entspricht 300 dps, 100 entspricht 600 dps, 200 entspricht 900 dps."
+    },
+    "ezTuneExpoTips": {
+        "message": "Legt das Expo der RC-Eingabe fest. Niedrigere Werte sorgen für einen empfindlicheren Knüppel in der Mitte. Höhere Werte sorgen für eine weniger empfindliche Mitte und eine schnellere Reaktion am Knüppelende. Der Wert 0 entspricht 0 Expo, 100 entspricht 0.7 Expo, 200 entspricht 1.0 Expo."
+    },
+    "ezTunePidPreview": {
+        "message": "PID-Vorschau"
+    },
+    "ezTuneRatePreview": {
+        "message": "Rate-Vorschau"
+    },
+    "ezTuneRatePreviewAxis": {
+        "message": "Achse"
+    },
+    "ezTuneRatePreviewRate": {
+        "message": "Rate"
+    },
+    "ezTuneRatePreviewExpo": {
+        "message": "Expo"
+    },
+    "ezTuneEnabledTips": {
+        "message": "Wenn aktiviert, überschreibt <strong>Ez Tune</strong> mehrere INAV-Einstellungen, um den Tuning-Prozess zu vereinfachen. Statt jede PID- und Filtereinstellung einzeln zu setzen, arbeitest du nur mit 7 Schiebereglern. Ez Tune passt automatisch alle anderen Einstellungen an deine Bedürfnisse an. Ez Tune ist ein großartiger Startpunkt für neue Nutzer und ein guter Weg, ein neues UAV schnell zu tunen. Bei fortgeschrittenen Builds wird Ez Tune nicht empfohlen, da es alle deine Einstellungen überschreibt und du dein UAV nicht feintunen kannst. Wenn Ez Tune aktiviert ist, werden die Einstellungen im <strong>PID-Tuning</strong>-Tab von EzTune überschrieben."
+    },
+    "ezTuneDisclaimer": {
+        "message": "<strong>Disclaimer:</strong> Ez Tune ist eine experimentelle Funktion. Es ist nicht garantiert, dass sie auf allen UAVs funktioniert. Es ist nicht garantiert, dass sie mit allen Frame-Typen funktioniert. Es ist nicht garantiert, dass sie mit allen Propellern funktioniert. Alle Berechnungen und Tuning-Ergebnisse können sich in zukünftigen INAV-Versionen ändern. Wir ermutigen dich dennoch, es auszuprobieren und deine Erfahrungen im INAV Discord im Kanal <strong>#ez-tune</strong> zu teilen"
+    },
+    "ezTuneNote": {
+        "message": "<strong>Wichtig</strong> Ez Tune ist aktiviert. Alle Einstellungen in diesem Tab werden von Ez Tune gesetzt und gesteuert. Um den PID-Tuning-Tab zu nutzen, musst du Ez Tune deaktivieren. Entferne dazu den Haken bei der <strong>Aktiviert</strong>-Checkbox im Ez-Tune-Tab."
+    },
+    "gsActivated": {
+        "message": "Ground-Station-Modus aktiviert"
+    },
+    "gsDeactivated": {
+        "message": "Ground-Station-Modus deaktiviert"
+    },
+    "gsTelemetry": {
+        "message": "Telemetrie"
+    },
+    "gsTelemetryLatitude": {
+        "message": "Breitengrad"
+    },
+    "gsTelemetryLongitude": {
+        "message": "Längengrad"
+    },
+    "gsTelemetryAltitude": {
+        "message": "Höhe"
+    },
+    "gsTelemetryAltitudeShort": {
+        "message": "Höhe"
+    },
+    "gsTelemetryVoltageShort": {
+        "message": "Vbat"
+    },
+    "gsTelemetrySats": {
+        "message": "Sats"
+    },
+    "gsTelemetryFix": {
+        "message": "Fix"
+    },
+    "gsTelemetrySpeed": {
+        "message": "Geschwindigkeit"
+    },
+    "maintenance": {
+        "message": "Wartung"
+    },
+    "maintenanceFlushSettingsCache": {
+        "message": "Settings-Cache leeren"
+    },
+    "gpsOptions": {
+        "message": "GPS-Optionen"
+    },
+    "gpsOptionsAssistnowToken": {
+        "message": "AssistNow Token"
+    },
+    "gpsLoadAssistnowOfflineButton": {
+        "message": "AssistNow Offline laden"
+    },
+    "gpsLoadAssistnowOnlineButton": {
+        "message": "AssistNow Online laden"
+    },
+    "gpsAssistnowStart": {
+        "message": "AssistNow-Datenübertragung startet..."
+    },
+    "gpsAssistnowDone": {
+        "message": "AssistNow-Datenübertragung abgeschlossen."
+    },
+    "gpsAssistnowUpdate": {
+        "message": "AssistNow-Nachrichten gesendet."
+    },
+    "gpsAssistnowLoadDataError": {
+        "message": "Fehler beim Laden der AssistNow-Daten."
+    },
+    "layerManagementTitle": {
+        "message": "Kartenebenen"
+    },
+    "layerLoadGeoFile": {
+        "message": "GEO-Datei laden"
+    },
+    "layerDragDropHint": {
+        "message": "oder GEO-Dateien per Drag & Drop auf die Karte ziehen"
+    },
+    "layerConfirmDelete": {
+        "message": "Möchtest du diese Ebene wirklich löschen?"
+    },
+    "layerLoadError": {
+        "message": "Fehler beim Laden der GEO-Datei. Bitte überprüfe das Dateiformat."
+    },
+    "layerParseError": {
+        "message": "Fehler beim Parsen der GEO-Datei. Nicht unterstütztes Format oder beschädigte Daten."
+    },
+    "adsbVehicleTotalMessages": {
+        "message": "Vehicle-Msgs"
+    },
+    "adsbHeartbeatTotalMessages": {
+        "message": "Heartbeat-Msgs"
+    },
+    "currentLanguage": {
+        "message": "de"
+    },
+    "search": {
+        "message": "Suche"
+    },
+    "tabJavaScriptProgramming": {
+        "message": "JavaScript-Programmierung"
+    },
+    "javascriptProgrammingDescription": {
+        "message": "Schreibe JavaScript-Code, um dein Modell zu steuern. Der Transpiler wandelt deinen Code in INAV Logic Conditions um."
+    },
+    "javascriptBetaWarning": {
+        "message": "<strong>Derzeit Beta, zum Testen. Nicht für sicherheitskritische Anwendungen verwenden!</strong>"
+    },
+    "javascriptEditorTitle": {
+        "message": "JavaScript-Editor (Shift+Strg+V zum Einfügen, Rechtsklick auf eine Variable zum Umbenennen)"
+    },
+    "javascriptLoadExample": {
+        "message": "Beispiel laden:"
+    },
+    "javascriptSelectExample": {
+        "message": "-- Beispiel wählen --"
+    },
+    "javascriptTranspile": {
+        "message": "Nach INAV transpilieren"
+    },
+    "javascriptLoad": {
+        "message": "Vom FC laden"
+    },
+    "javascriptSave": {
+        "message": "Auf FC speichern"
+    },
+    "javascriptClear": {
+        "message": "Editor leeren"
+    },
+    "javascriptOutputTitle": {
+        "message": "INAV Logic Conditions Ausgabe"
+    },
+    "javascriptLcCount": {
+        "message": "$1 / $2 LCs"
+    },
+    "javascriptOptimizationsApplied": {
+        "message": "Angewandte Optimierungen:"
+    },
+    "javascriptApiReference": {
+        "message": "API-Referenz & Beispiele"
+    },
+    "javascriptQuickReference": {
+        "message": "Kurzreferenz"
+    },
+    "javascriptFlightParameters": {
+        "message": "Flugparameter (schreibgeschützt)"
+    },
+    "javascriptRcChannels": {
+        "message": "RC-Kanäle"
+    },
+    "javascriptOverrides": {
+        "message": "Overrides (Schreiben)"
+    },
+    "javascriptGlobalVariables": {
+        "message": "Globale Variablen"
+    },
+    "javascriptCompleteExample": {
+        "message": "Vollständiges Beispiel"
+    },
+    "sensorProfileTitle": {
+        "message": "Control-Profil — speichert PID-Tuning, Rates und Filtereinstellungen"
+    },
+    "mixerProfileTitle": {
+        "message": "Mixer-Profil — speichert Motor-/Servo-Mixing und Ausgangskonfiguration"
+    },
+    "sensorBatteryProfileTitle": {
+        "message": "Akku-Profil — speichert Spannungs-, Kapazitäts- und Stromsensor-Einstellungen"
+    },
+    "gpsFixNotConnected": {
+        "message": "<span class=\"fixnone\">Nicht verbunden</span>"
+    },
+    "receiverButtonSticksTitle": {
+        "message": "Zeigt ein Live-Overlay der Stick-Eingaben zur Überprüfung der Empfängerkanäle"
+    },
+    "searchPlaceholder": {
+        "message": "Einstellungen suchen..."
+    },
+    "backupRestoreButtonBackup": {
+        "message": "Konfiguration sichern"
+    },
+    "backupRestoreButtonRestore": {
+        "message": "Konfiguration wiederherstellen"
+    },
+    "backupRestoreOpenBackupsFolder": {
+        "message": "Backups öffnen"
+    },
+    "backupRestoreStatusConnecting": {
+        "message": "Verbinde mit Flight Controller..."
+    },
+    "backupRestoreStatusEnteringCli": {
+        "message": "Wechsle in den CLI-Modus..."
+    },
+    "backupRestoreStatusReadingConfig": {
+        "message": "Lese Konfiguration (diff all)..."
+    },
+    "backupRestoreStatusSavingFile": {
+        "message": "Speichere Backup-Datei..."
+    },
+    "backupRestoreStatusExitingCli": {
+        "message": "Verlasse CLI (Neustart)..."
+    },
+    "backupRestoreStatusRestoringConfig": {
+        "message": "Stelle Konfiguration wieder her..."
+    },
+    "backupRestoreStatusSaving": {
+        "message": "Speichere und starte neu..."
+    },
+    "backupRestoreStatusBackupComplete": {
+        "message": "Backup abgeschlossen. Fahre mit dem Flashen fort..."
+    },
+    "backupRestoreBackupSaved": {
+        "message": "Konfigurations-Backup gespeichert unter: $1"
+    },
+    "backupRestoreAutoBackupSaved": {
+        "message": "Auto-Backup gespeichert unter: $1"
+    },
+    "backupRestoreBackupComplete": {
+        "message": "Backup abgeschlossen."
+    },
+    "backupRestoreBackupCancelled": {
+        "message": "Backup abgebrochen."
+    },
+    "backupRestoreBackupFailed": {
+        "message": "Backup fehlgeschlagen."
+    },
+    "backupRestoreRestoreComplete": {
+        "message": "Konfiguration wiederhergestellt. Flight Controller startet neu."
+    },
+    "backupRestoreRestoreCancelled": {
+        "message": "Wiederherstellung abgebrochen."
+    },
+    "backupRestoreRestoreFailed": {
+        "message": "Wiederherstellung fehlgeschlagen."
+    },
+    "backupRestoreFlashCompleteBackupSaved": {
+        "message": "Flashen abgeschlossen. Konfigurations-Backup wurde gespeichert."
+    },
+    "backupRestoreOverlayTitle": {
+        "message": "Stelle Konfiguration wieder her"
+    },
+    "backupRestoreStatusRestoringProgress": {
+        "message": "Stelle Konfiguration wieder her... ($1 / $2)"
+    },
+    "backupRestoreRestoreAborted": {
+        "message": "Wiederherstellung abgebrochen — Einstellungen wurden NICHT gespeichert."
+    },
+    "backupRestoreErrorTitle": {
+        "message": "Fehler bei der Wiederherstellung"
+    },
+    "backupRestoreErrorText": {
+        "message": "Die folgenden Fehler wurden vom Flight Controller gemeldet. Du kannst die Einstellungen trotzdem speichern oder ohne Speichern abbrechen."
+    },
+    "backupRestoreErrorAbort": {
+        "message": "Abbrechen (nicht speichern)"
+    },
+    "backupRestoreErrorSave": {
+        "message": "Trotzdem speichern"
+    },
+    "backupRestoreFlashCompleteOfferRestore": {
+        "message": "Flashen abgeschlossen. Vor dem Flashen wurde ein Backup gespeichert."
+    },
+    "backupRestoreAutoRestoreConfirm": {
+        "message": "Es wurde ein vollständiges Löschen des Chips durchgeführt. Möchtest du das vor dem Flashen gespeicherte Konfigurations-Backup wiederherstellen?"
+    },
+    "backupRestoreAutoRestoreWaiting": {
+        "message": "Warte auf den Start des Flight Controllers..."
+    },
+    "backupRestoreAutoRestoreYes": {
+        "message": "Ja, wiederherstellen"
+    },
+    "backupRestoreAutoRestoreNo": {
+        "message": "Nein, überspringen"
+    },
+    "backupRestoreAutoRestoreWaitingPort": {
+        "message": "Warte, bis $1 verfügbar wird..."
+    },
+    "firmwareFlasherVersionWarningTitle": {
+        "message": "⚠ Versions-Update-Warnung"
+    },
+    "firmwareFlasherVersionWarningText": {
+        "message": "Ein Update von $1 auf $2 ohne vollständiges Löschen des Chips kann zu unvorhersehbaren Problemen oder einer beschädigten Konfiguration führen. Der Configurator stellt deine FC-Konfiguration nicht automatisch wieder her."
+    },
+    "firmwareFlasherVersionWarningContinue": {
+        "message": "Ohne Löschen fortfahren"
+    },
+    "firmwareFlasherVersionWarningCancel": {
+        "message": "Abbrechen"
+    },
+    "backupRestoreMigrationApplied": {
+        "message": "Migration angewendet: $1 → $2 ($3 Änderungen)"
+    },
+    "backupRestoreMigrationWarningsHeader": {
+        "message": "Migrations-Warnungen:"
+    },
+    "backupRestoreDowngradeNoAutoRestore": {
+        "message": "Downgrade einer Hauptversion erkannt. Auto-Wiederherstellung ist nicht verfügbar — bitte stelle dein Backup nach Prüfung der Einstellungen manuell wieder her."
+    },
+    "migrationPreviewTitle": {
+        "message": "Einstellungs-Migration erforderlich"
+    },
+    "migrationPreviewSubtitle": {
+        "message": "Dein Backup ($1) wird migriert, um zur neuen Firmware ($2) zu passen. Die folgenden Änderungen werden angewendet:"
+    },
+    "migrationPreviewRemovedHeader": {
+        "message": "Entfernte Einstellungen ($1):"
+    },
+    "migrationPreviewRenamedSettingsHeader": {
+        "message": "Umbenannte Einstellungen ($1):"
+    },
+    "migrationPreviewRenamedCommandsHeader": {
+        "message": "Umbenannte Befehle ($1):"
+    },
+    "migrationPreviewValueReplacementsHeader": {
+        "message": "Wert-Ersetzungen ($1):"
+    },
+    "migrationPreviewSettingRemappingsHeader": {
+        "message": "Einstellungs-Neuzuordnungen ($1):"
+    },
+    "migrationPreviewContinue": {
+        "message": "Mit Wiederherstellung fortfahren"
+    },
+    "migrationPreviewCancel": {
+        "message": "Abbrechen (manuelle Prüfung)"
+    },
+    "migrationMissingProfileWarning": {
+        "message": "Kein Migrationsprofil für Version $1 → $2 verfügbar. Die Einstellungen werden ohne Konvertierung wiederhergestellt — einige können fehlschlagen oder von der Firmware ignoriert werden."
+    }
+}


### PR DESCRIPTION
## German (de) translation

Adds full German localization and makes it selectable in the language dropdown.

### Changes
- **`locale/de/messages.json`** – complete German translation (2263 keys, structure identical to `en`).
  - 1912 keys translated; technical terms intentionally kept in English where the FPV/INAV community uses them (e.g. *Flight Controller, ESC, VTX, Gyro, Throttle, Failsafe, RTH, LOITER, MSP, CLI, UART, Blackbox, TPA, RSSI*, flight-mode and CLI variable names).
  - Replaces a stale partial translation that was ~94 % untranslated English placeholders (fell through to the `en` fallback in the app).
- **`js/localization.js`** – register `'de'` in `availableLanguages` so it appears in the language selector (`language_de` = "Deutsch" already existed).

### Known follow-up (out of scope, separate PR)
The redesigned **LED Strip** tab has hardcoded English UI text (`tabs/led_strip.html`) with no i18n keys: "Quick Presets", the ①–④ step headers and their instructions, the X-Frame/Cross-Frame/Wing preset buttons, "/ 128 placed", and "Edit palette colors". Localizing these requires adding new keys across **all** locales, so they are deliberately left for a follow-up.
