### PR TITLE
Add INA226 configuration options

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1179,6 +1179,24 @@
     "configurationCurrentOffset": {
         "message": "Offset in millivolt steps"
     },
+    "configurationIna226I2cBus": {
+        "message": "INA226 I2C Bus"
+    },
+    "configurationIna226I2cBusHelp": {
+        "message": "Hardware I2C bus connected to the INA226."
+    },
+    "configurationIna226I2cAddress": {
+        "message": "INA226 I2C Address"
+    },
+    "configurationIna226I2cAddressHelp": {
+        "message": "7-bit I2C address in decimal. 64 is 0x40 and 79 is 0x4F."
+    },
+    "configurationIna226ShuntResistance": {
+        "message": "INA226 Shunt Resistance (µΩ)"
+    },
+    "configurationIna226ShuntResistanceHelp": {
+        "message": "Shunt resistor value in micro-ohms (µΩ) used to calculate current."
+    },
     "configurationBatteryMultiwiiCurrent": {
         "message": "Enable support for legacy Multiwii MSP current output"
     },

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -95,7 +95,7 @@
                         <div for="voltagesource" class="helpicon cf_tip" data-i18n_title="configurationVoltageSourceHelp"></div>
                     </div>
                     
-                    <div class="number">
+                    <div class="number adc-voltage-setting">
                         <input type="number" id="voltagescale" name="voltagescale" step="1" min="10" max="65535" />
                         <label for="voltagescale">
                             <span data-i18n="configurationBatteryScale"></span>
@@ -114,14 +114,35 @@
                             <span data-i18n="configurationCurrentMeterType"></span>
                         </label>
                     </div>
-                    <div class="number">
+                    <div class="number ina226-common-setting" style="display: none;">
+                        <input type="number" id="ina_bus" data-setting="ina_bus" />
+                        <label for="ina_bus">
+                            <span data-i18n="configurationIna226I2cBus">INA226 I2C Bus</span>
+                        </label>
+                        <div for="ina_bus" class="helpicon cf_tip" data-i18n_title="configurationIna226I2cBusHelp"></div>
+                    </div>
+                    <div class="number ina226-common-setting" style="display: none;">
+                        <input type="number" id="ina_address" data-setting="ina_address" />
+                        <label for="ina_address">
+                            <span data-i18n="configurationIna226I2cAddress">INA226 I2C Address</span>
+                        </label>
+                        <div for="ina_address" class="helpicon cf_tip" data-i18n_title="configurationIna226I2cAddressHelp"></div>
+                    </div>
+                    <div class="number ina226-current-setting" style="display: none;">
+                        <input type="number" id="ina_shunt_res_uohm" data-setting="ina_shunt_res_uohm" />
+                        <label for="ina_shunt_res_uohm">
+                            <span data-i18n="configurationIna226ShuntResistance">INA226 Shunt Resistance (µΩ)</span>
+                        </label>
+                        <div for="ina_shunt_res_uohm" class="helpicon cf_tip" data-i18n_title="configurationIna226ShuntResistanceHelp"></div>
+                    </div>
+                    <div class="number adc-current-setting">
                         <input type="number" id="currentscale" name="currentscale" step="1" min="-10000" max="10000" data-setting-placeholder="current_meter_scale" />
                         <label for="currentscale">
                             <span data-i18n="configurationCurrentScale"></span>
                         </label>
                         <div for="currentscale" class="helpicon cf_tip" data-i18n_title="configurationCurrentScaleHelp"></div>
                     </div>
-                    <div class="number">
+                    <div class="number adc-current-setting">
                         <input type="number" id="currentoffset" name="currentoffset" step="0.1" min="-3276.8" max="3276.7" />
                         <label for="currentoffset">
                             <span data-i18n="configurationCurrentOffset"></span>

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -14,6 +14,23 @@ import features from './../js/feature_framework';
 
 const configurationTab = {};
 
+function isIna226Selected($meterType) {
+    const settingInfo = $meterType.data('setting-info');
+    const selectedValue = Number.parseInt($meterType.val());
+
+    return settingInfo?.table?.values?.[selectedValue] === 'INA226';
+}
+
+function updateIna226SettingsVisibility() {
+    const usesIna226Voltage = isIna226Selected($('#vbat_meter_type'));
+    const usesIna226Current = isIna226Selected($('#current_meter_type'));
+
+    $('.ina226-common-setting').toggle(usesIna226Voltage || usesIna226Current);
+    $('.ina226-current-setting').toggle(usesIna226Current);
+    $('.adc-voltage-setting').toggle(!usesIna226Voltage);
+    $('.adc-current-setting').toggle(!usesIna226Current);
+}
+
 configurationTab.initialize = function (callback, scrollPosition) {
 
     if (GUI.active_tab !== this) {
@@ -264,8 +281,10 @@ configurationTab.initialize = function (callback, scrollPosition) {
         // Wait for settings to load before triggering change event
         settingsPromise.then(function() {
             $i2cSpeed.trigger('change');
+            $('#vbat_meter_type, #current_meter_type').on('change', updateIna226SettingsVisibility);
+            updateIna226SettingsVisibility();
         }).catch(function(error) {
-            console.error('Settings load failed, I2C speed change not triggered:', error);
+            console.error('Settings load failed, dependent controls not initialized:', error);
         });
 
         $('a.save').on('click', function () {


### PR DESCRIPTION
## Summary

- add graphical settings for the INA226 I2C bus, address, and shunt resistance
- show the shared INA226 settings when either voltage or current uses INA226, and show the shunt setting only for INA226 current
- hide the corresponding ADC calibration controls while INA226 is selected
- rely on firmware setting metadata instead of hard-coded voltage or current meter enum values
- keep compatibility with firmware that does not expose the new `ina_*` settings

This complements iNavFlight/inav#11656.

## Validation

- `yarn test`
- `yarn package`
- macOS ARM64 `yarn make`
- packaged Configurator tested against stock SITL to verify old-firmware fallback
- packaged Configurator tested against INA226-enabled SITL for all four voltage/current selection combinations
- verified `ina_bus`, `ina_address`, and `ina_shunt_res_uohm` persist after Save and Reboot
- `git diff --check`
