### PR TITLE
Bump version to 9.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inav-configurator",
   "productName": "INAV Configurator",
   "description": "Configurator for the open source flight controller software INAV.",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "main": ".vite/build/main.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Configurator-only patch release. Firmware unchanged since 9.1.0.

Includes (already merged to `maintenance-9.x`):
- #2678 — fix(flasher): render failedToFlash progress message as HTML, not text
- #2680 — outputs tab allow 18 servos

No SITL binary changes — firmware hasn't moved since 9.1.0, existing bundled SITL (from #2676) remains current.