### PR TITLE
Advanced Tuning: add nav_cruise_lock_on_level toggle (companion to inav#11804)

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -3561,6 +3561,12 @@
     "cruiseYawRateHelp": {
         "message": "This is the turning rate in Cruise and 3D Cruise."
     },
+    "cruiseLockOnLevel": {
+        "message": "Lock Course when Level"
+    },
+    "cruiseLockOnLevelHelp": {
+        "message": "Fixed wing only: When enabled, Course Hold / Cruise locks the new course only once the aircraft has rolled out level (below 10° bank) after a heading adjustment or a banked mode entry, so the course is not overshot while the aircraft is still turning. When disabled, the course locks as soon as the sticks are centered (legacy behaviour)."
+    },
     "cruiseManualThrottleLabel": {
         "message": "Allow manual throttle increase"
     },

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -231,6 +231,12 @@
                             <div for="cruiseYawRate" class="helpicon cf_tip" data-i18n_title="cruiseYawRateHelp"></div>
                         </div>
 
+                        <div class="checkbox">
+                            <input type="checkbox" class="toggle" id="cruiseLockOnLevel" data-setting="nav_cruise_lock_on_level" />
+                            <label for="cruiseLockOnLevel"><span data-i18n="cruiseLockOnLevel"></span></label>
+                            <div for="cruiseLockOnLevel" class="helpicon cf_tip" data-i18n_title="cruiseLockOnLevelHelp"></div>
+                        </div>
+
                         <div class="number">
                             <input id="loiterRadius" type="number" data-unit="cm" data-setting="nav_fw_loiter_radius" data-setting-multiplier="1" step="1" min="0" max="30000" />
                             <label for="loiterRadius"><span data-i18n="loiterRadius"></span></label>


### PR DESCRIPTION
Configurator counterpart to the firmware PR iNavFlight/inav#11804
(FW nav: replace roll PT1 smoothing with a triggered S-curve). Please
review/merge together with that PR.

## What
Adds the new `nav_cruise_lock_on_level` boolean setting to
**Advanced Tuning → Fixed Wing Navigation Settings**, directly below
"Cruise Yaw Rate", as a toggle labeled **"Lock Course when Level"**.

## Why
inav#11804 changes when Course Hold / Cruise locks its course after a
heading adjustment or a banked mode entry: the course now locks once the
aircraft has rolled out level (below 10° bank) instead of immediately on
stick release, preventing course overshoot during the level-off. On
maintainer feedback this behavior change is gated behind a setting:

- **ON (default):** lock the course once rolled out level (new behavior)
- **OFF:** lock the course as soon as the sticks are centered (legacy behavior)

The tooltip explains both states.

## Notes
- Only `locale/en` is updated, other locales fall back to English.
- On firmware without this setting the toggle is hidden automatically by
  the existing settings framework, so the Configurator stays compatible
  with older 10.x firmware.