### PR TITLE
fix(outputs): match Mixer page's raw servo numbering, not target+1

### DIFF
--- a/tabs/outputs.js
+++ b/tabs/outputs.js
@@ -356,7 +356,7 @@ outputsTab.initialize = function (callback) {
         let usedServoIndex = 0;
 
         for (let servoIndex = 0; servoIndex < FC.SERVO_RULES.getServoCount(); servoIndex++) {
-            renderServos('Servo ' + (servoIndex + 1), '', servoIndex);
+            renderServos('Servo ' + servoIndex, '', servoIndex);
         }
         if (usedServoIndex == 0) {
             // No servos configured

--- a/tests/outputs-servo-label.test.mjs
+++ b/tests/outputs-servo-label.test.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Regression test for the Outputs/Mixer servo-numbering mismatch.
+ *
+ * Bug: The Mixer page (tabs/mixer.js) shows the raw servo `target` value
+ * directly in its `mix-rule-servo` input (e.g. "1", "2", "3", "4" for
+ * smix rules targeting those servos, with target 0 conventionally unused).
+ *
+ * The Outputs page (tabs/outputs.js) rendered its servo row labels as
+ * `servoIndex + 1`, so for the exact same servos it showed "Servo 2",
+ * "Servo 3", "Servo 4", "Servo 5" -- a one-off mismatch against the Mixer
+ * page's "1", "2", "3", "4" labels for identical physical servos.
+ *
+ * Fix: tabs/outputs.js now labels each row with the raw `servoIndex`
+ * (no +1), matching the Mixer page's target numbering.
+ *
+ * This test source-inspects tabs/outputs.js to pin down the exact label
+ * formula passed to renderServos(), so a future `+ 1` regression is caught.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+describe('Outputs page servo label matches Mixer page numbering', () => {
+    const src = readFileSync(resolve(root, 'tabs/outputs.js'), 'utf8');
+
+    test('servo count loop exists', () => {
+        assert.ok(
+            src.includes('for (let servoIndex = 0; servoIndex < FC.SERVO_RULES.getServoCount(); servoIndex++)'),
+            'expected the servo-count render loop to exist in tabs/outputs.js'
+        );
+    });
+
+    test('renderServos is called with the raw servoIndex, not servoIndex + 1', () => {
+        // Isolate the render loop body so we don't accidentally match something
+        // elsewhere in the file.
+        const loopStart = src.indexOf('for (let servoIndex = 0; servoIndex < FC.SERVO_RULES.getServoCount(); servoIndex++)');
+        assert.notEqual(loopStart, -1, 'render loop must exist');
+        const loopBody = src.slice(loopStart, loopStart + 300);
+
+        const callMatch = loopBody.match(/renderServos\(\s*'Servo '\s*\+\s*([^,]+?)\s*,/);
+        assert.ok(callMatch, `expected to find a renderServos('Servo ' + <expr>, ...) call, got: ${loopBody.slice(0, 150)}`);
+
+        const labelExpr = callMatch[1].trim();
+
+        // Pin down the exact formula: must be the bare variable, never servoIndex + 1
+        // (or any other offset). This is the crux of the regression: the Outputs
+        // page must show the same number as the Mixer page's raw `target` value.
+        assert.equal(
+            labelExpr,
+            'servoIndex',
+            `renderServos() label must use the raw servoIndex value with no offset, got: 'Servo ' + ${labelExpr}`
+        );
+
+        // Extra belt-and-suspenders check: explicitly reject the old buggy formula.
+        assert.ok(
+            !/servoIndex\s*\+\s*1/.test(loopBody),
+            'renderServos() must not add 1 to servoIndex (this reintroduces the Outputs/Mixer numbering mismatch)'
+        );
+    });
+});


### PR DESCRIPTION
## Summary
Fixes a servo numbering mismatch between the Mixer page and the Outputs page: the same physical servo showed different "Servo N" numbers depending on which page you looked at.

## Root Cause
Confirmed via a real user's FC config diff (`smix` rules with targets 1, 2, 3, 4 — target 0 unused). The Mixer page's servo-target number input shows the raw stored `target` value directly, with no transformation. The Outputs page instead labeled each row as `target + 1`. For targets {1,2,3,4} this produced "Servo 2, 3, 4, 5" on the Outputs page vs "1, 2, 3, 4" on the Mixer page for the exact same servos — a pure display-formula inconsistency, not a data/indexing bug (the stored target values are identical and correct on both pages).

Also confirmed target 0 being unused is normal, not a symptom of anything wrong: every built-in airframe preset in `js/model.js` skips target 0 too (conventionally reserved for gimbal pitch), so there's no special-casing needed for it.

Separately verified: the physical-output column (the "S3", "S4" text) is computed via a different code path (`FC.OUTPUT_MAPPING`) using a different counter, and was independently confirmed correct against the reporting user's real hardware — that column is unaffected by and unrelated to this fix.

## Changes
- `tabs/outputs.js`: changed `renderServos('Servo ' + (servoIndex + 1), '', servoIndex)` to `renderServos('Servo ' + servoIndex, '', servoIndex)`, matching the Mixer page's existing raw-target display.
- Added `tests/outputs-servo-label.test.mjs`: source-inspection regression test (consistent with this repo's existing `tests/firmware-flasher.test.mjs` conventions) that pins down the exact label formula so a reintroduced `+ 1` is caught.

## Testing
- Regression test written first, confirmed it fails against the pre-fix `+ 1` formula and passes with the fix.
- Full suite: `npm test` — 45/45 passing.
- Reviewed with the inav-code-review agent — no critical/important issues.
- Verified with the reporting user's real FC diff (`smix` targets 1-4) that this produces matching numbers on both pages after the fix.
- Verified the default/no-gap case (target 0 used) still renders sensibly ("Servo 0", consistent with Mixer page's raw display for that case).
- Confirmed the label text isn't parsed/consumed anywhere else in the codebase (pure display string).