### PR TITLE
Fix false Ground Station activation during Blackbox download

### DIFF
--- a/js/groundstation.js
+++ b/js/groundstation.js
@@ -151,6 +151,10 @@ const groundstation = (function () {
 
         let telemetry = ltmDecoder.get();
 
+        const formatNumber = function (value, divisor, decimals, suffix) {
+            return Number.isFinite(value) ? (value / divisor).toFixed(decimals) + suffix : '-';
+        };
+
         if (telemetry.gpsFix && telemetry.gpsFix > 1) {
 
             let lat = telemetry.latitude / 10000000;
@@ -206,10 +210,10 @@ const groundstation = (function () {
             privateScope.$viewport.find("#gs-telemetry-longitude").html(lon);
         }
 
-        privateScope.$viewport.find("#gs-telemetry-altitude").html((telemetry.altitude / 100.0).toFixed(2) + 'm');
-        privateScope.$viewport.find("#gs-telemetry-voltage").html((telemetry.voltage / 1000.0).toFixed(2) + 'V');
-        privateScope.$viewport.find("#gs-telemetry-sats").html(telemetry.gpsSats);
-        privateScope.$viewport.find("#gs-telemetry-speed").html(telemetry.groundSpeed.toFixed(0) + 'm/s');
+        privateScope.$viewport.find("#gs-telemetry-altitude").html(formatNumber(telemetry.altitude, 100.0, 2, 'm'));
+        privateScope.$viewport.find("#gs-telemetry-voltage").html(formatNumber(telemetry.voltage, 1000.0, 2, 'V'));
+        privateScope.$viewport.find("#gs-telemetry-sats").html(Number.isFinite(telemetry.gpsSats) ? telemetry.gpsSats : '-');
+        privateScope.$viewport.find("#gs-telemetry-speed").html(formatNumber(telemetry.groundSpeed, 1, 0, 'm/s'));
 
         let fixText = '';
         if (telemetry.gpsFix == 3) {

--- a/js/ltmDecoder.js
+++ b/js/ltmDecoder.js
@@ -2,40 +2,42 @@
 
 const ltmDecoder = (function () {
 
-    let TELEMETRY = {
-        //A frame
-        pitch: null,
-        roll: null,
-        heading: null,
+    const createTelemetry = function () {
+        return {
+            //A frame
+            pitch: null,
+            roll: null,
+            heading: null,
 
-        //S frame
-        voltage: null,
-        currectDrawn: null,
-        rssi: null,
-        airspeed: null,
-        flightmode: null,
-        flightmodeName: null,
+            //S frame
+            voltage: null,
+            currectDrawn: null,
+            rssi: null,
+            airspeed: null,
+            flightmode: null,
+            flightmodeName: null,
 
-        armed: null,
-        failsafe: null,
+            armed: null,
+            failsafe: null,
 
-        //G frame
-        latitude: null,
-        longitude: null,
-        altitude: null,
-        groundSpeed: null,
-        gpsFix: null,
-        gpsSats: null,
-        
-        
-        //X frame
-        hdop: null,
-        sensorStatus: null,
-        frameCounter: null,
-        disarmReason: null,
-        disarmReasonName: null
+            //G frame
+            latitude: null,
+            longitude: null,
+            altitude: null,
+            groundSpeed: null,
+            gpsFix: null,
+            gpsSats: null,
 
+            //X frame
+            hdop: null,
+            sensorStatus: null,
+            frameCounter: null,
+            disarmReason: null,
+            disarmReasonName: null
+        };
     };
+
+    let TELEMETRY = createTelemetry();
 
     let publicScope = {},
         privateScope = {};
@@ -248,6 +250,19 @@ const ltmDecoder = (function () {
 
     publicScope.wasEverReceiving = function () {
         return privateScope.lastFrameReceivedMs !== null;
+    };
+
+    // LTM detection is only meaningful for the current connection. Keep no
+    // partially decoded frame or telemetry from a previous serial session.
+    publicScope.reset = function () {
+        TELEMETRY = createTelemetry();
+        privateScope.protocolState = LTM_STATE_IDLE;
+        privateScope.lastFrameReceivedMs = null;
+        privateScope.frameType = null;
+        privateScope.frameLength = null;
+        privateScope.receiverIndex = 0;
+        privateScope.serialBuffer = [];
+        privateScope.frameProcessingStartedAtMs = 0;
     };
 
     publicScope.get = function () {

--- a/js/ltmProtocolGate.js
+++ b/js/ltmProtocolGate.js
@@ -1,0 +1,41 @@
+'use strict';
+
+// Routes serial bytes to LTM only until a valid MSP frame has been received in
+// the current connection. MSP and LTM share the same serial transport, so raw
+// MSP payloads must not be allowed to look like LTM after MSP is established.
+const createLtmProtocolGate = function ({ ltmDecoder, wasMspReceiving, activateGroundstation }) {
+    let mspDetected = false;
+
+    const publicScope = {};
+
+    publicScope.reset = function () {
+        mspDetected = false;
+        ltmDecoder.reset();
+    };
+
+    publicScope.read = function (info) {
+        if (mspDetected) {
+            return;
+        }
+
+        if (wasMspReceiving()) {
+            // This transition happens once per connection. Discard any partial
+            // LTM candidate that preceded the first valid MSP response.
+            mspDetected = true;
+            ltmDecoder.reset();
+            return;
+        }
+
+        ltmDecoder.read(info);
+    };
+
+    publicScope.activateGroundstationIfLtmOnly = function () {
+        if (!mspDetected && ltmDecoder.isReceiving()) {
+            activateGroundstation();
+        }
+    };
+
+    return publicScope;
+};
+
+export default createLtmProtocolGate;

--- a/js/msp.js
+++ b/js/msp.js
@@ -443,6 +443,9 @@ var MSP = {
     disconnect_cleanup() {
         this.state = 0; // reset packet state for "clean" initial entry (this is only required if user hot-disconnects)
         this.packet_error = 0; // reset CRC packet error counter for next session
+        this.last_received_timestamp = null;
+        this.analog_last_received_timestamp = null;
+        this.lastFrameReceivedMs = 0;
 
         this.callbacks_cleanup();
     },

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -23,6 +23,7 @@ import BitHelper from './bitHelper';
 import jBox from 'jbox';
 import groundstation from './groundstation';
 import ltmDecoder from './ltmDecoder';
+import createLtmProtocolGate from './ltmProtocolGate';
 import mspDeduplicationQueue from './msp/mspDeduplicationQueue';
 import store from './store';
 import cliTab from '../tabs/cli';
@@ -38,6 +39,16 @@ var SerialBackend = (function () {
     privateScope.isWirelessMode = false;
 
     privateScope.reopenTab = null;
+
+    privateScope.ltmProtocolGate = createLtmProtocolGate({
+        ltmDecoder,
+        wasMspReceiving: function () {
+            return MSP.wasEverReceiving();
+        },
+        activateGroundstation: function () {
+            groundstation.activate($('#main-wrapper'));
+        }
+    });
 
     /*
      * Handle "Wireless" mode with strict queueing of messages
@@ -187,7 +198,7 @@ var SerialBackend = (function () {
                         mspQueue.freeSoftLock();
                         mspDeduplicationQueue.flush();
                         MSP.disconnect_cleanup();
-                        ltmDecoder.reset();
+                        privateScope.ltmProtocolGate.reset();
 
                         // lock port select & baud while we are connecting / connected
                         $('#port, #baud, #delay').prop('disabled', true);
@@ -261,7 +272,7 @@ var SerialBackend = (function () {
 
                             CONFIGURATOR.connection.disconnect(privateScope.onClosed);
                             MSP.disconnect_cleanup();
-                            ltmDecoder.reset();
+                            privateScope.ltmProtocolGate.reset();
 
                             // Reset various UI elements
                             $('span.i2c-error').text(0);
@@ -389,7 +400,7 @@ var SerialBackend = (function () {
             // garbage bytes or boot messages don't corrupt the MSP decoder
             FC.resetState();
             MSP.disconnect_cleanup();
-            ltmDecoder.reset();
+            privateScope.ltmProtocolGate.reset();
 
             CONFIGURATOR.connection.addOnReceiveListener(publicScope.read_serial);
             CONFIGURATOR.connection.addOnReceiveListener(publicScope.read_ltm);
@@ -415,9 +426,7 @@ var SerialBackend = (function () {
             // been validated, its payloads (including raw dataflash blocks)
             // must never be interpreted as LTM telemetry.
             interval.add('ltm-connection-check', function () {
-                if (!CONFIGURATOR.connectionValid && !MSP.wasEverReceiving() && ltmDecoder.isReceiving()) {
-                    groundstation.activate($('#main-wrapper'));
-                }
+                privateScope.ltmProtocolGate.activateGroundstationIfLtmOnly();
             }, 1000);
 
             // request configuration data. Start with MSPv1 and
@@ -543,16 +552,7 @@ var SerialBackend = (function () {
     }
 
     publicScope.read_ltm = function (info) {
-        // LTM is only a fallback until we see the first checksum-valid MSP
-        // response. That avoids interpreting MSP setup payloads and, later,
-        // MSP_DATAFLASH_READ's arbitrary Blackbox bytes as LTM telemetry.
-        if (!CONFIGURATOR.connectionValid && !MSP.wasEverReceiving()) {
-            ltmDecoder.read(info);
-        } else if (MSP.wasEverReceiving()) {
-            // Clear a candidate LTM frame that may have arrived before the
-            // first valid MSP response completed protocol detection.
-            ltmDecoder.reset();
-        }
+        privateScope.ltmProtocolGate.read(info);
     }
 
     /**

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -187,6 +187,7 @@ var SerialBackend = (function () {
                         mspQueue.freeSoftLock();
                         mspDeduplicationQueue.flush();
                         MSP.disconnect_cleanup();
+                        ltmDecoder.reset();
 
                         // lock port select & baud while we are connecting / connected
                         $('#port, #baud, #delay').prop('disabled', true);
@@ -260,6 +261,7 @@ var SerialBackend = (function () {
 
                             CONFIGURATOR.connection.disconnect(privateScope.onClosed);
                             MSP.disconnect_cleanup();
+                            ltmDecoder.reset();
 
                             // Reset various UI elements
                             $('span.i2c-error').text(0);
@@ -387,9 +389,10 @@ var SerialBackend = (function () {
             // garbage bytes or boot messages don't corrupt the MSP decoder
             FC.resetState();
             MSP.disconnect_cleanup();
+            ltmDecoder.reset();
 
             CONFIGURATOR.connection.addOnReceiveListener(publicScope.read_serial);
-            CONFIGURATOR.connection.addOnReceiveListener(ltmDecoder.read);
+            CONFIGURATOR.connection.addOnReceiveListener(publicScope.read_ltm);
 
             // disconnect after 10 seconds with error if we don't get IDENT data
             timeout.add('connecting', function () {
@@ -408,9 +411,11 @@ var SerialBackend = (function () {
                 }
             }, 10000);
 
-            //Add a timer that every 1s will check if LTM stream is receiving data and display alert if so
+            // LTM is only a fallback for an LTM-only connection. Once MSP has
+            // been validated, its payloads (including raw dataflash blocks)
+            // must never be interpreted as LTM telemetry.
             interval.add('ltm-connection-check', function () {
-                if (ltmDecoder.isReceiving()) {
+                if (!CONFIGURATOR.connectionValid && !MSP.wasEverReceiving() && ltmDecoder.isReceiving()) {
                     groundstation.activate($('#main-wrapper'));
                 }
             }, 1000);
@@ -534,6 +539,19 @@ var SerialBackend = (function () {
             MSP.read(info);
         } else if (CONFIGURATOR.cliActive) {
             cliTab.read(info);
+        }
+    }
+
+    publicScope.read_ltm = function (info) {
+        // LTM is only a fallback until we see the first checksum-valid MSP
+        // response. That avoids interpreting MSP setup payloads and, later,
+        // MSP_DATAFLASH_READ's arbitrary Blackbox bytes as LTM telemetry.
+        if (!CONFIGURATOR.connectionValid && !MSP.wasEverReceiving()) {
+            ltmDecoder.read(info);
+        } else if (MSP.wasEverReceiving()) {
+            // Clear a candidate LTM frame that may have arrived before the
+            // first valid MSP response completed protocol detection.
+            ltmDecoder.reset();
         }
     }
 

--- a/tests/ltm-decoder.test.mjs
+++ b/tests/ltm-decoder.test.mjs
@@ -1,12 +1,8 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import test from 'node:test';
-import { fileURLToPath } from 'node:url';
 
 import ltmDecoder from '../js/ltmDecoder.js';
-
-const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+import createLtmProtocolGate from '../js/ltmProtocolGate.js';
 
 test('LTM decoder accepts a valid frame and reset clears its connection state', () => {
     ltmDecoder.reset();
@@ -25,11 +21,64 @@ test('LTM decoder accepts a valid frame and reset clears its connection state', 
     assert.equal(ltmDecoder.get().voltage, null);
 });
 
-test('a detected MSP stream does not route arbitrary payload bytes to LTM', () => {
-    const serialBackend = readFileSync(resolve(repoRoot, 'js/serial_backend.js'), 'utf8');
+test('a valid MSP frame blocks LTM-shaped bytes from activating Ground Station', () => {
+    // $M>, zero payload bytes, command 1, checksum 1.
+    const validMspFrame = Uint8Array.from([0x24, 0x4d, 0x3e, 0, 1, 1]);
+    // $TS followed by seven payload bytes and their valid XOR checksum.
+    const ltmShapedPayload = Uint8Array.from([0x24, 0x54, 0x53, 1, 2, 3, 4, 5, 6, 7, 0]);
+    let mspReceived = false;
+    let ltmReads = 0;
+    let ltmResets = 0;
+    let groundstationActivations = 0;
 
-    assert.match(serialBackend, /addOnReceiveListener\(publicScope\.read_ltm\)/);
-    assert.match(serialBackend, /publicScope\.read_ltm\s*=\s*function\s*\(info\)\s*\{[\s\S]*?if\s*\(!CONFIGURATOR\.connectionValid\s*&&\s*!MSP\.wasEverReceiving\(\)\)\s*\{[\s\S]*?ltmDecoder\.read\(info\);/);
-    assert.match(serialBackend, /else if\s*\(MSP\.wasEverReceiving\(\)\)\s*\{[\s\S]*?ltmDecoder\.reset\(\);/);
-    assert.match(serialBackend, /if\s*\(!CONFIGURATOR\.connectionValid\s*&&\s*!MSP\.wasEverReceiving\(\)\s*&&\s*ltmDecoder\.isReceiving\(\)\)/);
+    const decoder = {
+        read: function (info) {
+            ltmReads++;
+            ltmDecoder.read(info);
+        },
+        reset: function () {
+            ltmResets++;
+            ltmDecoder.reset();
+        },
+        isReceiving: function () {
+            return ltmDecoder.isReceiving();
+        }
+    };
+
+    const ltmProtocolGate = createLtmProtocolGate({
+        ltmDecoder: decoder,
+        wasMspReceiving: function () {
+            return mspReceived;
+        },
+        activateGroundstation: function () {
+            groundstationActivations++;
+        }
+    });
+
+    const receive = function (frame) {
+        // read_serial is registered before read_ltm, so a checksum-valid MSP
+        // frame has set MSP.wasEverReceiving() before the LTM route runs.
+        if (frame[0] === 0x24 && frame[1] === 0x4d && frame[2] === 0x3e) {
+            const payloadLength = frame[3];
+            let checksum = 0;
+
+            for (let index = 3; index < frame.length - 1; index++) {
+                checksum ^= frame[index];
+            }
+
+            mspReceived = frame.length === payloadLength + 6 && checksum === frame[frame.length - 1];
+        }
+
+        ltmProtocolGate.read({ data: frame.buffer });
+        ltmProtocolGate.activateGroundstationIfLtmOnly();
+    };
+
+    ltmProtocolGate.reset();
+    receive(validMspFrame);
+    receive(ltmShapedPayload);
+    receive(ltmShapedPayload);
+
+    assert.equal(ltmReads, 0);
+    assert.equal(ltmResets, 2, 'the initial reset and the MSP transition reset exactly once each');
+    assert.equal(groundstationActivations, 0);
 });

--- a/tests/ltm-decoder.test.mjs
+++ b/tests/ltm-decoder.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import ltmDecoder from '../js/ltmDecoder.js';
+
+const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+
+test('LTM decoder accepts a valid frame and reset clears its connection state', () => {
+    ltmDecoder.reset();
+
+    // $TS followed by seven payload bytes and their XOR checksum.
+    const frame = Uint8Array.from([0x24, 0x54, 0x53, 1, 2, 3, 4, 5, 6, 7, 0]);
+    ltmDecoder.read({ data: frame.buffer });
+
+    assert.equal(ltmDecoder.isReceiving(), true);
+    assert.equal(ltmDecoder.get().voltage, 513);
+
+    ltmDecoder.reset();
+
+    assert.equal(ltmDecoder.isReceiving(), false);
+    assert.equal(ltmDecoder.wasEverReceiving(), false);
+    assert.equal(ltmDecoder.get().voltage, null);
+});
+
+test('a detected MSP stream does not route arbitrary payload bytes to LTM', () => {
+    const serialBackend = readFileSync(resolve(repoRoot, 'js/serial_backend.js'), 'utf8');
+
+    assert.match(serialBackend, /addOnReceiveListener\(publicScope\.read_ltm\)/);
+    assert.match(serialBackend, /publicScope\.read_ltm\s*=\s*function\s*\(info\)\s*\{[\s\S]*?if\s*\(!CONFIGURATOR\.connectionValid\s*&&\s*!MSP\.wasEverReceiving\(\)\)\s*\{[\s\S]*?ltmDecoder\.read\(info\);/);
+    assert.match(serialBackend, /else if\s*\(MSP\.wasEverReceiving\(\)\)\s*\{[\s\S]*?ltmDecoder\.reset\(\);/);
+    assert.match(serialBackend, /if\s*\(!CONFIGURATOR\.connectionValid\s*&&\s*!MSP\.wasEverReceiving\(\)\s*&&\s*ltmDecoder\.isReceiving\(\)\)/);
+});


### PR DESCRIPTION
## What changed

- Route LTM decoding only until a valid MSP stream is detected.
- Prevent Ground Station auto-activation when MSP is active.
- Reset MSP and LTM decoder state between connection sessions.
- Handle incomplete LTM telemetry values safely in the Ground Station UI.
- Add regression coverage for a checksum-valid LTM frame embedded in arbitrary data.

## Root cause

The serial connection fed every received byte to both MSP and LTM decoders. Raw `MSP_DATAFLASH_READ` payloads contain arbitrary Blackbox bytes, so they could accidentally form a valid LTM frame and switch the UI into Ground Station mode.

## Validation

- `yarn test` — passed.
- Windows x64 ZIP build completed and archive integrity was verified.