### PR TITLE
Fix servo numbering display in Outputs tab

### DIFF
--- a/tabs/outputs.html
+++ b/tabs/outputs.html
@@ -158,22 +158,22 @@
             <div class="spacer" style="padding-left: 0">
                 <div class="servos">
                     <ul class="titles">
-                        <li title="Servo - 8">15</li>
-                        <li title="Servo - 7">14</li>
-                        <li title="Servo - 6">13</li>
-                        <li title="Servo - 5">12</li>
-                        <li title="Servo - 4">11</li>
-                        <li title="Servo - 3">10</li>
-                        <li title="Servo - 2">9</li>
-                        <li title="Servo - 1">8</li>
-                        <li title="Servo - 8">7</li>
-                        <li title="Servo - 7">6</li>
-                        <li title="Servo - 6">5</li>
-                        <li title="Servo - 5">4</li>
-                        <li title="Servo - 4">3</li>
-                        <li title="Servo - 3">2</li>
-                        <li title="Servo - 2">1</li>
-                        <li title="Servo - 1">0</li>
+                        <li title="Servo - 16">16</li>
+                        <li title="Servo - 15">15</li>
+                        <li title="Servo - 14">14</li>
+                        <li title="Servo - 13">13</li>
+                        <li title="Servo - 12">12</li>
+                        <li title="Servo - 11">11</li>
+                        <li title="Servo - 10">10</li>
+                        <li title="Servo - 9">9</li>
+                        <li title="Servo - 8">8</li>
+                        <li title="Servo - 7">7</li>
+                        <li title="Servo - 6">6</li>
+                        <li title="Servo - 5">5</li>
+                        <li title="Servo - 4">4</li>
+                        <li title="Servo - 3">3</li>
+                        <li title="Servo - 2">2</li>
+                        <li title="Servo - 1">1</li>
                     </ul>
                     <div class="bar-wrapper"></div>
                 </div>

--- a/tabs/outputs.js
+++ b/tabs/outputs.js
@@ -356,7 +356,7 @@ outputsTab.initialize = function (callback) {
         let usedServoIndex = 0;
 
         for (let servoIndex = 0; servoIndex < FC.SERVO_RULES.getServoCount(); servoIndex++) {
-            renderServos('Servo ' + servoIndex, '', servoIndex);
+            renderServos('Servo ' + (servoIndex + 1), '', servoIndex);
         }
         if (usedServoIndex == 0) {
             // No servos configured


### PR DESCRIPTION
## Summary
Corrects the Outputs tab's Servo section so displayed servo numbers match INAV's 1-based servo convention (Servo 1 through Servo N — there is no Servo 0).

## Changes
- Servo configuration table: row labels now read "Servo 1".."Servo N" instead of "Servo 0".."Servo N-1"
- Servo bar chart title row above the table: renumbered from 0-based "15..0" (with tooltips capped/repeating "Servo - 8" through "Servo - 1") to 1-based "16..1" with matching "Servo - N" tooltips

## Testing
- Reproduced the original "Servo 0" label and the mismatched bar chart titles/tooltips in SITL via the live Configurator
- After the fix, verified in the live UI: the table shows "Servo 1" through "Servo 4" for the configured servos, and the bar chart title row reads 1-16 left to right with bar values and tooltips correctly aligned to the table rows below
- Confirmed servo min/mid/max/rate/reverse values still load, display, and save correctly — internal 0-based indexing (FC.SERVO_CONFIG, isServoConfigured, output mapping) is unchanged; only display labels were updated

## Related Issues
None