### PR TITLE
feat(mixer): warn when servo mixer target exceeds rule count

### DIFF
--- a/js/servoMixerTargetWarning.js
+++ b/js/servoMixerTargetWarning.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// A servo target can't be higher than the number of servo mixer rules that
+// exist (1-based: N rules means valid targets are #1..#N). Returns details
+// for the warning, or null if `enteredTarget` is valid.
+export function getServoTargetWarning(rules, enteredTarget) {
+    const ruleCount = rules.filter((rule) => rule.isUsed()).length;
+
+    if (enteredTarget <= ruleCount) {
+        return null;
+    }
+
+    return { ruleCount, enteredTarget };
+}

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5268,6 +5268,12 @@
     "servoMixerAdd": {
         "message": "Add new mixer rule"
     },
+    "servoMixRuleInvalidServoTargetTitle": {
+        "message": "Invalid servo target"
+    },
+    "servoMixRuleInvalidServoTarget": {
+        "message": "$1 servos are defined. Cannot output to servo #$2 because only $1 servos exist."
+    },
     "platformType": {
         "message": "Platform type"
     },

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -213,6 +213,11 @@
             <a id="execute-button" class="modal__button modal__button--main" data-i18n="mixerButtonSaveAndReboot"></a>
         </div>
     </div>
+    <div id="servoTargetWarningContent" class="is-hidden">
+        <div class="modal__content">
+            <div class="modal__text"><p class="servo-target-warning-text"></p></div>
+        </div>
+    </div>
     <div id="mixerWizardContent" class="is-hidden">
         <div class="modal__content">
             <h1 class="modal__title modal__title--warning" data-i18n="mixerWizardModalTitle"></h1>

--- a/tabs/mixer.js
+++ b/tabs/mixer.js
@@ -12,6 +12,7 @@ import Settings from './../js/settings';
 import jBox from 'jbox';
 import interval from './../js/intervals';
 import ServoMixRule from './../js/servoMixRule';
+import { getServoTargetWarning } from './../js/servoMixerTargetWarning';
 import MotorMixRule from './../js/motorMixRule';
 import BitHelper from './../js/bitHelper';
 
@@ -29,7 +30,8 @@ mixerTab.initialize = function (callback, scrollPosition) {
         $motorMixTable,
         $motorMixTableBody,
         modal,
-        motorWizardModal;
+        motorWizardModal,
+        servoTargetWarningModal;
 
     if (GUI.active_tab !== this) {
         GUI.active_tab = this;
@@ -380,7 +382,16 @@ mixerTab.initialize = function (callback, scrollPosition) {
                 });
 
                 $row.find(".mix-rule-servo").val(servoRule.getTarget()).on('change', function () {
-                    servoRule.setTarget(Number($(this).val()));
+                    const enteredTarget = Number($(this).val());
+
+                    servoRule.setTarget(enteredTarget);
+
+                    const warning = getServoTargetWarning(FC.SERVO_RULES.get(), enteredTarget);
+                    if (warning) {
+                        $('#servoTargetWarningContent .servo-target-warning-text')
+                            .html(i18n.getMessage('servoMixRuleInvalidServoTarget', [warning.ruleCount, warning.enteredTarget]));
+                        servoTargetWarningModal.open();
+                    }
                 });
 
                 $row.find(".mix-rule-rate").val(servoRule.getRate()).on('change', function () {
@@ -970,6 +981,15 @@ mixerTab.initialize = function (callback, scrollPosition) {
             attach: $('#load-and-apply-mixer-button'),
             title: i18n.getMessage("mixerApplyModalTitle"),
             content: $('#mixerApplyContent')
+        });
+
+        servoTargetWarningModal = new jBox('Modal', {
+            width: 480,
+            height: 200,
+            closeButton: 'title',
+            animation: false,
+            title: i18n.getMessage("servoMixRuleInvalidServoTargetTitle"),
+            content: $('#servoTargetWarningContent')
         });
 
         $('#execute-button').on('click', function () {

--- a/tests/servo-mixer-target-validation.test.mjs
+++ b/tests/servo-mixer-target-validation.test.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Tests for the servo-mixer target validation warning (Mixer tab).
+ *
+ * A servo mixer rule's "target" is the servo's 1-based index. A target can't
+ * be higher than the number of servo mixer rules that exist: with N rules
+ * (rate != 0, i.e. isUsed()), only servos #1..#N can be validly targeted.
+ * Entering anything higher means some servo number in 1..N would be skipped.
+ *
+ * getServoTargetWarning() is the exact function used by tabs/mixer.js's
+ * .mix-rule-servo change handler.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import ServoMixRule from '../js/servoMixRule.js';
+import { getServoTargetWarning } from '../js/servoMixerTargetWarning.js';
+
+describe('editing one of 2 existing rules (targets #1 and #2)', () => {
+    const makeRules = () => [ServoMixRule(1, 0, 100, 0), ServoMixRule(2, 0, 100, 0)];
+
+    test('entered 1 → no warning', () => {
+        assert.equal(getServoTargetWarning(makeRules(), 1), null);
+    });
+
+    test('entered 2 (no change) → no warning', () => {
+        assert.equal(getServoTargetWarning(makeRules(), 2), null);
+    });
+
+    test('entered 3 → warning with ruleCount=2 (only 2 rules exist, can\'t have a 3rd servo)', () => {
+        const warning = getServoTargetWarning(makeRules(), 3);
+        assert.deepEqual(warning, { ruleCount: 2, enteredTarget: 3 });
+    });
+
+    test('entered 4 → warning with ruleCount=2', () => {
+        const warning = getServoTargetWarning(makeRules(), 4);
+        assert.deepEqual(warning, { ruleCount: 2, enteredTarget: 4 });
+    });
+});
+
+describe('"Add new mixer rule" row (rate=100, auto-target via getNextUnusedIndex)', () => {
+    // 2 rules (#1, #2) already exist; "Add new mixer rule" adds a 3rd rule
+    // (target=3, rate=100, used). Now 3 rules exist, so servos #1..#3 are valid.
+    const makeRules = () => [
+        ServoMixRule(1, 0, 100, 0),
+        ServoMixRule(2, 0, 100, 0),
+        ServoMixRule(3, 0, 100, 0),
+    ];
+
+    test('entered 1..3 → no warning', () => {
+        for (const entered of [1, 2, 3]) {
+            assert.equal(getServoTargetWarning(makeRules(), entered), null, `entered=${entered}`);
+        }
+    });
+
+    test('entered 4 → warning with ruleCount=3', () => {
+        const warning = getServoTargetWarning(makeRules(), 4);
+        assert.deepEqual(warning, { ruleCount: 3, enteredTarget: 4 });
+    });
+});
+
+describe('a single rule', () => {
+    test('entered 1 → no warning', () => {
+        assert.equal(getServoTargetWarning([ServoMixRule(1, 0, 100, 0)], 1), null);
+    });
+
+    test('entered 2 → warning with ruleCount=1 (only 1 rule exists)', () => {
+        const warning = getServoTargetWarning([ServoMixRule(1, 0, 100, 0)], 2);
+        assert.deepEqual(warning, { ruleCount: 1, enteredTarget: 2 });
+    });
+});
+
+describe('unused (rate=0) rules do not count toward the rule count', () => {
+    test('1 used + 1 unused rule: ruleCount=1, entering 2 warns', () => {
+        const rules = [ServoMixRule(1, 0, 100, 0), ServoMixRule(2, 0, 0, 0)];
+        const warning = getServoTargetWarning(rules, 2);
+        assert.deepEqual(warning, { ruleCount: 1, enteredTarget: 2 });
+    });
+
+    test('counts duplicate-target rules separately (e.g. elevon roll+pitch both targeting servo #1)', () => {
+        const rules = [ServoMixRule(1, 0, 100, 0), ServoMixRule(1, 0, 100, 0)];
+        assert.equal(getServoTargetWarning(rules, 2), null);
+    });
+});
+
+describe('entered = 0', () => {
+    test('never warns, regardless of rule count (0 means "no output")', () => {
+        assert.equal(getServoTargetWarning([], 0), null);
+        assert.equal(getServoTargetWarning([ServoMixRule(1, 0, 100, 0)], 0), null);
+    });
+});


### PR DESCRIPTION
## Summary
Adds a warning dialog in the Mixer tab's Servo Mixer table when a rule's target servo number is invalid given the number of servo mixer rules currently defined.

## Changes
- New pure helper `getServoTargetWarning()` in `js/servoMixerTargetWarning.js`: with N servo mixer rules defined (rate != 0), only servo targets #1..#N are valid (1-based numbering). Entering a higher number would skip a servo.
- `.mix-rule-servo` change handler in `tabs/mixer.js` calls this helper and, if the entered target is invalid, shows a jBox modal warning (new `servoTargetWarningModal`, content in `tabs/mixer.html`).
- New i18n strings `servoMixRuleInvalidServoTargetTitle` / `servoMixRuleInvalidServoTarget` in `locale/en/messages.json`.
- The entered value is still applied (`setTarget()`) regardless of the warning - this is informational, not a hard block.

## Testing
- Added `tests/servo-mixer-target-validation.test.mjs` (Node's built-in test runner) - 12 tests covering: editing one of 2 existing rules, editing the first vs. second rule, the "Add new mixer rule" auto-targeted row, a single-rule mixer, unused (rate=0) rules not counting, duplicate-target rules, and `entered = 0` never warning. All pass (`node --test tests/*.test.mjs`, 24/24 across the full suite).
- Manually tested in the running configurator against a live mixer configuration: confirmed the warning appears/doesn't appear correctly when editing existing rows and newly-added rows, including the edge case of retargeting one of two existing rules to a value that would skip a servo.
- Verified `tabs/mixer.js` and `js/servoMixerTargetWarning.js` pass `node --input-type=module --check`.

## Code Review
Reviewed with the inav-code-review agent; addressed all IMPORTANT findings (verified the warning can't fire during programmatic preset-load/rebuild flows, and extracted the decision logic into a shared module so tests exercise the real code path instead of a mirror).