### PR TITLE
Missions Control fixes + Add Manual Throttle Launch Option

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1350,6 +1350,12 @@
     "configurationLaunchClimbAngleHelp": {
         "message": "Climb angle (attitude of model, not climb slope) for launch sequence (degrees), is also restrained by global max_angle_inclination_pit. Default: 18 [5-45]"
     },
+    "configurationLaunchManual": {
+        "message": "Manual Throttle Launch"
+    },
+    "configurationLaunchManualHelp": {
+        "message": "Allows launch with throttle controlled directly by throttle stick. Launch control only levels wings and maintains climb pitch during launch. IF USED WITHOUT A GPS LOCK plane must be launched immediately after throttle is increased to avoid issues with climb out stabilisation and the launch ending sooner than expected."
+    },
     "configuration3d": {
         "message": "Reversible motors"
     },
@@ -4571,7 +4577,7 @@
     },
     "osdElement_GPS_EXTRA_STATS_HELP": {
         "message": "Visible satellite count and locked satellite indicator(5 levels) for each constellation in this order: GPS–Galileo–BeiDou–GLONASS. Followed by SNR level (higher better)"
-    },    
+    },
     "osdElement_ROLL_PIDS": {
         "message": "Roll PIDs"
     },

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -70,6 +70,11 @@
                             <label for="launchEndTime"><span data-i18n="configurationLaunchEndTime"></span></label>
                             <div for="launchEndTime" class="helpicon cf_tip" data-i18n_title="configurationLaunchEndTimeHelp"></div>
                         </div>
+                        <div class="checkbox">
+                            <input type="checkbox" class="toggle update_preview" id="launchManual" data-setting="nav_fw_launch_manual_throttle" data-live="true" />
+                            <label for="launchManual"><span data-i18n="configurationLaunchManual"></span></label>
+                            <div for="launchManual" class="helpicon cf_tip" data-i18n_title="configurationLaunchManualHelp"></div>
+                        </div>
                     </div>
                 </div>
 

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -87,7 +87,7 @@ var dictOfLabelParameterPoint = {
     5:  {parameter1: '', parameter2: '', parameter3: ''},
     6:  {parameter1: 'Target WP number', parameter2: 'Number of repeat (-1: infinite)', parameter3: ''},
     7:  {parameter1: 'Heading (deg)', parameter2: '', parameter3: ''},
-    8:  {parameter1: '', parameter2: '', parameter3: 'Sea level Ref'}
+    8:  {parameter1: 'Speed (cm/s)', parameter2: '', parameter3: 'Sea level Ref'}
 };
 
 var waypointOptions = ['JUMP','SET_HEAD','RTH'];
@@ -3137,6 +3137,9 @@ function iconKey(filename) {
 
         $('#pointP1').on('change', function (event) {
             if (selectedMarker) {
+                if (selectedMarker.getAction() != MWNP.WPTYPE.SET_HEAD) {
+                    $('#pointP1').val(Math.abs(Number($('#pointP1').val())));
+                }
                 selectedMarker.setP1(Number($('#pointP1').val()));
                 mission.updateWaypoint(selectedMarker);
                 mission.update(singleMissionActive());
@@ -3146,6 +3149,9 @@ function iconKey(filename) {
 
         $('#pointP2').on('change', function (event) {
             if (selectedMarker) {
+                if (selectedMarker.getAction() == MWNP.WPTYPE.POSHOLD_TIME) {
+                    $('#pointP2').val(Math.abs(Number($('#pointP2').val())));
+                }
                 selectedMarker.setP2(Number($('#pointP2').val()));
                 mission.updateWaypoint(selectedMarker);
                 mission.update(singleMissionActive());


### PR DESCRIPTION
Adds missing speed option for landing waypoints and restricts waypoint P1 and P2 to only +ve values where applicable.