### PR TITLE
fix(flasher): render failedToFlash progress message as HTML, not text

### DIFF
--- a/js/protocols/stm32.js
+++ b/js/protocols/stm32.js
@@ -328,7 +328,7 @@ STM32_protocol.prototype.connectSerial = function(port, hex, options) {
                     function onTimeout() {
                         console.log('DFU/bootloader detection timed out on port ' + port);
                         GUI.log(i18n.getMessage('failedToFlash') + port);
-                        $('span.progressLabel').text(i18n.getMessage('failedToFlash') + port);
+                        $('span.progressLabel').html(i18n.getMessage('failedToFlash') + port);
                         GUI.connect_lock = false;
                     }
                 );

--- a/tests/firmware-flasher-progress-html.test.mjs
+++ b/tests/firmware-flasher-progress-html.test.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Regression test for: STM32_protocol.prototype.connect's onTimeout callback
+ * writes the `failedToFlash` i18n string into span.progressLabel using
+ * jQuery's .text() instead of .html().
+ *
+ * `failedToFlash` (locale/en/messages.json) is HTML markup:
+ *   "<span style=\"color: red\">Failed</span> to flash"
+ *
+ * GUI.log(...) on the line above correctly renders it because
+ * GUI_control.prototype.log (js/gui.js) uses jQuery .append('<p>' + message + '</p>'),
+ * which parses HTML. But js/protocols/stm32.js then does:
+ *
+ *   $('span.progressLabel').text(i18n.getMessage('failedToFlash') + port);
+ *
+ * jQuery's .text() escapes markup, so instead of a styled red "Failed" the
+ * user sees the literal string:
+ *   <span style="color: red">Failed</span> to flash COM3
+ *
+ * Elsewhere (tabs/firmware_flasher.js, firmwareFlasherTab.flashingMessage)
+ * the same span.progressLabel element is updated with .html(message) for
+ * exactly this reason.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+const failedToFlashMessage = JSON.parse(
+    readFileSync(resolve(root, 'locale/en/messages.json'), 'utf8')
+).failedToFlash.message;
+
+describe('failedToFlash message content', () => {
+    test('sanity: failedToFlash message contains raw HTML markup', () => {
+        assert.match(failedToFlashMessage, /<span[^>]*>/,
+            'failedToFlash message must contain a <span> tag to be a meaningful regression case');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Source-inspection assertion: the onTimeout callback in js/protocols/stm32.js
+// must use $('span.progressLabel').html(...) not .text(...) when displaying
+// the failedToFlash message, since the message contains HTML markup.
+// ---------------------------------------------------------------------------
+
+describe('STM32_protocol onTimeout uses .html() for span.progressLabel', () => {
+    test('onTimeout callback does not call .text() with failedToFlash on span.progressLabel', () => {
+        const src = readFileSync(resolve(root, 'js/protocols/stm32.js'), 'utf8');
+
+        const onTimeoutStart = src.indexOf('function onTimeout()');
+        assert.notEqual(onTimeoutStart, -1, 'onTimeout callback must exist in stm32.js');
+
+        // Grab a reasonably-sized window covering the whole callback body.
+        const onTimeoutBody = src.slice(onTimeoutStart, onTimeoutStart + 500);
+
+        const progressLabelLineMatch = onTimeoutBody.match(
+            /\$\(['"]span\.progressLabel['"]\)\.(text|html)\(\s*i18n\.getMessage\(['"]failedToFlash['"]\)/
+        );
+
+        assert.notEqual(
+            progressLabelLineMatch,
+            null,
+            'expected to find a span.progressLabel update using i18n.getMessage("failedToFlash") in onTimeout'
+        );
+
+        assert.equal(
+            progressLabelLineMatch[1],
+            'html',
+            `span.progressLabel must be updated with .html() (message contains HTML markup), ` +
+            `but found .${progressLabelLineMatch[1]}() — this renders the raw <span> tag as literal text to the user`
+        );
+    });
+});


### PR DESCRIPTION
## Summary
Fixes the firmware-flasher progress bar showing the literal markup `<span style="color: red">Failed</span> to flash COM3` as plain text instead of styled red text, when a DFU/bootloader detection timeout occurs during flashing.

## Root Cause
The `failedToFlash` i18n string (`locale/en/messages.json`) intentionally embeds an HTML `<span style="color: red">` tag, matching the pattern used for several other i18n strings displayed in this UI. `GUI.log(...)` renders it correctly because it inserts content via `.append()`, which parses HTML. The very next line, however, updated `span.progressLabel` with jQuery's `.text()`, which escapes markup instead of interpreting it — so users saw the raw tag text.

Checked every other call site that writes to `span.progressLabel`: all other i18n keys used there are plain text with no markup, and `firmwareFlasherTab.flashingMessage()` (the primary path for updating this element) already uses `.html()`. This was the one inconsistent call site.

## Changes
- `js/protocols/stm32.js`: changed `$('span.progressLabel').text(...)` to `.html(...)` in the DFU/bootloader timeout handler, matching the existing `.html()` pattern used elsewhere for this element.
- Added `tests/firmware-flasher-progress-html.test.mjs`: a regression test that source-inspects the `onTimeout` callback and asserts it uses `.html()` (not `.text()`) when writing the `failedToFlash` message, consistent with this repo's existing `tests/firmware-flasher.test.mjs` conventions.

## Testing
- Added a regression test that fails against the pre-fix code (confirmed) and passes after the fix.
- Ran full test suite: `npm test` — 45/45 passing.
- Reviewed with the inav-code-review agent — no critical/important issues; one minor test-structure suggestion applied (dropped a non-exercising DOM simulation, kept the effective source-inspection assertion).
- Not hardware-tested: reproducing the actual DFU timeout requires a real flash timeout condition on hardware. The fix is a one-line rendering change (`.text()` → `.html()`) matching an existing, proven pattern already used elsewhere for the same UI element, so this is low risk, but flagging that live-hardware confirmation wasn't performed.

## Other progress bar states checked
Confirmed no other progress bar messages (success, in-progress, cancelled) have the same text/HTML mismatch.