### PR TITLE
LED strip: add rainbow overlay GUI controls

### DIFF
--- a/js/msp.js
+++ b/js/msp.js
@@ -82,7 +82,7 @@ var MSP = {
     ledDirectionLetters:        ['n', 'e', 's', 'w', 'u', 'd'],        // in LSB bit order
     ledFunctionLetters:         ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b', 'l'], // in LSB bit order
     ledBaseFunctionLetters:     ['c', 'f', 'a', 'l', 's', 'g', 'r', 'h'], // in LSB bit
-    ledOverlayLetters:          ['t', 'o', 'b', 'n', 'i', 'w', 'e'], // in LSB bit
+    ledOverlayLetters:          ['t', 'o', 'b', 'n', 'i', 'w', 'e', 'v'], // in LSB bit
 
     last_received_timestamp:   null,
     analog_last_received_timestamp: null,

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5953,10 +5953,10 @@
         "message": "Rainbow Overlay Settings"
     },
     "ledStripRainbowFreqLabel": {
-        "message": "Frequency"
+        "message": "Sweep Rate"
     },
     "ledStripRainbowFreqUnit": {
-        "message": "Hz"
+        "message": "1-255"
     },
     "ledStripRainbowColorDeltaLabel": {
         "message": "Color Delta"

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5946,6 +5946,24 @@
     "ledStripEnableStrobeLightEffectText": {
         "message": "Enable strobe light effect"
     },
+    "ledStripRainbowOverlay": {
+        "message": "Rainbow"
+    },
+    "ledStripRainbowSettingsTitle": {
+        "message": "Rainbow Overlay Settings"
+    },
+    "ledStripRainbowFreqLabel": {
+        "message": "Frequency"
+    },
+    "ledStripRainbowFreqUnit": {
+        "message": "Hz"
+    },
+    "ledStripRainbowColorDeltaLabel": {
+        "message": "Color Delta"
+    },
+    "ledStripRainbowDeltaUnit": {
+        "message": "Degrees"
+    },
     "ledStripOverlayTitle": {
         "message": "Overlay"
     },

--- a/tabs/led_strip.html
+++ b/tabs/led_strip.html
@@ -144,7 +144,7 @@
                         <div style="font-weight: bold; margin-bottom: 6px; color: #1dacf2;">Rainbow Overlay Settings</div>
                         <div class="rainbowSettingRow" style="display: flex; align-items: center; margin-bottom: 4px;">
                             <label for="rainbowFreqInput" style="width: 100px; flex-shrink: 0;" i18n="ledStripRainbowFreqLabel"></label>
-                            <input type="number" id="rainbowFreqInput" min="1" max="2000" step="1" disabled style="width: 40px; text-align: right;" />
+                                                        <input type="number" id="rainbowFreqInput" min="1" max="255" step="1" disabled style="width: 40px; text-align: right;" />
                             <span style="margin-left: 6px;" i18n="ledStripRainbowFreqUnit"></span>
                         </div>
                         <div class="rainbowSettingRow" style="display: flex; align-items: center; margin-bottom: 4px;">

--- a/tabs/led_strip.html
+++ b/tabs/led_strip.html
@@ -135,6 +135,23 @@
                             <input type="checkbox" name="strobe" class="toggle function-e" />
                             <label> <span i18n="ledStripEnableStrobeLightEffectText"></span></label>
                         </div>
+                        <div class="checkbox rainbowOverlay extra_functions20">
+                            <input type="checkbox" name="rainbow" class="toggle function-v" />
+                            <label> <span i18n="ledStripRainbowOverlay"></span></label>
+                        </div>
+                    </div>
+                    <div class="rainbowSettings" id="rainbowSettings" style="margin-top: 8px; margin-left: 4px;">
+                        <div style="font-weight: bold; margin-bottom: 6px; color: #1dacf2;">Rainbow Overlay Settings</div>
+                        <div class="rainbowSettingRow" style="display: flex; align-items: center; margin-bottom: 4px;">
+                            <label for="rainbowFreqInput" style="width: 100px; flex-shrink: 0;" i18n="ledStripRainbowFreqLabel"></label>
+                            <input type="number" id="rainbowFreqInput" min="1" max="2000" step="1" disabled style="width: 40px; text-align: right;" />
+                            <span style="margin-left: 6px;" i18n="ledStripRainbowFreqUnit"></span>
+                        </div>
+                        <div class="rainbowSettingRow" style="display: flex; align-items: center; margin-bottom: 4px;">
+                            <label for="rainbowDeltaInput" style="width: 100px; flex-shrink: 0;" i18n="ledStripRainbowColorDeltaLabel"></label>
+                            <input type="number" id="rainbowDeltaInput" min="0" max="359" step="1" disabled style="width: 40px; text-align: right;" />
+                            <span style="margin-left: 6px;" i18n="ledStripRainbowDeltaUnit"></span>
+                        </div>
                     </div>
                 </div>
 
@@ -201,7 +218,6 @@
         </div>
 
         <div class="colorControls">
-
         </div>
 
         <div class="clear-both"></div>

--- a/tabs/led_strip.js
+++ b/tabs/led_strip.js
@@ -225,13 +225,11 @@ ledStripTab.initialize = function (callback, scrollPosition) {
             $('#rainbowFreqInput, #rainbowDeltaInput').prop('disabled', !rainbowActive).css('pointer-events', rainbowActive ? 'auto' : '');
         }
 
-        mspHelper.getSetting('ledstrip_rainbow_freq_hz').then(function (result) {
-            console.log('[Rainbow] ledstrip_rainbow_freq_hz =', result);
+        mspHelper.getSetting('ledstrip_rainbow_sweep_rate').then(function (result) {
             if (result && result.value !== null && result.value !== undefined) {
                 $('#rainbowFreqInput').val(result.value);
             }
         }).catch(function (err) {
-            console.error('[Rainbow] getSetting ledstrip_rainbow_freq_hz FAILED:', err);
         });
         mspHelper.getSetting('ledstrip_rainbow_delta_deg').then(function (result) {
             console.log('[Rainbow] ledstrip_rainbow_delta_deg =', result);
@@ -829,10 +827,10 @@ ledStripTab.initialize = function (callback, scrollPosition) {
             }
 
             function save_rainbow_settings() {
-                var freq = parseInt($('#rainbowFreqInput').val(), 10);
+                var freq = Math.max(1, Math.min(255, parseInt($('#rainbowFreqInput').val(), 10) || 1));
                 var delta = parseInt($('#rainbowDeltaInput').val(), 10);
 
-                mspHelper.setSetting('ledstrip_rainbow_freq_hz', freq, function () {
+                mspHelper.setSetting('ledstrip_rainbow_sweep_rate', freq, function () {
                     mspHelper.setSetting('ledstrip_rainbow_delta_deg', delta, save_to_eeprom);
                 });
             }

--- a/tabs/led_strip.js
+++ b/tabs/led_strip.js
@@ -1,11 +1,11 @@
 'use strict';
 
-import mspHelper from './../js/msp/MSPHelper';
-import MSPCodes from './../js/msp/MSPCodes';
-import MSP from './../js/msp';
-import GUI from './../js/gui';
-import FC from './../js/fc';
-import i18n from './../js/localization';
+import mspHelper from '../js/msp/MSPHelper.js';
+import MSPCodes from '../js/msp/MSPCodes.js';
+import MSP from '../js/msp.js';
+import GUI from '../js/gui.js';
+import FC from '../js/fc.js';
+import i18n from '../js/localization.js';
 import LED_STRIP_PRESETS from './led_strip_presets.js';
 
 const ledStripTab = {
@@ -22,7 +22,7 @@ ledStripTab.initialize = function (callback, scrollPosition) {
 
     ledStripTab.functions = ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b', 'l', 'o', 'n'];
     ledStripTab.baseFuncs = ['c', 'f', 'a', 'l', 's', 'g', 'r', 'h'];
-    ledStripTab.overlays = ['t', 'o', 'b', 'n', 'i', 'w', 'e'];
+    ledStripTab.overlays = ['t', 'o', 'b', 'n', 'i', 'w', 'e', 'v'];
 
     ledStripTab.wireMode = false;
 
@@ -219,6 +219,30 @@ ledStripTab.initialize = function (callback, scrollPosition) {
         }
 
        i18n.localize();;
+
+        function syncRainbowInputState() {
+            var rainbowActive = $('.toggle.function-v').prop('checked');
+            $('#rainbowFreqInput, #rainbowDeltaInput').prop('disabled', !rainbowActive).css('pointer-events', rainbowActive ? 'auto' : '');
+        }
+
+        mspHelper.getSetting('ledstrip_rainbow_freq_hz').then(function (result) {
+            console.log('[Rainbow] ledstrip_rainbow_freq_hz =', result);
+            if (result && result.value !== null && result.value !== undefined) {
+                $('#rainbowFreqInput').val(result.value);
+            }
+        }).catch(function (err) {
+            console.error('[Rainbow] getSetting ledstrip_rainbow_freq_hz FAILED:', err);
+        });
+        mspHelper.getSetting('ledstrip_rainbow_delta_deg').then(function (result) {
+            console.log('[Rainbow] ledstrip_rainbow_delta_deg =', result);
+            if (result && result.value !== null && result.value !== undefined) {
+                $('#rainbowDeltaInput').val(result.value);
+            }
+        }).catch(function (err) {
+            console.error('[Rainbow] getSetting ledstrip_rainbow_delta_deg FAILED:', err);
+        });
+
+        syncRainbowInputState();
 
         // Build Grid
         var theHTML = [];
@@ -603,6 +627,14 @@ ledStripTab.initialize = function (callback, scrollPosition) {
                 setColorSliders(selectedColorIndex);
 
                 setOptionalGroupsVisibility();
+                
+                var rainbowEnabled = !!$('.ui-selected').filter(function() {
+                    return $(this).is('.function-v');
+                }).length;
+                $('#rainbowFreqInput, #rainbowDeltaInput').prop('disabled', !rainbowEnabled).css('pointer-events', rainbowEnabled ? 'auto' : '');
+
+
+                updateBulkCmd();
 
                 $('.directions button').removeClass('btnOn');
                 directionsInSelection.forEach(function(direction_e) {
@@ -675,6 +707,10 @@ ledStripTab.initialize = function (callback, scrollPosition) {
                                     if (areOverlaysActive('function-' + f))
                                         p.addClass('function-' + letter);
                                     break;
+                                case 'v':
+                                    if (areOverlaysActive('function-' + f))
+                                        p.addClass('function-' + letter);
+                                    break;
                                 case 'w':
                                     if (areOverlaysActive('function-' + f))
                                         if (isWarningActive('function-' + f))
@@ -691,12 +727,13 @@ ledStripTab.initialize = function (callback, scrollPosition) {
             return $(that).is(':checked');
         }
 
-        // UI: check-box toggle
+                // UI: check-box toggle
         $('.checkbox').on('change', function(e) {
             if (e.originalEvent) {
                 // user-triggered event
-                saveUndoState();
                 var that = $(this).find('input');
+
+                saveUndoState();
                 if ($('.ui-selected').length > 0) {
 
                     ledStripTab.overlays.forEach(function(letter) {
@@ -723,6 +760,12 @@ ledStripTab.initialize = function (callback, scrollPosition) {
                     clearModeColorSelection();
                     updateBulkCmd();
                     setOptionalGroupsVisibility();
+                }
+
+                if ($(that).is('.function-v')) {
+                    var enabled = $(that).prop('checked');
+                    $('#rainbowFreqInput, #rainbowDeltaInput').prop('disabled', !enabled).css('pointer-events', enabled ? 'auto' : '');
+
                 }
             } else {
                 // code-triggered event
@@ -782,7 +825,16 @@ ledStripTab.initialize = function (callback, scrollPosition) {
             }
 
             function send_led_strip_mode_colors() {
-                mspHelper.sendLedStripModeColors(save_to_eeprom);
+                mspHelper.sendLedStripModeColors(save_rainbow_settings);
+            }
+
+            function save_rainbow_settings() {
+                var freq = parseInt($('#rainbowFreqInput').val(), 10);
+                var delta = parseInt($('#rainbowDeltaInput').val(), 10);
+
+                mspHelper.setSetting('ledstrip_rainbow_freq_hz', freq, function () {
+                    mspHelper.setSetting('ledstrip_rainbow_delta_deg', delta, save_to_eeprom);
+                });
             }
 
             function save_to_eeprom() {
@@ -1017,6 +1069,14 @@ ledStripTab.initialize = function (callback, scrollPosition) {
             $('.strobeOverlay').show();
         }
 
+        if (areOverlaysActive(activeFunction)) {
+            $('.rainbowOverlay').show();
+            $('#rainbowSettings').show();
+        } else {
+            $('.rainbowOverlay').hide();
+            $('#rainbowSettings').hide();
+        }
+        
         if (isWarningActive(activeFunction))
             $('.warningOverlay').show();
 


### PR DESCRIPTION
Adds GUI support for the new rainbow overlay ('V') introduced in the companion FC PR.

Changes:
- Adds rainbow overlay toggle to the overlays section
- Adds Rainbow Overlay Settings panel with sweep rate and colour delta inputs, enabled only when the rainbow overlay is active
- Registers 'V' in the overlay letters array in msp.js

Companion FC PR: https://github.com/iNavFlight/inav/pull/11816

Testing: Verified with SKYSTARSH743HD running the companion firmware build.