### PR TITLE
fix(map-generator): handle all-sea Copernicus neighbour tiles + tab cleanup

### DIFF
--- a/tabs/map_generator.js
+++ b/tabs/map_generator.js
@@ -607,17 +607,6 @@ async function copernicusRetry(fn) {
     throw lastErr || new Error('Copernicus request failed');
 }
 
-// Copernicus publishes no tile for 1°x1° squares that are entirely sea, so the
-// bucket answers 404 for them. That is "no data", not an outage.
-async function copernicusTileMissing(lat, lon) {
-    try {
-        const resp = await fetch(copernicusUrl(lat, lon), { method: 'HEAD' });
-        return resp.status === 404 || resp.status === 403;
-    } catch (_) {
-        return false;   // could not ask — treat as a real network problem
-    }
-}
-
 // Opens one Copernicus tile. `full` downloads the whole GeoTIFF in a single
 // request (used for the tile being generated); otherwise the file is read
 // remotely with HTTP range requests, so a thin neighbour strip only pulls the
@@ -632,8 +621,8 @@ async function openCopernicusImage(lat, lon, imgCache, full, statusCb) {
             if (full) {
                 if (statusCb) statusCb('downloading');
                 const resp = await fetch(copernicusUrl(lat, lon));
-                if (resp.status === 404 || resp.status === 403) {
-                    const err = new Error('HTTP ' + resp.status);
+                if (resp.status === 404) {           // no file = square is entirely sea
+                    const err = new Error('HTTP 404');
                     err.notFound = true;
                     throw err;
                 }
@@ -647,12 +636,14 @@ async function openCopernicusImage(lat, lon, imgCache, full, statusCb) {
                 const tiff = await fromUrl(copernicusUrl(lat, lon));
                 return { image: await tiff.getImage(), full: false };
             } catch (e) {
-                // geotiff throws a generic error with no status, so a tile that
-                // simply does not exist (a square that is entirely sea) is
-                // indistinguishable from a server problem here. Ask the bucket
-                // directly before deciding — otherwise a missing sea neighbour
-                // aborts the whole generation for any coastal area.
-                if (await copernicusTileMissing(lat, lon)) {
+                // geotiff throws a generic error with no status. Confirm with a
+                // HEAD: this bucket returns 404 for 1° squares that are entirely
+                // sea (no file) — that is "no data", so the edge stays at sea
+                // level. A 403 or anything else is a real access/network problem
+                // and must surface (→ ask-first SRTM fallback), not be silently
+                // zeroed into the terrain.
+                const head = await fetch(copernicusUrl(lat, lon), { method: 'HEAD' });
+                if (head.status === 404) {
                     const err = new Error('HTTP 404');
                     err.notFound = true;
                     throw err;

--- a/tabs/map_generator.js
+++ b/tabs/map_generator.js
@@ -607,6 +607,17 @@ async function copernicusRetry(fn) {
     throw lastErr || new Error('Copernicus request failed');
 }
 
+// Copernicus publishes no tile for 1°x1° squares that are entirely sea, so the
+// bucket answers 404 for them. That is "no data", not an outage.
+async function copernicusTileMissing(lat, lon) {
+    try {
+        const resp = await fetch(copernicusUrl(lat, lon), { method: 'HEAD' });
+        return resp.status === 404 || resp.status === 403;
+    } catch (_) {
+        return false;   // could not ask — treat as a real network problem
+    }
+}
+
 // Opens one Copernicus tile. `full` downloads the whole GeoTIFF in a single
 // request (used for the tile being generated); otherwise the file is read
 // remotely with HTTP range requests, so a thin neighbour strip only pulls the
@@ -632,8 +643,22 @@ async function openCopernicusImage(lat, lon, imgCache, full, statusCb) {
                 const tiff = await fromArrayBuffer(buf);
                 return { image: await tiff.getImage(), full: true };
             }
-            const tiff = await fromUrl(copernicusUrl(lat, lon));
-            return { image: await tiff.getImage(), full: false };
+            try {
+                const tiff = await fromUrl(copernicusUrl(lat, lon));
+                return { image: await tiff.getImage(), full: false };
+            } catch (e) {
+                // geotiff throws a generic error with no status, so a tile that
+                // simply does not exist (a square that is entirely sea) is
+                // indistinguishable from a server problem here. Ask the bucket
+                // directly before deciding — otherwise a missing sea neighbour
+                // aborts the whole generation for any coastal area.
+                if (await copernicusTileMissing(lat, lon)) {
+                    const err = new Error('HTTP 404');
+                    err.notFound = true;
+                    throw err;
+                }
+                throw e;
+            }
         });
         imgCache[key] = entry;
         return entry.image;
@@ -864,8 +889,10 @@ const hgtDb = {
 
 // ─── Tab lifecycle ──────────────────────────────────────────────────────
 TABS.map_generator.initialize = function (callback) {
-    if (GUI.active_tab !== 'map_generator') {
-        GUI.active_tab = 'map_generator';
+    // Must be the tab object, not its name — GUI.tab_switch_cleanup() calls
+    // active_tab.cleanup() when leaving the tab.
+    if (GUI.active_tab !== TABS.map_generator) {
+        GUI.active_tab = TABS.map_generator;
     }
 
     loadHtml();


### PR DESCRIPTION
Two fixes for the Map Generator terrain source, both found after #2599 merged (thanks to @error414 for testing).

**Coastal areas failed with "Copernicus GLO-30 is unavailable."** Copernicus publishes no tile for 1°×1° squares that are entirely sea, so the bucket 404s on them — that is "no data", not an outage. The 404 was only recognised for the square being generated, not for the neighbour squares fetched for edge data, so a missing sea neighbour aborted the whole run for any coastal area. It now checks whether the neighbour square actually exists (a HEAD request) before deciding: a genuinely missing sea square leaves that edge at sea level and generation continues; a real network error still offers the SRTM fallback as before.

**Leaving the tab threw `active_tab.cleanup is not a function`.** The tab set `GUI.active_tab` to a string instead of the tab object; it now stores the object like every other tab.

Tested on the Gdańsk coast (N54E017–019): generation completes, all blocks pass CRC, sea areas correctly read 0 m, and switching tabs no longer errors.