### PR TITLE
 Fix CLI command input showing cache building output

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -2396,6 +2396,9 @@
     "cliInputPlaceholder": {
         "message": "Write your command here"
     },
+    "cliInputPlaceholderBuilding": {
+        "message": "Building AutoComplete cache, please wait ..."
+    },
     "cliEnter": {
         "message": "CLI mode detected"
     },

--- a/tabs/cli.js
+++ b/tabs/cli.js
@@ -518,12 +518,10 @@ cliTab.read = function (readInfo) {
         }
     }
 
-    // fallback to native autocomplete
-    if (!CliAutoComplete.isEnabled()) {
+    // do not echo the cache builder output into the input textarea
+    if (!CliAutoComplete.isBuilding()) {
         setPrompt(removePromptHash(this.cliBuffer));
     }
-
-    setPrompt(removePromptHash(this.cliBuffer));
 
     if (cliTab.promptCallback && this.cliBuffer.endsWith('# ')) {
         const cb = cliTab.promptCallback;


### PR DESCRIPTION
 Fix CLI autocomplete cache building output leaking into the command input                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    
While the CLI autocomplete cache is building, the raw output of help, dump and get commands was shown in the command textarea.                                                                          
                                                                                                                                                                                                                                                                                                                    
This PR stops writing to the textarea while the cache is building, and adds the missing translation key: "Building AutoComplete cache, please wait ..."