### PR TITLE
Fix BLE device chooser: keep the discovered device list stable

### DIFF
--- a/js/libraries/bluetooth-device-chooser/bt-device-chooser-renderer.js
+++ b/js/libraries/bluetooth-device-chooser/bt-device-chooser-renderer.js
@@ -1,56 +1,64 @@
 import './bt-device-chooser-style.css'
 
 document.addEventListener("DOMContentLoaded", () => {
-    // Store all discovered devices
+    const MAX_DEVICE_NAME_LENGTH = 45;
+
+    // Store all discovered devices (Map preserves discovery order)
     const devices = new Map();
+    // Track the DOM row created for each device so we can update it in place
+    const deviceElements = new Map();
 
     // Get DOM elements
     const searchInput = document.getElementById('search');
     const listElement = document.getElementById('list');
     const cancelElement = document.getElementById('cancel');
 
-    // Render devices in sorted and filtered order
-    function renderDevices() {
+    function deviceLabel(device) {
+        const text = `${device.deviceName} (${device.deviceId})`;
+        return text.length > MAX_DEVICE_NAME_LENGTH ? text.substring(0, MAX_DEVICE_NAME_LENGTH) : text;
+    }
+
+    // Show/hide rows according to the search text, without moving or recreating them
+    function applyFilter() {
         const searchText = searchInput.value.toLowerCase().trim();
-
-        // Get all devices except cancel button
-        const existingDevices = Array.from(listElement.querySelectorAll('.item:not(#cancel)'));
-        existingDevices.forEach(el => el.remove());
-
-        // Sort devices alphabetically by name
-        const sortedDevices = Array.from(devices.values()).sort((a, b) => {
-            return a.deviceName.localeCompare(b.deviceName);
-        });
-
-        // Filter devices based on search text
-        const filteredDevices = sortedDevices.filter(device => {
-            if (!searchText) return true;
+        devices.forEach((device, deviceId) => {
+            const el = deviceElements.get(deviceId);
+            if (!el) {
+                return;
+            }
             const deviceText = `${device.deviceName} ${device.deviceId}`.toLowerCase();
-            return deviceText.includes(searchText);
+            const visible = !searchText || deviceText.includes(searchText);
+            el.style.display = visible ? '' : 'none';
+        });
+    }
+
+    // Render incrementally in discovery order: existing rows stay put, new
+    // devices are appended at the bottom, resolved names update in place.
+    function renderDevices() {
+        devices.forEach((device, deviceId) => {
+            let item = deviceElements.get(deviceId);
+            if (!item) {
+                item = document.createElement('div');
+                item.className = 'item';
+                item.id = device.deviceId;
+                item.addEventListener('click', () => {
+                    window.electronAPI.deviceSelected(item.id);
+                    window.close();
+                });
+                deviceElements.set(deviceId, item);
+                // Insert before cancel button to keep it at the bottom
+                listElement.insertBefore(item, cancelElement);
+            }
+            // Update label in place (name may have resolved from empty)
+            item.textContent = deviceLabel(device);
         });
 
-        // Render filtered and sorted devices
-        filteredDevices.forEach(device => {
-            const item = document.createElement('div');
-            item.className = 'item';
-            item.id = device.deviceId;
-            item.addEventListener('click', () => {
-                window.electronAPI.deviceSelected(item.id);
-                window.close();
-            });
-            const MAX_DEVICE_NAME_LENGTH = 45;
-            const text = `${device.deviceName} (${device.deviceId})`;
-            const displayText = text.length > MAX_DEVICE_NAME_LENGTH ? text.substring(0, MAX_DEVICE_NAME_LENGTH) : text;
-            item.appendChild(document.createTextNode(displayText));
-
-            // Insert before cancel button to keep it at the bottom
-            listElement.insertBefore(item, cancelElement);
-        });
+        applyFilter();
     }
 
     // Handle search input changes
     searchInput.addEventListener('input', () => {
-        renderDevices();
+        applyFilter();
     });
 
     // Handle device scan updates


### PR DESCRIPTION
### Problem

The BLE device chooser rebuilt its entire list on every scan update: all rows were removed, the devices re-sorted alphabetically, then re-inserted. Since advertisements keep arriving while the scan runs, the list constantly reshuffles:

- a row can move (or be replaced by another device) between the moment you aim at it and the moment you click it;
- a device whose name resolves after its first advertisement jumps to a different position;
- typing in the search box re-sorted and re-rendered everything as well.

### Fix

`bt-device-chooser-renderer.js` now renders incrementally, in discovery order:

- each device gets its DOM row once; rows are kept and never re-created, new devices are appended just above the Cancel button;
- when a name resolves later, the existing row's label is updated in place;
- the search box only toggles row visibility (`display`), it no longer reorders or rebuilds the list.

Net effect: the list only grows, rows stay where they are, and clicks land on the device the user actually aimed at.

### How to test

1. Open the BLE connection dialog with several BLE devices powered on nearby.
2. Watch the list while the scan runs: previously discovered rows must stay in place while new ones are appended at the bottom, and names that resolve late must update without moving the row.
3. Type in the search field: non-matching rows are hidden, the remaining ones keep their order and position.
4. Click a device: the correct device is selected and the window closes.

### Notes

UI-only change in the chooser window, no MSP/protocol impact, so no firmware/configurator compatibility implications — targeted at `maintenance-9.x` per the branch-targeting guidance.
