### PR TITLE
outputs tab allow 18 servos

### DIFF
--- a/src/css/tabs/motors.css
+++ b/src/css/tabs/motors.css
@@ -198,7 +198,7 @@
 
 .tab-motors .servos .titles li {
     float: right;
-    width: calc((100% / 16) - 10px);
+    width: calc((100% / 18) - 10px);
     margin: 0 0 0 10px;
 }
 
@@ -249,7 +249,7 @@
 
 .tab-motors .servos .m-block {
     float: right;
-    width: calc((100% / 16) - 10px);
+    width: calc((100% / 18) - 10px);
     margin: 0 0 0 10px;
     border-radius: 3px;
 }

--- a/tabs/outputs.html
+++ b/tabs/outputs.html
@@ -158,6 +158,8 @@
             <div class="spacer" style="padding-left: 0">
                 <div class="servos">
                     <ul class="titles">
+                        <li title="Servo - 18">18</li>
+                        <li title="Servo - 17">17</li>
                         <li title="Servo - 16">16</li>
                         <li title="Servo - 15">15</li>
                         <li title="Servo - 14">14</li>

--- a/tabs/outputs.js
+++ b/tabs/outputs.js
@@ -356,7 +356,7 @@ outputsTab.initialize = function (callback) {
         let usedServoIndex = 0;
 
         for (let servoIndex = 0; servoIndex < FC.SERVO_RULES.getServoCount(); servoIndex++) {
-            renderServos('Servo ' + (servoIndex + 1), '', servoIndex);
+            renderServos('Servo ' + (servoIndex), '', servoIndex);
         }
         if (usedServoIndex == 0) {
             // No servos configured
@@ -499,15 +499,16 @@ outputsTab.initialize = function (callback) {
         $motorSliders.append('<div class="motor-slider-container"><input type="range" min="1000" max="2000" value="1000" disabled="disabled" class="master"/></div>');
         $motorValues.append('<li style="font-weight: bold" data-i18n="motorsMaster"></li>');
 
-        for (let i = 0; i < FC.SERVO_RULES.getServoCount(); i++) {
+        let servoCount = FC.SERVO_RULES.getServoCount();
+        for (let i = 0; i < servoCount; i++) {
 
             let opacity = "";
-            if (!FC.SERVO_RULES.isServoConfigured(15 - i)) {
+            if (!FC.SERVO_RULES.isServoConfigured(servoCount - i)) {
                 opacity = ' style="opacity: 0.2"';
             }
 
             servos_wrapper.append('\
-                <div class="m-block servo-' + (15 - i) + '" ' + opacity + '>\
+                <div class="m-block servo-' + (servoCount - i) + '" ' + opacity + '>\
                     <div class="meter-bar">\
                         <div class="label"></div>\
                         <div class="indicator">\


### PR DESCRIPTION
Update Configurator outputs tab to handle 18 (or more) servos, since the firmware now does.
Previously, it displayed an empty "servo 0" which was internally servo # -2 because it subtracts from the "maximum" of 16.

Should fix the issue brought up in #2679

