### PR TITLE
Advanced Tuning: FW coordinated WP turn settings - comes with FW #11812

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -3712,19 +3712,13 @@
         "message": "Waypoint Turn Mode"
     },
     "wpTurnModeHelp": {
-        "message": "Fixed wing only: How the aircraft turns at waypoints during missions. FLY_BY starts the turn early, based on the aircraft's real turn radius (from speed and maximum navigation bank angle), so the flight path joins the next leg smoothly without overshoot - the corner is cut and the waypoint is passed abeam instead of overflown. FLY_OVER flies directly over the waypoint, then flies a coordinated turn that rolls out exactly on the line to the next waypoint. FLY_INTO eases away from the corner before the waypoint and then crosses it already aligned on the outbound course (survey/mapping line entries)."
-    },
-    "wpTurnCoordination": {
-        "message": "Waypoint Turn Coordination"
-    },
-    "wpTurnCoordinationHelp": {
-        "message": "Fixed wing only: How waypoint turns are controlled. COORDINATED (default) flies the turn as an explicit coordinated arc of the planned radius and bank angle, tracking it precisely onto the next leg. DIRECT uses the classic reactive heading controller instead (legacy behaviour)."
+        "message": "Fixed wing only: How the aircraft turns at waypoints during missions. DIRECT uses the classic reactive heading controller (legacy behaviour). The COORD modes fly the turn as an explicit coordinated arc of the aircraft's real turn radius (from speed and maximum navigation bank angle): COORD_FLYBY starts the turn early so the flight path joins the next leg smoothly without overshoot - the corner is cut and the waypoint is passed abeam instead of overflown. COORD_FLYOVER flies directly over the waypoint, then rolls out exactly on the line to the next waypoint. COORD_FLYINTO eases away from the corner before the waypoint and then crosses it already aligned on the outbound course (survey/mapping line entries)."
     },
     "wpTurnMaxLeadTime": {
         "message": "Waypoint Turn Max Lead Time"
     },
     "wpTurnMaxLeadTimeHelp": {
-        "message": "Fixed wing FLY_BY turns only: Limits how early before a waypoint the turn is allowed to start [ms]. The required lead time grows with speed and turn angle; a too-low cap forces late turn-ins and overshoot. Raise towards 12000 for sluggish models, lower towards 3000 to keep turns close to the waypoint [3000-12000]."
+        "message": "Fixed wing COORD_FLYBY turns only: Limits how early before a waypoint the turn is allowed to start [ms]. The required lead time grows with speed and turn angle; a too-low cap forces late turn-ins and overshoot. Raise towards 12000 for sluggish models, lower towards 3000 to keep turns close to the waypoint [3000-12000]."
     },
     "navMotorStop": {
         "message": "Navigation Motor Stop Override"

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -3712,7 +3712,7 @@
         "message": "Waypoint Turn Mode"
     },
     "wpTurnModeHelp": {
-        "message": "Fixed wing only: How the aircraft turns at waypoints during missions. FLY_BY starts the turn early, based on the aircraft's real turn radius (from speed and maximum navigation bank angle), so the flight path joins the next leg smoothly without overshoot - the corner is cut and the waypoint is passed abeam instead of overflown. FLY_OVER flies directly over the waypoint and only then turns towards the next leg."
+        "message": "Fixed wing only: How the aircraft turns at waypoints during missions. FLY_BY starts the turn early, based on the aircraft's real turn radius (from speed and maximum navigation bank angle), so the flight path joins the next leg smoothly without overshoot - the corner is cut and the waypoint is passed abeam instead of overflown. FLY_OVER flies directly over the waypoint, then flies a coordinated turn that rolls out exactly on the line to the next waypoint. FLY_INTO eases away from the corner before the waypoint and then crosses it already aligned on the outbound course (survey/mapping line entries)."
     },
     "wpTurnCoordination": {
         "message": "Waypoint Turn Coordination"

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -3712,7 +3712,7 @@
         "message": "Waypoint Turn Mode"
     },
     "wpTurnModeHelp": {
-        "message": "Fixed wing only: How the aircraft turns at waypoints during missions. DIRECT uses the classic reactive heading controller (legacy behaviour). The COORD modes fly the turn as an explicit coordinated arc of the aircraft's real turn radius (from speed and maximum navigation bank angle): COORD_FLYBY starts the turn early so the flight path joins the next leg smoothly without overshoot - the corner is cut and the waypoint is passed abeam instead of overflown. COORD_FLYOVER flies directly over the waypoint, then rolls out exactly on the line to the next waypoint. COORD_FLYINTO eases away from the corner before the waypoint and then crosses it already aligned on the outbound course (survey/mapping line entries)."
+        "message": "Fixed wing only: How the aircraft turns at waypoints during missions. DIRECT uses the classic reactive heading controller (legacy behaviour). The COORD modes fly the turn as an explicit coordinated arc of the aircraft's real turn radius (from speed and maximum navigation bank angle): COORD_FLYBY starts the turn early so the flight path joins the next leg smoothly without overshoot - the corner is cut and the waypoint is passed abeam instead of overflown. COORD_FLYOVER flies directly over the waypoint, then rolls out exactly on the line to the next waypoint. COORD_FLYINTO eases away from the corner before the waypoint and then crosses it already aligned on the outbound course (survey/mapping line entries). Autoland approach turns always fly COORD_FLYBY, regardless of this setting."
     },
     "wpTurnMaxLeadTime": {
         "message": "Waypoint Turn Max Lead Time"

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -3708,11 +3708,23 @@
     "wpRestartMissionHelp": {
         "message": "Sets restart behaviour for a WP mission when interrupted mid mission. START from first WP, RESUME from last active WP or SWITCH between START and RESUME each time WP Mode is reselected ON. SWITCH effectively allows resuming once only from a previous mid mission waypoint after which the mission will restart from the first waypoint."
     },
-    "wpTurnSmoothing": {
-        "message": "Waypoint Turn Smoothing"
+    "wpTurnMode": {
+        "message": "Waypoint Turn Mode"
     },
-    "wpTurnSmoothingHelp": {
-        "message": "Smooths turns during WP missions by switching to a loiter turn at waypoints. When set to ON the craft will reach the waypoint during the turn. When set to ON-CUT the craft will turn inside the waypoint without actually reaching it (cuts the corner)."
+    "wpTurnModeHelp": {
+        "message": "Fixed wing only: How the aircraft turns at waypoints during missions. FLY_BY starts the turn early, based on the aircraft's real turn radius (from speed and maximum navigation bank angle), so the flight path joins the next leg smoothly without overshoot - the corner is cut and the waypoint is passed abeam instead of overflown. FLY_OVER flies directly over the waypoint and only then turns towards the next leg."
+    },
+    "wpTurnCoordination": {
+        "message": "Waypoint Turn Coordination"
+    },
+    "wpTurnCoordinationHelp": {
+        "message": "Fixed wing only: How waypoint turns are controlled. COORDINATED (default) flies the turn as an explicit coordinated arc of the planned radius and bank angle, tracking it precisely onto the next leg. DIRECT uses the classic reactive heading controller instead (legacy behaviour)."
+    },
+    "wpTurnMaxLeadTime": {
+        "message": "Waypoint Turn Max Lead Time"
+    },
+    "wpTurnMaxLeadTimeHelp": {
+        "message": "Fixed wing FLY_BY turns only: Limits how early before a waypoint the turn is allowed to start [ms]. The required lead time grows with speed and turn angle; a too-low cap forces late turn-ins and overshoot. Raise towards 12000 for sluggish models, lower towards 3000 to keep turns close to the waypoint [3000-12000]."
     },
     "navMotorStop": {
         "message": "Navigation Motor Stop Override"

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -683,12 +683,6 @@
                             <div for="wpTurnMode" class="helpicon cf_tip" data-i18n_title="wpTurnModeHelp"></div>
                         </div>
 
-                        <div class="select">
-                            <select id="wpTurnCoordination" data-setting="nav_fw_wp_turn_coordination"></select>
-                            <label for="wpTurnCoordination"><span data-i18n="wpTurnCoordination"></span></label>
-                            <div for="wpTurnCoordination" class="helpicon cf_tip" data-i18n_title="wpTurnCoordinationHelp"></div>
-                        </div>
-
                         <div class="number">
                             <input type="number" id="wpTurnMaxLeadTime" data-unit="msec" data-setting="nav_fw_wp_turn_max_lead_time" data-setting-multiplier="1" step="100" min="3000" max="12000" />
                             <label for="wpTurnMaxLeadTime"><span data-i18n="wpTurnMaxLeadTime"></span></label>

--- a/tabs/advanced_tuning.html
+++ b/tabs/advanced_tuning.html
@@ -614,7 +614,7 @@
 
             <div class="rightWrapper">
 
-                <div class="config-setion gui_box grey">
+                <div class="config-section gui_box grey">
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title" data-i18n="generalNavigationSettings"></div>
                     </div>
@@ -678,9 +678,21 @@
                         </div>
 
                         <div class="select">
-                            <select id="wpTurnSmoothing" data-setting="nav_fw_wp_turn_smoothing"></select>
-                            <label for="wpTurnSmoothing"><span data-i18n="wpTurnSmoothing"></span></label>
-                            <div for="wpTurnSmoothing" class="helpicon cf_tip" data-i18n_title="wpTurnSmoothingHelp"></div>
+                            <select id="wpTurnMode" data-setting="nav_fw_wp_turn_mode"></select>
+                            <label for="wpTurnMode"><span data-i18n="wpTurnMode"></span></label>
+                            <div for="wpTurnMode" class="helpicon cf_tip" data-i18n_title="wpTurnModeHelp"></div>
+                        </div>
+
+                        <div class="select">
+                            <select id="wpTurnCoordination" data-setting="nav_fw_wp_turn_coordination"></select>
+                            <label for="wpTurnCoordination"><span data-i18n="wpTurnCoordination"></span></label>
+                            <div for="wpTurnCoordination" class="helpicon cf_tip" data-i18n_title="wpTurnCoordinationHelp"></div>
+                        </div>
+
+                        <div class="number">
+                            <input type="number" id="wpTurnMaxLeadTime" data-unit="msec" data-setting="nav_fw_wp_turn_max_lead_time" data-setting-multiplier="1" step="100" min="3000" max="12000" />
+                            <label for="wpTurnMaxLeadTime"><span data-i18n="wpTurnMaxLeadTime"></span></label>
+                            <div for="wpTurnMaxLeadTime" class="helpicon cf_tip" data-i18n_title="wpTurnMaxLeadTimeHelp"></div>
                         </div>
 
                         <div class="select">


### PR DESCRIPTION
## Summary

Belongs to https://github.com/iNavFlight/inav/pull/11812

Updates the Advanced Tuning → General Navigation Settings box for the new FW coordinated
waypoint turn system:

- Replaces the removed `nav_fw_wp_turn_smoothing` dropdown with the new consolidated
  **`nav_fw_wp_turn_mode`** select (DIRECT / COORD_FLYBY / COORD_FLYOVER / COORD_FLYINTO —
  values populate from the FC).
- Adds **`nav_fw_wp_turn_max_lead_time`** (3000–12000 ms) — the cap on how early a COORD_FLYBY
  turn may start before the waypoint.
- Help texts for both, covering all four turn modes, the path-tracking S-turn variant of
  COORD_FLYOVER, and the note that autoland approaches always fly COORD_FLYBY.

The turn feed-forward gain and control-ease settings intentionally get no UI — they stay
CLI-only while the system proves itself in the field.

Drive-by: fixes a `config-setion` → `config-section` class typo in the same box.

## Testing

Verified against the firmware branch on MATEKF765: dropdown values populate correctly from the
FC settings table, save/reload round-trips, tooltips render.