### PR TITLE
Fix/flasher msp lockup

### DIFF
--- a/js/connection/connection.js
+++ b/js/connection/connection.js
@@ -153,6 +153,18 @@ class Connection {
             });
         } else {
             this._openCanceled = true;
+
+            // The port can already be gone when disconnect() runs (FC rebooting into
+            // DFU, cable pulled). This connection object is a session-wide singleton,
+            // so without this it stays stuck with _transmitting true and every later
+            // send() only fills the buffer. Listener teardown is deliberately left to
+            // the branch above: the transports notify their error listeners after
+            // abort(), which lands here, and would then be talking to an empty list.
+            this.emptyOutputBuffer();
+
+            if (callback) {
+                callback(false);
+            }
         }
     }
     

--- a/js/connection/connection.js
+++ b/js/connection/connection.js
@@ -270,6 +270,65 @@ class Connection {
         });
     }
 
+    /*
+     * Bridge a transport's write promise onto sendImplementation()'s callback.
+     * send() advances its queue only from there, so every path has to report once.
+     * A null promise means there is no port left to write to.
+     */
+    completeSend(label, promise, callback) {
+        const report = (bytesSent, resultCode) => {
+            if (callback) {
+                callback({ bytesSent: bytesSent, resultCode: resultCode });
+            }
+        };
+
+        if (!promise) {
+            report(0, 1);
+            return;
+        }
+
+        promise.then(response => {
+            if (response.error) {
+                console.log(label + ' write error: ' + response.msg);
+                report(0, 1);
+            } else {
+                report(response.bytesWritten, 0);
+            }
+        }).catch(error => {
+            console.log(label + ' write failed: ' + error);
+            report(0, 1);
+        });
+    }
+
+    // Same for a transport's close promise - disconnect() has to hear back either way.
+    completeClose(label, promise, callback) {
+        if (!promise) {
+            if (callback) {
+                callback(false);
+            }
+            return;
+        }
+
+        promise.then(response => {
+            if (response.error) {
+                console.log('Unable to close ' + label + ': ' + response.msg);
+            }
+            if (callback) {
+                callback(!response.error);
+            }
+        }).catch(this.reportFailure('Unable to close ' + label, callback));
+    }
+
+    // Rejection handler that reports a failed transport call instead of losing its callback.
+    reportFailure(message, callback) {
+        return error => {
+            console.log(message + ': ' + error);
+            if (callback) {
+                callback(false);
+            }
+        };
+    }
+
     removeAllListeners() {
         this._onReceiveListeners.forEach(listener => this.removeOnReceiveCallback(listener));
         this._onReceiveListeners = [];

--- a/js/connection/connection.js
+++ b/js/connection/connection.js
@@ -154,12 +154,8 @@ class Connection {
         } else {
             this._openCanceled = true;
 
-            // The port can already be gone when disconnect() runs (FC rebooting into
-            // DFU, cable pulled). This connection object is a session-wide singleton,
-            // so without this it stays stuck with _transmitting true and every later
-            // send() only fills the buffer. Listener teardown is deliberately left to
-            // the branch above: the transports notify their error listeners after
-            // abort(), which lands here, and would then be talking to an empty list.
+            // Port already gone: without this the singleton stays stuck with _transmitting
+            // true. No listener teardown here - transports notify them after abort().
             this.emptyOutputBuffer();
 
             if (callback) {
@@ -252,11 +248,8 @@ class Connection {
         // Note: Don't call addOnReceiveErrorCallback here - it would duplicate the push
     }
 
-    /**
-     * Hand received data to every listener. A listener that throws must not abort
-     * the loop: the remaining listeners would never see this or any later chunk,
-     * and the exception would escape uncaught into the IPC handler.
-     */
+    // A throwing listener must not abort the loop - the rest would never see this
+    // or any later chunk, and the exception would escape into the IPC handler.
     notifyReceiveListeners(info) {
         this._onReceiveListeners.forEach(listener => {
             try {

--- a/js/connection/connection.js
+++ b/js/connection/connection.js
@@ -252,6 +252,31 @@ class Connection {
         // Note: Don't call addOnReceiveErrorCallback here - it would duplicate the push
     }
 
+    /**
+     * Hand received data to every listener. A listener that throws must not abort
+     * the loop: the remaining listeners would never see this or any later chunk,
+     * and the exception would escape uncaught into the IPC handler.
+     */
+    notifyReceiveListeners(info) {
+        this._onReceiveListeners.forEach(listener => {
+            try {
+                listener(info);
+            } catch (error) {
+                console.error('Receive listener threw:', error);
+            }
+        });
+    }
+
+    notifyReceiveErrorListeners(error) {
+        this._onReceiveErrorListeners.forEach(listener => {
+            try {
+                listener(error);
+            } catch (listenerError) {
+                console.error('Receive error listener threw:', listenerError);
+            }
+        });
+    }
+
     removeAllListeners() {
         this._onReceiveListeners.forEach(listener => this.removeOnReceiveCallback(listener));
         this._onReceiveListeners = [];

--- a/js/connection/connectionBle.js
+++ b/js/connection/connectionBle.js
@@ -206,9 +206,7 @@ class ConnectionBle extends Connection {
                         data: buffer
                     };
 
-                    this._onReceiveListeners.forEach(listener => {
-                        listener(info);
-                    });
+                    this.notifyReceiveListeners(info);
                 };
 
                 this._readCharacteristic.addEventListener('characteristicvaluechanged', this._handleOnCharateristicValueChanged)

--- a/js/connection/connectionSerial.js
+++ b/js/connection/connectionSerial.js
@@ -36,11 +36,9 @@ class ConnectionSerial extends Connection {
         }
 
         this._ipcDataHandler = window.electronAPI.onSerialData(buffer => {
-            this._onReceiveListeners.forEach(listener => {
-                listener({
-                    connectionId: this._connectionId,
-                    data: buffer
-                });
+            this.notifyReceiveListeners({
+                connectionId: this._connectionId,
+                data: buffer
             });
         });
 
@@ -54,9 +52,7 @@ class ConnectionSerial extends Connection {
             console.log(error);
             this.abort();
 
-            this._onReceiveErrorListeners.forEach(listener => {
-                listener(error);
-            });
+            this.notifyReceiveErrorListeners(error);
         });
     }
 

--- a/js/connection/connectionSerial.js
+++ b/js/connection/connectionSerial.js
@@ -87,49 +87,79 @@ class ConnectionSerial extends Connection {
                         bitrate: options.bitrate,
                         connectionId: this._connectionId
                     });
-                } 
+                }
             } else {
                 console.log("Serial connection error: " + response.msg);
                 if (callback) {
                     callback(false);
                 }
             }
+        }).catch(error => {
+            console.log("Serial connection failed: " + error);
+            if (callback) {
+                callback(false);
+            }
         });
     }
 
-    disconnectImplementation(callback) {   
+    disconnectImplementation(callback) {
         if (this._connectionId) {
             window.electronAPI.serialClose().then(response => {
                 var ok = true;
                 if (response.error) {
                     console.log("Unable to close serial: " + response.msg);
                     ok = false;
-                }            
+                }
                 if (callback) {
                     callback(ok);
                 }
-            });  
-        }  
-    }
-
-    sendImplementation(data, callback) {        
-        if (this._connectionId) {
-            window.electronAPI.serialSend(data).then(response => {
-                var result = 0;
-                var sent = response.bytesWritten;
-                if (response.error) {
-                    console.log("Serial write error: " + response.msg);
-                    result = 1;
-                    sent = 0;
-                }
+            }).catch(error => {
+                console.log("Unable to close serial: " + error);
                 if (callback) {
-                    callback({
-                        bytesSent: sent,
-                        resultCode: result
-                    });
+                    callback(false);
                 }
             });
+        } else if (callback) {
+            callback(false);
         }
+    }
+
+    sendImplementation(data, callback) {
+        // Connection.send() advances its output queue only from this callback, so
+        // every path has to fire it - a lost callback stalls the queue for good.
+        if (!this._connectionId) {
+            if (callback) {
+                callback({
+                    bytesSent: 0,
+                    resultCode: 1
+                });
+            }
+            return;
+        }
+
+        window.electronAPI.serialSend(data).then(response => {
+            var result = 0;
+            var sent = response.bytesWritten;
+            if (response.error) {
+                console.log("Serial write error: " + response.msg);
+                result = 1;
+                sent = 0;
+            }
+            if (callback) {
+                callback({
+                    bytesSent: sent,
+                    resultCode: result
+                });
+            }
+        }).catch(error => {
+            console.log("Serial write failed: " + error);
+            if (callback) {
+                callback({
+                    bytesSent: 0,
+                    resultCode: 1
+                });
+            }
+        });
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionSerial.js
+++ b/js/connection/connectionSerial.js
@@ -121,8 +121,7 @@ class ConnectionSerial extends Connection {
     }
 
     sendImplementation(data, callback) {
-        // Connection.send() advances its output queue only from this callback, so
-        // every path has to fire it - a lost callback stalls the queue for good.
+        // Connection.send() advances its queue only from this callback - never drop it.
         if (!this._connectionId) {
             if (callback) {
                 callback({

--- a/js/connection/connectionSerial.js
+++ b/js/connection/connectionSerial.js
@@ -90,71 +90,15 @@ class ConnectionSerial extends Connection {
                     callback(false);
                 }
             }
-        }).catch(error => {
-            console.log("Serial connection failed: " + error);
-            if (callback) {
-                callback(false);
-            }
-        });
+        }).catch(this.reportFailure("Serial connection failed", callback));
     }
 
     disconnectImplementation(callback) {
-        if (this._connectionId) {
-            window.electronAPI.serialClose().then(response => {
-                var ok = true;
-                if (response.error) {
-                    console.log("Unable to close serial: " + response.msg);
-                    ok = false;
-                }
-                if (callback) {
-                    callback(ok);
-                }
-            }).catch(error => {
-                console.log("Unable to close serial: " + error);
-                if (callback) {
-                    callback(false);
-                }
-            });
-        } else if (callback) {
-            callback(false);
-        }
+        this.completeClose('serial', this._connectionId ? window.electronAPI.serialClose() : null, callback);
     }
 
     sendImplementation(data, callback) {
-        // Connection.send() advances its queue only from this callback - never drop it.
-        if (!this._connectionId) {
-            if (callback) {
-                callback({
-                    bytesSent: 0,
-                    resultCode: 1
-                });
-            }
-            return;
-        }
-
-        window.electronAPI.serialSend(data).then(response => {
-            var result = 0;
-            var sent = response.bytesWritten;
-            if (response.error) {
-                console.log("Serial write error: " + response.msg);
-                result = 1;
-                sent = 0;
-            }
-            if (callback) {
-                callback({
-                    bytesSent: sent,
-                    resultCode: result
-                });
-            }
-        }).catch(error => {
-            console.log("Serial write failed: " + error);
-            if (callback) {
-                callback({
-                    bytesSent: 0,
-                    resultCode: 1
-                });
-            }
-        });
+        this.completeSend('Serial', this._connectionId ? window.electronAPI.serialSend(data) : null, callback);
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionTcp.js
+++ b/js/connection/connectionTcp.js
@@ -89,12 +89,7 @@ class ConnectionTcp extends Connection {
                     callback(false);
                 }
             }
-        }).catch(error => {
-            console.log("TCP connection failed: " + error);
-            if (callback) {
-                callback(false);
-            }
-        });
+        }).catch(this.reportFailure("TCP connection failed", callback));
     }
 
     disconnectImplementation(callback) {
@@ -111,41 +106,8 @@ class ConnectionTcp extends Connection {
        }
     }
 
-   sendImplementation(data, callback) {
-        // Connection.send() advances its queue only from this callback - never drop it.
-        if (!this._connectionId) {
-            if (callback) {
-                callback({
-                    bytesSent: 0,
-                    resultCode: 1
-                });
-            }
-            return;
-        }
-
-        window.electronAPI.tcpSend(data).then(response => {
-            var result = 0;
-            var sent = response.bytesWritten;
-            if (response.error) {
-                console.log("TCP write error: " + response.msg);
-                result = 1;
-                sent = 0;
-            }
-            if (callback) {
-                callback({
-                    bytesSent: sent,
-                    resultCode: result
-                });
-            }
-        }).catch(error => {
-            console.log("TCP write failed: " + error);
-            if (callback) {
-                callback({
-                    bytesSent: 0,
-                    resultCode: 1
-                });
-            }
-        });
+    sendImplementation(data, callback) {
+        this.completeSend('TCP', this._connectionId ? window.electronAPI.tcpSend(data) : null, callback);
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionTcp.js
+++ b/js/connection/connectionTcp.js
@@ -93,6 +93,11 @@ class ConnectionTcp extends Connection {
                     callback(false);
                 }
             }
+        }).catch(error => {
+            console.log("TCP connection failed: " + error);
+            if (callback) {
+                callback(false);
+            }
         });
     }
 
@@ -110,24 +115,42 @@ class ConnectionTcp extends Connection {
        }
     }
 
-   sendImplementation(data, callback) {     
-        if (this._connectionId) {
-            window.electronAPI.tcpSend(data).then(response => {
-                var result = 0;
-                var sent = response.bytesWritten;
-                if (response.error) {
-                    console.log("Serial write error: " + response.msg);
-                    result = 1;
-                    sent = 0;
-                }
-                if (callback) {
-                    callback({
-                        bytesSent: sent,
-                        resultCode: result
-                    });
-                }
-            });
+   sendImplementation(data, callback) {
+        // Connection.send() advances its output queue only from this callback, so
+        // every path has to fire it - a lost callback stalls the queue for good.
+        if (!this._connectionId) {
+            if (callback) {
+                callback({
+                    bytesSent: 0,
+                    resultCode: 1
+                });
+            }
+            return;
         }
+
+        window.electronAPI.tcpSend(data).then(response => {
+            var result = 0;
+            var sent = response.bytesWritten;
+            if (response.error) {
+                console.log("TCP write error: " + response.msg);
+                result = 1;
+                sent = 0;
+            }
+            if (callback) {
+                callback({
+                    bytesSent: sent,
+                    resultCode: result
+                });
+            }
+        }).catch(error => {
+            console.log("TCP write failed: " + error);
+            if (callback) {
+                callback({
+                    bytesSent: 0,
+                    resultCode: 1
+                });
+            }
+        });
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionTcp.js
+++ b/js/connection/connectionTcp.js
@@ -112,8 +112,7 @@ class ConnectionTcp extends Connection {
     }
 
    sendImplementation(data, callback) {
-        // Connection.send() advances its output queue only from this callback, so
-        // every path has to fire it - a lost callback stalls the queue for good.
+        // Connection.send() advances its queue only from this callback - never drop it.
         if (!this._connectionId) {
             if (callback) {
                 callback({

--- a/js/connection/connectionTcp.js
+++ b/js/connection/connectionTcp.js
@@ -27,11 +27,9 @@ class ConnectionTcp extends Connection {
         }
 
         this._ipcDataHandler = window.electronAPI.onTcpData(buffer => {
-            this._onReceiveListeners.forEach(listener => {
-                listener({
-                    connectionId: this._connectionId,
-                    data: buffer
-                });
+            this.notifyReceiveListeners({
+                connectionId: this._connectionId,
+                data: buffer
             });
         });
 
@@ -44,9 +42,7 @@ class ConnectionTcp extends Connection {
             GUI.log(error);
             console.log(error);
             this.abort();
-            this._onReceiveErrorListeners.forEach(listener => {
-                listener(error);
-            });
+            this.notifyReceiveErrorListeners(error);
         });
     }
 

--- a/js/connection/connectionUdp.js
+++ b/js/connection/connectionUdp.js
@@ -82,71 +82,15 @@ class ConnectionUdp extends Connection {
                     callback(false);
                 }
             }
-        }).catch(error => {
-            console.log("UDP connection failed: " + error);
-            if (callback) {
-                callback(false);
-            }
-        });
+        }).catch(this.reportFailure("UDP connection failed", callback));
     }
 
     disconnectImplementation(callback) {
-        if (this._connectionId) {
-            window.electronAPI.udpClose().then(response => {
-                var ok = true;
-                if (response.error) {
-                    console.log("Unable to close UDP: " + response.msg);
-                    ok = false;
-                }
-                if (callback) {
-                    callback(ok);
-                }
-            }).catch(error => {
-                console.log("Unable to close UDP: " + error);
-                if (callback) {
-                    callback(false);
-                }
-            });
-        } else if (callback) {
-            callback(false);
-        }
+        this.completeClose('UDP', this._connectionId ? window.electronAPI.udpClose() : null, callback);
     }
 
-   sendImplementation(data, callback) {
-        // Connection.send() advances its queue only from this callback - never drop it.
-        if (!this._connectionId) {
-            if (callback) {
-                callback({
-                    bytesSent: 0,
-                    resultCode: 1
-                });
-            }
-            return;
-        }
-
-        window.electronAPI.udpSend(data).then(response => {
-            var result = 0;
-            var sent = response.bytesWritten;
-            if (response.error) {
-                console.log("UDP write error: " + response.msg);
-                result = 1;
-                sent = 0;
-            }
-            if (callback) {
-                callback({
-                    bytesSent: sent,
-                    resultCode: result
-                });
-            }
-        }).catch(error => {
-            console.log("UDP write failed: " + error);
-            if (callback) {
-                callback({
-                    bytesSent: 0,
-                    resultCode: 1
-                });
-            }
-        });
+    sendImplementation(data, callback) {
+        this.completeSend('UDP', this._connectionId ? window.electronAPI.udpSend(data) : null, callback);
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionUdp.js
+++ b/js/connection/connectionUdp.js
@@ -29,11 +29,9 @@ class ConnectionUdp extends Connection {
         }
 
         this._ipcMessageHandler = window.electronAPI.onUdpMessage(message => {
-            this._onReceiveListeners.forEach(listener => {
-                listener({
-                    connectionId: this._connectionId,
-                    data: message
-                });
+            this.notifyReceiveListeners({
+                connectionId: this._connectionId,
+                data: message
             });
         });
 
@@ -41,9 +39,7 @@ class ConnectionUdp extends Connection {
             GUI.log(error);
             console.log(error);
             this.abort();
-            this._onReceiveErrorListeners.forEach(listener => {
-                listener(error);
-            });
+            this.notifyReceiveErrorListeners(error);
         });
     }
 

--- a/js/connection/connectionUdp.js
+++ b/js/connection/connectionUdp.js
@@ -86,6 +86,11 @@ class ConnectionUdp extends Connection {
                     callback(false);
                 }
             }
+        }).catch(error => {
+            console.log("UDP connection failed: " + error);
+            if (callback) {
+                callback(false);
+            }
         });
     }
 
@@ -96,32 +101,57 @@ class ConnectionUdp extends Connection {
                 if (response.error) {
                     console.log("Unable to close UDP: " + response.msg);
                     ok = false;
-                }            
+                }
                 if (callback) {
                     callback(ok);
                 }
-            });  
-        }  
-    }
-
-   sendImplementation(data, callback) {    
-        if (this._connectionId) {
-            window.electronAPI.udpSend(data).then(response => {
-                var result = 0;
-                var sent = response.bytesWritten;
-                if (response.error) {
-                    console.log("Serial write error: " + response.msg);
-                    result = 1;
-                    sent = 0;
-                }
+            }).catch(error => {
+                console.log("Unable to close UDP: " + error);
                 if (callback) {
-                    callback({
-                        bytesSent: sent,
-                        resultCode: result
-                    });
+                    callback(false);
                 }
             });
+        } else if (callback) {
+            callback(false);
         }
+    }
+
+   sendImplementation(data, callback) {
+        // Connection.send() advances its output queue only from this callback, so
+        // every path has to fire it - a lost callback stalls the queue for good.
+        if (!this._connectionId) {
+            if (callback) {
+                callback({
+                    bytesSent: 0,
+                    resultCode: 1
+                });
+            }
+            return;
+        }
+
+        window.electronAPI.udpSend(data).then(response => {
+            var result = 0;
+            var sent = response.bytesWritten;
+            if (response.error) {
+                console.log("UDP write error: " + response.msg);
+                result = 1;
+                sent = 0;
+            }
+            if (callback) {
+                callback({
+                    bytesSent: sent,
+                    resultCode: result
+                });
+            }
+        }).catch(error => {
+            console.log("UDP write failed: " + error);
+            if (callback) {
+                callback({
+                    bytesSent: 0,
+                    resultCode: 1
+                });
+            }
+        });
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionUdp.js
+++ b/js/connection/connectionUdp.js
@@ -113,8 +113,7 @@ class ConnectionUdp extends Connection {
     }
 
    sendImplementation(data, callback) {
-        // Connection.send() advances its output queue only from this callback, so
-        // every path has to fire it - a lost callback stalls the queue for good.
+        // Connection.send() advances its queue only from this callback - never drop it.
         if (!this._connectionId) {
             if (callback) {
                 callback({

--- a/js/msp.js
+++ b/js/msp.js
@@ -9,7 +9,7 @@ import CONFIGURATOR from './data_storage';
 // Every MSP code that changes something on the FC, recognised by name so a write
 // added later is covered without maintaining a list here.
 const WRITE_CODE_NAMES = Object.keys(MSPCodes)
-    .filter(name => /SET_|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
+    .filter(name => /(^|_)SET(_|$)|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
 
 // Writes carrying nothing read off the FC, so an unreadable response cannot poison
 // them. Refusing the live ones would be a hazard of its own.
@@ -42,7 +42,9 @@ for (const name of WRITE_CODE_NAMES) {
     if (ALWAYS_ALLOWED_WRITE_CODES.has(MSPCodes[name])) {
         continue;
     }
-    const sourceName = IRREGULAR_WRITE_SOURCES[name] || name.replace('SET_', '');
+    // MSP2_INAV_EZ_TUNE_SET names its write the other way round.
+    const sourceName = IRREGULAR_WRITE_SOURCES[name]
+        || (name.endsWith('_SET') ? name.slice(0, -4) : name.replace('SET_', ''));
     if (MSPCodes[sourceName] !== undefined && sourceName !== name) {
         WRITE_SOURCE_CODES.set(MSPCodes[name], MSPCodes[sourceName]);
     }
@@ -161,6 +163,24 @@ var MSP = {
         // Unpaired write: refuse rather than guess. Over-blocking costs a refused save,
         // under-blocking puts wrong values into the aircraft.
         return WRITE_CODES.has(code) ? this.parseFailures.values().next().value : false;
+    },
+
+    // Reports and refuses a write built from an unreadable response.
+    refuseBlockedWrite(code) {
+        const blockedBy = this.blockedWriteSource(code);
+        if (blockedBy === false) {
+            return false;
+        }
+
+        console.error('Refusing MSP write ' + this.getCodeName(code) + ': its source ' +
+            this.getCodeName(blockedBy) + ' could not be parsed this session');
+
+        // A silent refusal would be worse - the user would believe it was saved.
+        if (this.onConfigWriteBlocked) {
+            this.onConfigWriteBlocked(code, blockedBy);
+        }
+
+        return true;
     },
 
     init() {
@@ -381,21 +401,9 @@ var MSP = {
     },
 
     send_message(code, data, callback_sent, callback_msp, protocolVersion) {
-        const blockedBy = this.blockedWriteSource(code);
-        if (blockedBy !== false) {
-            console.error('Refusing MSP write ' + this.getCodeName(code) + ': its source ' +
-                this.getCodeName(blockedBy) + ' could not be parsed this session');
-
-            // A silent refusal would be worse - the user would believe it was saved.
-            if (this.onConfigWriteBlocked) {
-                this.onConfigWriteBlocked(code, blockedBy);
-            }
-
-            // Report failure rather than going quiet, or the caller's save chain hangs.
-            if (callback_msp) {
-                callback_msp(false);
-            }
-
+        // No callback on a refusal: save chains ignore its argument, so calling it
+        // would run the EEPROM write and reboot as if the settings had been stored.
+        if (this.refuseBlockedWrite(code)) {
             return false;
         }
 

--- a/js/msp.js
+++ b/js/msp.js
@@ -6,6 +6,50 @@ import eventFrequencyAnalyzer from './eventFrequencyAnalyzer';
 import timeout from './timeouts';
 import CONFIGURATOR from './data_storage';
 
+// Every MSP code that changes something on the FC, recognised by name so a write
+// added later is covered without maintaining a list here.
+const WRITE_CODE_NAMES = Object.keys(MSPCodes)
+    .filter(name => /SET_|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
+
+// Writes carrying nothing read off the FC, so an unreadable response cannot poison
+// them. Refusing the live ones would be a hazard of its own.
+const ALWAYS_ALLOWED_WRITE_NAMES = [
+    'MSP_SET_REBOOT',            // stores nothing; the user's way out of a bad session
+    'MSP_SET_MOTOR',             // stopMotors() stops a running motor test with this
+    'MSP_SET_RAW_RC', 'MSP_SET_RAW_GPS', 'MSP_SET_HEAD', 'MSP_SET_RTC',
+    'MSP_EEPROM_WRITE',          // persists what is already on the FC
+    'MSP_RESET_CONF', 'MSP_SET_RESET_CURR_PID',
+    'MSP_SELECT_SETTING', 'MSP2_INAV_SELECT_BATTERY_PROFILE', 'MSP2_INAV_SELECT_MIXER_PROFILE',
+    'MSP_WP_MISSION_SAVE', 'MSP_DATAFLASH_ERASE', 'MSP_OSD_CHAR_WRITE',
+    'MSP_SET_BOX',               // legacy, never sent by this Configurator
+];
+
+// Writes that do not pair with their read by name alone.
+const IRREGULAR_WRITE_SOURCES = {
+    MSP_SET_MODE_RANGE:            'MSP_MODE_RANGES',
+    MSP_SET_ADJUSTMENT_RANGE:      'MSP_ADJUSTMENT_RANGES',
+    MSP2_INAV_OSD_SET_LAYOUT_ITEM: 'MSP2_INAV_OSD_LAYOUTS',
+    MSP2_INAV_SET_GEOZONE_VERTICE: 'MSP2_INAV_GEOZONE_VERTEX',
+};
+
+const WRITE_CODES = new Set(WRITE_CODE_NAMES.map(name => MSPCodes[name]));
+const ALWAYS_ALLOWED_WRITE_CODES = new Set(ALWAYS_ALLOWED_WRITE_NAMES.map(name => MSPCodes[name]));
+
+// write -> the read whose parsed state it hands back, so an unreadable response
+// disables only the saves carrying its values instead of every save.
+const WRITE_SOURCE_CODES = new Map();
+for (const name of WRITE_CODE_NAMES) {
+    if (ALWAYS_ALLOWED_WRITE_CODES.has(MSPCodes[name])) {
+        continue;
+    }
+    const sourceName = IRREGULAR_WRITE_SOURCES[name] || name.replace('SET_', '');
+    if (MSPCodes[sourceName] !== undefined && sourceName !== name) {
+        WRITE_SOURCE_CODES.set(MSPCodes[name], MSPCodes[sourceName]);
+    }
+}
+
+const CODE_NAMES = new Map(Object.keys(MSPCodes).map(name => [MSPCodes[name], name]));
+
 /**
  *
  * @constructor
@@ -91,6 +135,33 @@ var MSP = {
     lastFrameReceivedMs: 0,
 
     processData: null,
+
+    // Reads whose response failed to parse this session. The FC state they fill is
+    // then part fresh and part stale, so the writes handing it back are refused.
+    parseFailures: new Set(),
+
+    // Set by MSPHelper; injected because gui.js already imports this module.
+    onConfigWriteBlocked: null,
+
+    getCodeName(code) {
+        return CODE_NAMES.get(code) || ('0x' + code.toString(16));
+    },
+
+    // Which unreadable response makes this write unsafe, or false if it is safe.
+    blockedWriteSource(code) {
+        if (this.parseFailures.size === 0 || ALWAYS_ALLOWED_WRITE_CODES.has(code)) {
+            return false;
+        }
+
+        const source = WRITE_SOURCE_CODES.get(code);
+        if (source !== undefined) {
+            return this.parseFailures.has(source) ? source : false;
+        }
+
+        // Unpaired write: refuse rather than guess. Over-blocking costs a refused save,
+        // under-blocking puts wrong values into the aircraft.
+        return WRITE_CODES.has(code) ? this.parseFailures.values().next().value : false;
+    },
 
     init() {
         mspQueue.setPutCallback(this.putCallback);
@@ -276,8 +347,7 @@ var MSP = {
             }
         } finally {
             /*
-             * Free port - processData is a pluggable callback, so releasing the lock
-             * cannot depend on it returning normally.
+             * Free port - processData is pluggable, so this cannot depend on it returning.
              */
             timeout.add('delayedFreeHardLock', function() {
                 mspQueue.freeHardLock();
@@ -311,6 +381,24 @@ var MSP = {
     },
 
     send_message(code, data, callback_sent, callback_msp, protocolVersion) {
+        const blockedBy = this.blockedWriteSource(code);
+        if (blockedBy !== false) {
+            console.error('Refusing MSP write ' + this.getCodeName(code) + ': its source ' +
+                this.getCodeName(blockedBy) + ' could not be parsed this session');
+
+            // A silent refusal would be worse - the user would believe it was saved.
+            if (this.onConfigWriteBlocked) {
+                this.onConfigWriteBlocked(code, blockedBy);
+            }
+
+            // Report failure rather than going quiet, or the caller's save chain hangs.
+            if (callback_msp) {
+                callback_msp(false);
+            }
+
+            return false;
+        }
+
         var payloadLength = data && data.length ? data.length : 0;
         var length;
         var buffer;
@@ -444,6 +532,7 @@ var MSP = {
     disconnect_cleanup() {
         this.state = 0; // reset packet state for "clean" initial entry (this is only required if user hot-disconnects)
         this.packet_error = 0; // reset CRC packet error counter for next session
+        this.parseFailures.clear(); // the next session re-reads everything from scratch
 
         this.callbacks_cleanup();
     },

--- a/js/msp.js
+++ b/js/msp.js
@@ -274,14 +274,15 @@ var MSP = {
                 this.packet_error++;
                 $('span.packet-error').html(this.packet_error);
             }
-
+        } finally {
             /*
-             * Free port
+             * Free port - processData is a pluggable callback, so releasing the lock
+             * cannot depend on it returning normally.
              */
             timeout.add('delayedFreeHardLock', function() {
                 mspQueue.freeHardLock();
             }, 10);
-        } finally {
+
             // Reset variables - MUST happen even if an exception occurred
             this.message_length_received = 0;
             this.state = this.decoder_states.IDLE;

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -4,6 +4,7 @@ import semver from 'semver';
 
 import './../injected_methods';
 import GUI from './../gui';
+import i18n from './../localization';
 import MSP from './../msp';
 import MSPCodes from './MSPCodes';
 import FC from './../fc';
@@ -54,8 +55,20 @@ var mspHelper = (function () {
     // always finish with a '\0'.
     var debugMsgBuffer = '';
 
+    var lastWriteBlockedNotice = 0;
+
     self.init = function() {
         MSP.setProcessData(this.processData);
+
+        MSP.onConfigWriteBlocked = function (code, sourceCode) {
+            // One notice per save burst - a save fans out into many writes.
+            const now = Date.now();
+            if (now - lastWriteBlockedNotice < 3000) {
+                return;
+            }
+            lastWriteBlockedNotice = now;
+            GUI.log(i18n.getMessage('mspWriteBlockedAfterParseFailure', [MSP.getCodeName(sourceCode)]));
+        };
     }
 
     /**
@@ -68,12 +81,15 @@ var mspHelper = (function () {
         try {
             parseMessage(dataHandler, data);
         } catch (error) {
-            // Completing the request below has to happen regardless. A payload this
-            // Configurator cannot parse (FC built from a different branch, fields
-            // added or removed) would otherwise leave the request pending forever:
-            // whatever tab is waiting on it never finishes loading and the GUI stays
-            // stuck mid tab-switch until the user disconnects.
+            // Completing the request below must happen anyway, or the tab waiting on it
+            // never finishes loading and the GUI stays stuck mid tab-switch.
             console.error('Failed to parse MSP code 0x' + dataHandler.code.toString(16) + ':', error);
+
+            // Half this message landed in FC state - refuse the writes handing it back.
+            if (!MSP.parseFailures.has(dataHandler.code)) {
+                MSP.parseFailures.add(dataHandler.code);
+                GUI.log(i18n.getMessage('mspResponseUnreadable', [MSP.getCodeName(dataHandler.code)]));
+            }
         }
 
         completeRequest(dataHandler, data);
@@ -335,10 +351,8 @@ var mspHelper = (function () {
             case MSPCodes.MSP2_PID:
                 // PID data arrived, we need to scale it and save to appropriate bank / array
                 for (let i = 0, needle = 0; i < (dataHandler.message_length_expected / 4); i++, needle += 4) {
-                    // A newer FC reports more banks than this Configurator knows about.
-                    // Keep them instead of writing past the array: MSP2_SET_PID is only
-                    // accepted at the FC's exact bank count, so dropping them would make
-                    // every PID save fail silently.
+                    // A newer FC reports more banks than we know. Keep them rather than
+                    // write past the array - MSP2_SET_PID needs the FC's exact count.
                     if (!FC.PIDs[i]) {
                         FC.PIDs[i] = new Array(4);
                     }

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -63,8 +63,24 @@ var mspHelper = (function () {
      * @param {MSP} dataHandler
      */
     self.processData = function (dataHandler) {
-        var data = new DataView(dataHandler.message_buffer, 0), // DataView (allowing us to view arrayBuffer as struct/union)
-            offset = 0,
+        var data = new DataView(dataHandler.message_buffer, 0); // DataView (allowing us to view arrayBuffer as struct/union)
+
+        try {
+            parseMessage(dataHandler, data);
+        } catch (error) {
+            // Completing the request below has to happen regardless. A payload this
+            // Configurator cannot parse (FC built from a different branch, fields
+            // added or removed) would otherwise leave the request pending forever:
+            // whatever tab is waiting on it never finishes loading and the GUI stays
+            // stuck mid tab-switch until the user disconnects.
+            console.error('Failed to parse MSP code 0x' + dataHandler.code.toString(16) + ':', error);
+        }
+
+        completeRequest(dataHandler, data);
+    };
+
+    var parseMessage = function (dataHandler, data) {
+        var offset = 0,
             needle = 0,
             i = 0,
             buff = [],
@@ -319,6 +335,13 @@ var mspHelper = (function () {
             case MSPCodes.MSP2_PID:
                 // PID data arrived, we need to scale it and save to appropriate bank / array
                 for (let i = 0, needle = 0; i < (dataHandler.message_length_expected / 4); i++, needle += 4) {
+                    // A newer FC reports more banks than this Configurator knows about.
+                    // Keep them instead of writing past the array: MSP2_SET_PID is only
+                    // accepted at the FC's exact bank count, so dropping them would make
+                    // every PID save fail silently.
+                    if (!FC.PIDs[i]) {
+                        FC.PIDs[i] = new Array(4);
+                    }
                     FC.PIDs[i][0] = data.getUint8(needle);
                     FC.PIDs[i][1] = data.getUint8(needle + 1);
                     FC.PIDs[i][2] = data.getUint8(needle + 2);
@@ -1711,7 +1734,9 @@ var mspHelper = (function () {
         } else {
             console.log('FC reports unsupported message error: 0x' + dataHandler.code.toString(16));
         }
+    };
 
+    var completeRequest = function (dataHandler, data) {
         // trigger callbacks, cleanup/remove callback after trigger
         for (let i = dataHandler.callbacks.length - 1; i >= 0; i--) { // iterating in reverse because we use .splice which modifies array length
             if (i < dataHandler.callbacks.length) {

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -58,7 +58,7 @@ var mspHelper = (function () {
     var lastWriteBlockedNotice = 0;
 
     self.init = function() {
-        MSP.setProcessData(this.processData);
+        MSP.setProcessData(this.handleResponse);
 
         MSP.onConfigWriteBlocked = function (code, sourceCode) {
             // One notice per save burst - a save fans out into many writes.
@@ -72,17 +72,14 @@ var mspHelper = (function () {
     }
 
     /**
-     *
+     * MSP response entry point. Completing the request must happen even when a
+     * parser case throws, or the tab waiting on it never finishes loading.
      * @param {MSP} dataHandler
      */
-    self.processData = function (dataHandler) {
-        var data = new DataView(dataHandler.message_buffer, 0); // DataView (allowing us to view arrayBuffer as struct/union)
-
+    self.handleResponse = function (dataHandler) {
         try {
-            parseMessage(dataHandler, data);
+            self.processData(dataHandler);
         } catch (error) {
-            // Completing the request below must happen anyway, or the tab waiting on it
-            // never finishes loading and the GUI stays stuck mid tab-switch.
             console.error('Failed to parse MSP code 0x' + dataHandler.code.toString(16) + ':', error);
 
             // Half this message landed in FC state - refuse the writes handing it back.
@@ -92,11 +89,16 @@ var mspHelper = (function () {
             }
         }
 
-        completeRequest(dataHandler, data);
+        completeRequest(dataHandler, new DataView(dataHandler.message_buffer, 0));
     };
 
-    var parseMessage = function (dataHandler, data) {
-        var offset = 0,
+    /**
+     *
+     * @param {MSP} dataHandler
+     */
+    self.processData = function (dataHandler) {
+        var data = new DataView(dataHandler.message_buffer, 0), // DataView (allowing us to view arrayBuffer as struct/union)
+            offset = 0,
             needle = 0,
             i = 0,
             buff = [],

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5769,6 +5769,12 @@
     "illegalStateRestartRequired": {
         "message": "Illegal state. Restart required."
     },
+    "mspResponseUnreadable": {
+        "message": "The flight controller's $1 response could not be read. The values it carries may be incomplete, so <span style=\"color: red\">saving them has been disabled</span> to prevent writing wrong settings to the aircraft. Settings that do not use this data are unaffected. Reconnect to try again."
+    },
+    "mspWriteBlockedAfterParseFailure": {
+        "message": "<span style=\"color: red\">Not saved.</span> These settings come from the flight controller's $1 response, which could not be read this session, so writing them back is refused. Reconnect to try again."
+    },
     "motor_direction_inverted": {
         "message": "Normal motor direction / Props-in configuration"
     },

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -807,6 +807,14 @@ firmwareFlasherTab.initialize = function (callback) {
                 var mspListener = function(info) { MSP.read(info); };
                 CONFIGURATOR.connection.addOnReceiveCallback(mspListener);
 
+                // FC.CONFIG is null until the first normal connect calls resetState(),
+                // and going straight to the flasher after startup skips that - the
+                // MSP_FC_VERSION handler would throw on write. Only seed it when it is
+                // missing, so an already cached version survives for the timeout path.
+                if (!FC.CONFIG) {
+                    FC.resetState();
+                }
+
                 var versionQueryDone = false;
                 var versionQueryTimeout = setTimeout(function() {
                     if (!versionQueryDone) {

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -807,10 +807,8 @@ firmwareFlasherTab.initialize = function (callback) {
                 var mspListener = function(info) { MSP.read(info); };
                 CONFIGURATOR.connection.addOnReceiveCallback(mspListener);
 
-                // FC.CONFIG is null until the first normal connect calls resetState(),
-                // and going straight to the flasher after startup skips that - the
-                // MSP_FC_VERSION handler would throw on write. Only seed it when it is
-                // missing, so an already cached version survives for the timeout path.
+                // FC.CONFIG is null until the first connect calls resetState(). Guarded on
+                // !FC.CONFIG so a cached version survives for the query's timeout path.
                 if (!FC.CONFIG) {
                     FC.resetState();
                 }

--- a/tests/connection-receive-listener-isolation.test.mjs
+++ b/tests/connection-receive-listener-isolation.test.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * Regression test for the receive chain being killed by one throwing listener.
+ *
+ * Bug: every transport dispatched incoming data with a bare
+ * `this._onReceiveListeners.forEach(listener => listener(info))`. A listener
+ * that throws aborts the whole forEach, so every listener registered after it
+ * never sees that chunk - or any later one - and the exception escapes uncaught
+ * into the IPC handler.
+ *
+ * Observed as: opening the firmware flasher right after startup and running a
+ * pre-flash backup died on `Cannot set properties of null (setting
+ * 'flightControllerVersion')` (FC.CONFIG is null until the first normal connect
+ * calls FC.resetState()). That throw happened inside the dispatch loop, so
+ * MSP.read() never processed the response, the flasher waited forever for an
+ * answer and GUI.connect_lock stayed true - the app soft-locked.
+ *
+ * Fix under test: Connection.notifyReceiveListeners() /
+ * notifyReceiveErrorListeners() wrap each listener call in try/catch, and all
+ * four transports dispatch through them. (The FC.CONFIG null itself is fixed
+ * separately in tabs/firmware_flasher.js - see tests/firmware-flasher.test.mjs.)
+ *
+ * The test executes the REAL production files. This codebase uses Vite-style
+ * extensionless relative imports which plain Node's ESM resolver refuses to
+ * load, so - like tests/cli-tab-msp-polling.test.mjs - the sources are read
+ * fresh off disk and only their *import specifiers* are rewritten (GUI and i18n
+ * to inert stubs, './connection' to the rewritten base class). No statement,
+ * expression or ordering inside the code under test is touched.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'connection-receive-listener-'));
+process.on('exit', () => rmSync(tmpDir, { recursive: true, force: true }));
+
+function dataModule(code) {
+    // encodeURIComponent leaves ' ( ) ! * unescaped; the generated specifiers are
+    // embedded in single-quoted string literals, so escape those too.
+    const encoded = encodeURIComponent(code).replace(/['()!*]/g, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+    return 'data:text/javascript,' + encoded;
+}
+
+const mockGuiUrl = dataModule(`
+    const GUI = { connected_to: false, connecting_to: false, log() {} };
+    export default GUI;
+`);
+
+const mockI18nUrl = dataModule(`
+    const i18n = { getMessage(key) { return key; } };
+    export default i18n;
+`);
+
+/**
+ * Rewrite the listed import specifiers in a real source file and write the
+ * result to a temp module. Throws loudly if a pattern stops matching, so a
+ * future reshuffle of those imports fails the test instead of passing
+ * vacuously.
+ */
+function rewriteAndWrite(relSrcPath, rules, outNamePrefix) {
+    let source = readFileSync(join(repoRoot, relSrcPath), 'utf8');
+    for (const [regex, replacement, label] of rules) {
+        if (!regex.test(source)) {
+            throw new Error(
+                `connection-receive-listener-isolation.test.mjs: expected to find and replace "${label}" in ` +
+                `${relSrcPath} but the pattern ${regex} did not match. Update the test's substitution rules.`
+            );
+        }
+        source = source.replace(regex, replacement);
+    }
+    const outPath = join(tmpDir, `${outNamePrefix}.mjs`);
+    writeFileSync(outPath, source, 'utf8');
+    return pathToFileURL(outPath).href;
+}
+
+const realConnectionUrl = rewriteAndWrite('js/connection/connection.js', [
+    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${mockGuiUrl}';`, "import GUI"],
+], 'connection-generated');
+
+const realConnectionSerialUrl = rewriteAndWrite('js/connection/connectionSerial.js', [
+    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${mockGuiUrl}';`, "import GUI"],
+    [/^import \{ ConnectionType, Connection \} from '\.\/connection';$/m, `import { ConnectionType, Connection } from '${realConnectionUrl}';`, "import Connection"],
+    [/^import i18n from '\.\/\.\.\/localization';$/m, `import i18n from '${mockI18nUrl}';`, "import i18n"],
+], 'connectionSerial-generated');
+
+const { default: ConnectionSerial } = await import(realConnectionSerialUrl);
+
+/**
+ * Minimal window.electronAPI stand-in. The on* hooks hand the registered
+ * handler straight back, so registerIpcListeners() parks the real dispatch
+ * closure in _ipcDataHandler / _ipcErrorHandler and the tests can fire it the
+ * way the IPC bridge would.
+ */
+function installElectronApiStub() {
+    global.window = {
+        electronAPI: {
+            onSerialData: (handler) => handler,
+            onSerialClose: (handler) => handler,
+            onSerialError: (handler) => handler,
+            offSerialData: () => {},
+            offSerialClose: () => {},
+            offSerialError: () => {},
+        }
+    };
+}
+
+/** console.error is noise here - the fix logs every swallowed listener error. */
+function silenceConsoleError(t) {
+    const original = console.error;
+    console.error = () => {};
+    t.after(() => { console.error = original; });
+}
+
+test('a throwing receive listener must not cut off the listeners behind it', (t) => {
+    installElectronApiStub();
+    silenceConsoleError(t);
+
+    const connection = new ConnectionSerial();
+    connection.registerIpcListeners();
+
+    const seen = { before: 0, after: 0 };
+    connection.addOnReceiveListener(() => { seen.before++; });
+    connection.addOnReceiveListener(() => {
+        // Exactly what the flasher hit: FC.CONFIG was null.
+        throw new TypeError("Cannot set properties of null (setting 'flightControllerVersion')");
+    });
+    connection.addOnReceiveListener(() => { seen.after++; });
+
+    assert.doesNotThrow(
+        () => connection._ipcDataHandler(new Uint8Array([1, 2, 3]).buffer),
+        'the exception must not escape into the IPC handler'
+    );
+
+    assert.equal(seen.before, 1);
+    assert.equal(seen.after, 1, 'listeners registered after the throwing one must still receive the chunk');
+
+    // The chain has to survive for every following chunk too, not just this one.
+    connection._ipcDataHandler(new Uint8Array([4, 5, 6]).buffer);
+    assert.equal(seen.before, 2);
+    assert.equal(seen.after, 2, 'the chain must stay intact for later chunks');
+});
+
+test('a throwing receive-error listener must not cut off the listeners behind it', (t) => {
+    installElectronApiStub();
+    silenceConsoleError(t);
+
+    const connection = new ConnectionSerial();
+    connection.registerIpcListeners();
+
+    const seen = { before: 0, after: 0 };
+    connection.addOnReceiveErrorListener(() => { seen.before++; });
+    connection.addOnReceiveErrorListener(() => { throw new Error('bad error handler'); });
+    connection.addOnReceiveErrorListener(() => { seen.after++; });
+
+    assert.doesNotThrow(
+        () => connection._ipcErrorHandler('port disappeared'),
+        'the exception must not escape into the IPC error handler'
+    );
+
+    assert.equal(seen.before, 1);
+    assert.equal(seen.after, 1, 'error listeners registered after the throwing one must still be notified');
+});
+
+test('positive control: data reaches every listener in registration order', () => {
+    installElectronApiStub();
+
+    const connection = new ConnectionSerial();
+    connection._connectionId = 7;
+    connection.registerIpcListeners();
+
+    const order = [];
+    connection.addOnReceiveListener((info) => order.push(['first', info]));
+    connection.addOnReceiveListener((info) => order.push(['second', info]));
+
+    const buffer = new Uint8Array([9]).buffer;
+    connection._ipcDataHandler(buffer);
+
+    assert.deepEqual(order.map(([name]) => name), ['first', 'second']);
+    assert.equal(order[0][1].data, buffer, 'the received buffer must be passed through unchanged');
+    assert.equal(order[0][1].connectionId, 7, 'the connection id must still be reported');
+});

--- a/tests/connection-send-queue.test.mjs
+++ b/tests/connection-send-queue.test.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for the permanently stalled output queue.
+ *
+ * Bug: js/connection/connection.js's send() drives its output buffer purely
+ * from the callback handed to sendImplementation() - that callback is what
+ * shifts the sent entry off the buffer and resets _transmitting. In
+ * js/connection/connectionSerial.js the callback was only reachable inside
+ * `if (this._connectionId)`, and none of the three electronAPI promises
+ * (serialConnect / serialSend / serialClose) had a .catch(). When the port
+ * disappears (FC rebooting into DFU, cable pulled, port busy during USB
+ * re-enumeration) the callback is lost, _transmitting stays true forever and
+ * every later send() only pushes into the buffer and returns.
+ *
+ * Because CONFIGURATOR.connection is a session-wide singleton
+ * (connectionFactory hands back the same instance per type), the object stays
+ * wedged for the rest of the app's lifetime. disconnect() could not heal it
+ * either: emptyOutputBuffer() - the only place resetting _transmitting - sat
+ * inside the very `if (this._connectionId)` branch that is false in exactly
+ * this situation.
+ *
+ * Fix under test:
+ *   - sendImplementation()/disconnectImplementation() fire their callback on
+ *     every path, including when there is no port
+ *   - .catch() on all three electronAPI promises
+ *   - Connection.disconnect()'s else branch performs the same cleanup
+ *
+ * The tests below execute the REAL production files. Both use this codebase's
+ * Vite-style extensionless relative imports, which plain Node's ESM resolver
+ * refuses to load, so - like tests/cli-tab-msp-polling.test.mjs - the sources
+ * are read fresh off disk and only their *import specifiers* are rewritten
+ * (GUI and i18n to inert stubs, './connection' to the rewritten base class).
+ * No statement, expression or ordering inside the code under test is touched.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'connection-send-queue-'));
+process.on('exit', () => rmSync(tmpDir, { recursive: true, force: true }));
+
+function dataModule(code) {
+    // encodeURIComponent leaves ' ( ) ! * unescaped; the generated specifiers are
+    // embedded in single-quoted string literals, so escape those too.
+    const encoded = encodeURIComponent(code).replace(/['()!*]/g, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+    return 'data:text/javascript,' + encoded;
+}
+
+const mockGuiUrl = dataModule(`
+    const GUI = { connected_to: false, connecting_to: false, log() {} };
+    export default GUI;
+`);
+
+const mockI18nUrl = dataModule(`
+    const i18n = { getMessage(key) { return key; } };
+    export default i18n;
+`);
+
+/**
+ * Rewrite the listed import specifiers in a real source file and write the
+ * result to a temp module. Throws loudly if a pattern stops matching, so a
+ * future reshuffle of those imports fails the test instead of passing
+ * vacuously.
+ */
+function rewriteAndWrite(relSrcPath, rules, outNamePrefix) {
+    let source = readFileSync(join(repoRoot, relSrcPath), 'utf8');
+    for (const [regex, replacement, label] of rules) {
+        if (!regex.test(source)) {
+            throw new Error(
+                `connection-send-queue.test.mjs: expected to find and replace "${label}" in ${relSrcPath} ` +
+                `but the pattern ${regex} did not match. Update the test's substitution rules.`
+            );
+        }
+        source = source.replace(regex, replacement);
+    }
+    const outPath = join(tmpDir, `${outNamePrefix}.mjs`);
+    writeFileSync(outPath, source, 'utf8');
+    return pathToFileURL(outPath).href;
+}
+
+const realConnectionUrl = rewriteAndWrite('js/connection/connection.js', [
+    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${mockGuiUrl}';`, "import GUI"],
+], 'connection-generated');
+
+const realConnectionSerialUrl = rewriteAndWrite('js/connection/connectionSerial.js', [
+    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${mockGuiUrl}';`, "import GUI"],
+    [/^import \{ ConnectionType, Connection \} from '\.\/connection';$/m, `import { ConnectionType, Connection } from '${realConnectionUrl}';`, "import Connection"],
+    [/^import i18n from '\.\/\.\.\/localization';$/m, `import i18n from '${mockI18nUrl}';`, "import i18n"],
+], 'connectionSerial-generated');
+
+const { default: ConnectionSerial } = await import(realConnectionSerialUrl);
+
+/**
+ * Minimal window.electronAPI stand-in. `behavior` decides what serialSend does,
+ * so each test can model a healthy port, a rejected IPC promise or a port that
+ * vanished mid-session.
+ */
+function installElectronApiStub(behavior) {
+    const calls = { send: 0, close: 0 };
+    global.window = {
+        electronAPI: {
+            serialConnect: () => Promise.resolve({ error: false, id: 1 }),
+            serialSend: (data) => {
+                calls.send++;
+                return behavior.send(data);
+            },
+            serialClose: () => {
+                calls.close++;
+                return behavior.close ? behavior.close() : Promise.resolve({ error: false });
+            },
+            onSerialData: (handler) => handler,
+            onSerialClose: (handler) => handler,
+            onSerialError: (handler) => handler,
+            offSerialData: () => {},
+            offSerialClose: () => {},
+            offSerialError: () => {},
+        }
+    };
+    return calls;
+}
+
+const payload = new Uint8Array([1, 2, 3]).buffer;
+
+/** Let the promise chains inside sendImplementation settle. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+test('send() completes instead of wedging the queue when there is no port', async () => {
+    installElectronApiStub({ send: () => Promise.resolve({ error: false, bytesWritten: 3 }) });
+
+    const connection = new ConnectionSerial();
+    // _connectionId is 0 out of the constructor: the port vanished (or was never
+    // opened) while the app still holds this singleton.
+    let sendInfo = null;
+    connection.send(payload, (info) => { sendInfo = info; });
+    await settle();
+
+    assert.notEqual(sendInfo, null, 'send() callback must fire even without a port');
+    assert.equal(sendInfo.resultCode, 1, 'a portless send must report failure');
+    assert.equal(sendInfo.bytesSent, 0);
+    assert.equal(connection._transmitting, false, '_transmitting must not stay stuck after a portless send');
+    assert.equal(connection._outputBuffer.length, 0, 'the failed entry must be shifted off the buffer');
+});
+
+test('a rejected serialSend promise must not stall the queue', async () => {
+    installElectronApiStub({ send: () => Promise.reject(new Error('port closed')) });
+
+    const connection = new ConnectionSerial();
+    connection._connectionId = 1;
+
+    let sendInfo = null;
+    connection.send(payload, (info) => { sendInfo = info; });
+    await settle();
+
+    assert.notEqual(sendInfo, null, 'send() callback must fire when the IPC promise rejects');
+    assert.equal(sendInfo.resultCode, 1);
+    assert.equal(connection._transmitting, false, '_transmitting must not stay stuck after a rejected send');
+    assert.equal(connection._outputBuffer.length, 0);
+});
+
+test('the queue keeps draining after the port disappears mid-session', async () => {
+    // First write succeeds, then the port is gone - the exact flash sequence that
+    // used to leave the singleton unusable until the app was restarted.
+    const calls = installElectronApiStub({
+        send: () => Promise.resolve({ error: false, bytesWritten: 3 })
+    });
+
+    const connection = new ConnectionSerial();
+    connection._connectionId = 1;
+
+    let firstInfo = null;
+    connection.send(payload, (info) => { firstInfo = info; });
+    await settle();
+    assert.equal(firstInfo.resultCode, 0, 'sanity: the first write goes out normally');
+
+    connection._connectionId = 0;
+
+    const results = [];
+    connection.send(payload, (info) => results.push(info));
+    connection.send(payload, (info) => results.push(info));
+    await settle();
+
+    assert.equal(results.length, 2, 'every queued write must resolve, not pile up behind a stuck flag');
+    assert.equal(connection._transmitting, false);
+    assert.equal(connection._outputBuffer.length, 0);
+    assert.equal(calls.send, 1, 'no write should be attempted once the port is gone');
+});
+
+test('disconnect() without a port clears the stuck state and fires its callback', async () => {
+    installElectronApiStub({ send: () => Promise.resolve({ error: false, bytesWritten: 3 }) });
+
+    const connection = new ConnectionSerial();
+    connection.registerIpcListeners();
+
+    // Reproduce the wedged singleton the old code left behind.
+    connection._connectionId = false;
+    connection._transmitting = true;
+    connection._outputBuffer = [{ data: payload, callback: null }];
+    connection.addOnReceiveListener(() => {});
+
+    let result = 'not called';
+    connection.disconnect((res) => { result = res; });
+
+    assert.notEqual(result, 'not called', 'disconnect() must fire its callback when there is no port');
+    assert.equal(connection._transmitting, false, 'disconnect() must reset _transmitting');
+    assert.equal(connection._outputBuffer.length, 0, 'disconnect() must drop queued output');
+    // The transports call abort() - which lands here - before notifying their error
+    // listeners, so this path must not tear the listener lists down.
+    assert.equal(connection._onReceiveListeners.length, 1, 'a portless disconnect must leave listener registration alone');
+
+    // ... and the healed object is usable again.
+    connection._connectionId = 1;
+    let sendInfo = null;
+    connection.send(payload, (info) => { sendInfo = info; });
+    await settle();
+    assert.equal(sendInfo.resultCode, 0, 'the connection must be reusable after a portless disconnect');
+});
+
+test('positive control: a healthy port still reports its written bytes', async () => {
+    const calls = installElectronApiStub({ send: () => Promise.resolve({ error: false, bytesWritten: 3 }) });
+
+    const connection = new ConnectionSerial();
+    connection._connectionId = 1;
+
+    let sendInfo = null;
+    connection.send(payload, (info) => { sendInfo = info; });
+    await settle();
+
+    assert.equal(calls.send, 1);
+    assert.equal(sendInfo.resultCode, 0);
+    assert.equal(sendInfo.bytesSent, 3);
+    assert.equal(connection._bytesSent, 3, 'byte statistics must still be tracked');
+    assert.equal(connection._transmitting, false);
+});
+
+test('disconnect() with a live port still reports the close result', async () => {
+    installElectronApiStub({
+        send: () => Promise.resolve({ error: false, bytesWritten: 3 }),
+        close: () => Promise.resolve({ error: false }),
+    });
+
+    const connection = new ConnectionSerial();
+    connection._connectionId = 1;
+
+    const result = await new Promise((r) => connection.disconnect(r));
+    assert.equal(result, true, 'a successful close must still report true');
+    assert.equal(connection._connectionId, false);
+});
+
+test('a rejected serialClose promise must still fire the disconnect callback', async () => {
+    installElectronApiStub({
+        send: () => Promise.resolve({ error: false, bytesWritten: 3 }),
+        close: () => Promise.reject(new Error('port already gone')),
+    });
+
+    const connection = new ConnectionSerial();
+    connection._connectionId = 1;
+
+    const result = await new Promise((r) => connection.disconnect(r));
+    assert.equal(result, false, 'a failed close must report false rather than hang');
+    assert.equal(connection._connectionId, false);
+});

--- a/tests/firmware-flasher.test.mjs
+++ b/tests/firmware-flasher.test.mjs
@@ -5,6 +5,8 @@
  *   Bug 1 — buildMigrationChain used range comparison instead of chain-walk
  *   Bug 2 — lastAutoBackup not cleared at the start of proceedWithFlash
  *   Bug 3 — _enterCli left its receive callback registered after resolving
+ * plus:
+ *   Bug 4 — restore's MSP version query ran against a null FC.CONFIG
  */
 
 import { test, describe } from 'node:test';
@@ -113,5 +115,42 @@ describe('_enterCli removes and nulls callback before resolving', () => {
         assert.notEqual(resolveIdx, -1, '_enterCli must call resolve()');
         assert.ok(removeIdx  < resolveIdx, 'removeOnReceiveCallback must come before resolve()');
         assert.ok(nullIdx    < resolveIdx, 'this._receiveCallback = null must come before resolve()');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 4 — restore seeds FC.CONFIG before querying the FC version
+//
+// FC.CONFIG is null in js/fc.js until the first normal connect calls
+// FC.resetState(). Going straight to the flasher after startup skips that, so
+// MSPHelper's MSP_FC_VERSION handler ("FC.CONFIG.flightControllerVersion = ...")
+// threw, the pre-flash backup hung waiting for a response that never got
+// processed, and GUI.connect_lock stayed true.
+//
+// The seeding must be guarded by !FC.CONFIG: an unconditional resetState()
+// would wipe the cached version that the query's 3s timeout path falls back on.
+// ---------------------------------------------------------------------------
+
+describe('restore seeds FC.CONFIG before the MSP version query', () => {
+    const src = readFileSync(resolve(root, 'tabs/firmware_flasher.js'), 'utf8');
+    // The restore flow's version query, not the target-prefetch one further down.
+    const listenerIdx = src.indexOf('CONFIGURATOR.connection.addOnReceiveCallback(mspListener)');
+    const queryIdx = src.indexOf('var versionQueryDone = false');
+
+    test('the guard sits between the MSP listener and the version query', () => {
+        assert.notEqual(listenerIdx, -1, 'the restore flow must still register mspListener');
+        assert.notEqual(queryIdx, -1, 'the restore flow must still have its version query');
+
+        const between = src.slice(listenerIdx, queryIdx);
+        assert.match(between, /if\s*\(\s*!FC\.CONFIG\s*\)\s*\{\s*FC\.resetState\(\);/,
+            'FC.CONFIG must be seeded via FC.resetState() before MSP_FC_VERSION is sent');
+    });
+
+    test('the seeding stays conditional so a cached version is not wiped', () => {
+        const between = src.slice(listenerIdx, queryIdx);
+        const resetIdx = between.indexOf('FC.resetState()');
+        const guardIdx = between.indexOf('!FC.CONFIG');
+        assert.notEqual(guardIdx, -1, 'resetState() must be guarded by !FC.CONFIG');
+        assert.ok(guardIdx < resetIdx, 'the !FC.CONFIG guard must come before resetState()');
     });
 });

--- a/tests/msp-parse-failure-recovery.test.mjs
+++ b/tests/msp-parse-failure-recovery.test.mjs
@@ -336,7 +336,7 @@ test('every write code is classified - none falls through unnoticed', () => {
     // else fails to parse. That is the safe direction, but it is not the intended
     // behaviour, so adding an MSP write command must fail here until it is either
     // paired with its read or listed as carrying no FC-read data.
-    const writeNames = Object.keys(MSPCodes).filter(name => /SET_|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
+    const writeNames = Object.keys(MSPCodes).filter(name => /(^|_)SET(_|$)|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
     assert.ok(writeNames.length > 60, 'sanity: the write codes must still be recognisable by name');
 
     clearParseFailures();
@@ -428,7 +428,7 @@ test('reads, reboot and live commands are never blocked', () => {
     // does carry FC-read data must be refused. Together with the "none falls
     // through unnoticed" test above this pins both directions - an empty pairing
     // map would pass one of them but never both.
-    const writeNames = Object.keys(MSPCodes).filter(name => /SET_|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
+    const writeNames = Object.keys(MSPCodes).filter(name => /(^|_)SET(_|$)|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
     const blocked = writeNames.filter(name => MSP.blockedWriteSource(MSPCodes[name]) !== false);
     assert.ok(blocked.length > 50, `expected the bulk of writes to be refused, got ${blocked.length}`);
     assert.ok(blocked.includes('MSP2_SET_PID'));
@@ -436,6 +436,34 @@ test('reads, reboot and live commands are never blocked', () => {
     assert.ok(!blocked.includes('MSP_EEPROM_WRITE'));
 
     clearParseFailures();
+});
+
+test('a write is recognised however its name spells SET', () => {
+    // The classifier is a name regex, so a test built on that same regex cannot
+    // notice a write it fails to match - MSP2_INAV_EZ_TUNE_SET was missed that way.
+    // Codes named after SET that are reads, or writes carrying no FC-read data:
+    const notGuarded = [
+        'MSPV2_SETTING', 'MSP2_COMMON_SETTING_INFO',
+        'MSP_SET_REBOOT', 'MSP_SET_MOTOR', 'MSP_SET_RAW_RC', 'MSP_SET_RAW_GPS',
+        'MSP_SET_HEAD', 'MSP_SET_RTC', 'MSP_RESET_CONF', 'MSP_SET_RESET_CURR_PID',
+        'MSP_SELECT_SETTING', 'MSP_SET_BOX',
+    ];
+
+    clearParseFailures();
+    for (const name of Object.keys(MSPCodes)) {
+        MSP.parseFailures.add(MSPCodes[name]);
+    }
+
+    const unguarded = Object.keys(MSPCodes)
+        .filter(name => name.includes('SET') && !notGuarded.includes(name))
+        .filter(name => MSP.blockedWriteSource(MSPCodes[name]) === false);
+
+    assert.equal(MSP.blockedWriteSource(MSPCodes.MSP2_INAV_EZ_TUNE_SET), MSPCodes.MSP2_INAV_EZ_TUNE,
+        'the suffix-form write must pair with the response it hands back');
+
+    clearParseFailures();
+    assert.deepEqual(unguarded, [],
+        `these SET codes are neither guarded nor listed as carrying no FC data: ${unguarded.join(', ')}`);
 });
 
 test('positive control: writes go out normally while parsing is healthy', () => {
@@ -448,7 +476,7 @@ test('positive control: writes go out normally while parsing is healthy', () => 
     assert.equal(mspQueue.getLength(), 1, 'a healthy session must still queue its writes');
 });
 
-test('a blocked write reaches neither the wire nor a silent dead end', () => {
+test('a blocked write reaches neither the wire nor the save chain behind it', () => {
     resetQueue();
     clearParseFailures();
     MSP.parseFailures.add(MSPCodes.MSP2_PID);
@@ -459,7 +487,9 @@ test('a blocked write reaches neither the wire nor a silent dead end', () => {
 
     assert.equal(sent, false, 'send_message must report the refusal');
     assert.equal(mspQueue.getLength(), 0, 'nothing may be queued for the FC');
-    assert.equal(result, false, 'the caller must be told, or its save chain hangs like the original bug');
+    // Save chains read being called as success - failsafe's savePhaseTwo ignores the
+    // argument and would go on to write EEPROM, log "saved" and reboot the FC.
+    assert.equal(result, 'not called', 'a write that never went out must not complete');
     assert.ok(
         GUI.logged.includes('mspWriteBlockedAfterParseFailure'),
         'a silent refusal is worse than none - the user would believe the settings were saved'

--- a/tests/msp-parse-failure-recovery.test.mjs
+++ b/tests/msp-parse-failure-recovery.test.mjs
@@ -22,7 +22,7 @@
  *
  * Fix under test:
  *   - MSP2_PID grows FC.PIDs to the bank count the FC actually reports
- *   - processData() wraps the parse and completes the request regardless
+ *   - handleResponse() runs the parse and completes the request regardless
  *   - msp.js releases the hard lock in a finally
  *
  * The tests execute the REAL production files. This codebase uses Vite-style
@@ -227,7 +227,7 @@ test('MSP2_PID: an FC reporting more banks than we know must not throw', () => {
     // serial_backend.js still pre-sizes FC.PIDs to 11.
     const handler = makeDataHandler(MSPCodes.MSP2_PID, pidPayload(12), (resp) => { response = resp; });
 
-    assert.doesNotThrow(() => mspHelper.processData(handler));
+    assert.doesNotThrow(() => mspHelper.handleResponse(handler));
 
     assert.equal(FC.PIDs.length, 12, 'FC.PIDs must grow to the bank count the FC reported');
     assert.deepEqual(FC.PIDs[0], [1, 2, 3, 4], 'the first bank must still be parsed');
@@ -240,7 +240,7 @@ test('MSP2_PID positive control: a matching bank count parses unchanged', () => 
 
     let response = null;
     const handler = makeDataHandler(MSPCodes.MSP2_PID, pidPayload(11), (resp) => { response = resp; });
-    mspHelper.processData(handler);
+    mspHelper.handleResponse(handler);
 
     assert.equal(FC.PIDs.length, 11, 'a matching FC must not change the bank count');
     assert.deepEqual(FC.PIDs[10], [41, 42, 43, 44]);
@@ -258,8 +258,8 @@ test('a parser that throws must still complete the request', async () => {
     mspDeduplicationQueue.put(MSPCodes.MSP_LOOP_TIME);
 
     assert.doesNotThrow(
-        () => mspHelper.processData(handler),
-        'a failed parse must not propagate out of processData()'
+        () => mspHelper.handleResponse(handler),
+        'a failed parse must not propagate out of handleResponse()'
     );
 
     assert.notEqual(response, null, 'the waiting tab must still get its callback, or it hangs forever');

--- a/tests/msp-parse-failure-recovery.test.mjs
+++ b/tests/msp-parse-failure-recovery.test.mjs
@@ -127,6 +127,16 @@ const fcStubUrl = dataModule(`
     export default FC;
 `);
 const inertDefaultUrl = dataModule('export default {};');
+// GUI.log and i18n.getMessage are called on the parse-failure path, so these two
+// have to behave like the real thing rather than being inert.
+const guiStubUrl = dataModule(`
+    const GUI = { logged: [], log(message) { GUI.logged.push(message); } };
+    export default GUI;
+`);
+const i18nStubUrl = dataModule(`
+    const i18n = { getMessage(key) { return key; } };
+    export default i18n;
+`);
 const inertFwApproachUrl = dataModule('export const FwApproach = class {};');
 const inertGeozoneUrl = dataModule(`
     export const Geozone = class {};
@@ -137,7 +147,8 @@ const inertGeozoneUrl = dataModule(`
 const realMspHelperUrl = rewriteAndWrite('js/msp/MSPHelper.js', [
     [/^import semver from 'semver';$/m, `import semver from '${inertDefaultUrl}';`, "import semver"],
     [/^import '\.\/\.\.\/injected_methods';$/m, `import '${realInjectedMethodsUrl}';`, "import injected_methods"],
-    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${inertDefaultUrl}';`, "import GUI"],
+    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${guiStubUrl}';`, "import GUI"],
+    [/^import i18n from '\.\/\.\.\/localization';$/m, `import i18n from '${i18nStubUrl}';`, "import i18n"],
     [/^import MSP from '\.\/\.\.\/msp';$/m, `import MSP from '${realMspUrl}';`, "import MSP"],
     [/^import MSPCodes from '\.\/MSPCodes';$/m, `import MSPCodes from '${realMspCodesUrl}';`, "import MSPCodes"],
     [/^import FC from '\.\/\.\.\/fc';$/m, `import FC from '${fcStubUrl}';`, "import FC"],
@@ -163,8 +174,13 @@ const { default: MSPCodes } = await import(realMspCodesUrl);
 const { default: MSP } = await import(realMspUrl);
 const { default: mspQueue } = await import(realMspQueueUrl);
 const { default: mspDeduplicationQueue } = await import(realDedupUrl);
+const { default: CONFIGURATOR } = await import(realConfiguratorUrl);
+const { default: GUI } = await import(guiStubUrl);
 
 const FC = globalThis[FC_STATE_ID];
+
+// Wires MSP.onConfigWriteBlocked, the same call configurator_main.js makes at startup.
+mspHelper.init();
 
 /** Stand-in for the MSP decoder object processData() reads its message off. */
 function makeDataHandler(code, payloadBytes, onFinish) {
@@ -248,6 +264,12 @@ test('a parser that throws must still complete the request', async () => {
 
     assert.notEqual(response, null, 'the waiting tab must still get its callback, or it hangs forever');
     assert.equal(response.command, MSPCodes.MSP_LOOP_TIME);
+    assert.ok(
+        MSP.parseFailures.has(MSPCodes.MSP_LOOP_TIME),
+        'the failure must be recorded, or half-parsed state could still be written back'
+    );
+    MSP.parseFailures.clear();
+    assert.ok(GUI.logged.includes('mspResponseUnreadable'), 'the user must be told the values are suspect');
     assert.equal(handler.callbacks.length, 0, 'the request must be removed from the pending list');
     assert.equal(
         mspDeduplicationQueue.check(MSPCodes.MSP_LOOP_TIME),
@@ -285,4 +307,193 @@ test('a throwing processData must not leave the MSP queue hard-locked', async ()
         mspQueue.freeHardLock();
         mspQueue.setLockMethod('soft');
     }
+});
+
+// ---------------------------------------------------------------------------
+// Once a response could not be parsed, FC state is part fresh and part stale
+// with no way to tell which. Writing any of it back would push wrong values
+// into the aircraft, so every config write is refused until the next session.
+// ---------------------------------------------------------------------------
+
+/** A queue that can accept a message, with no leftover locks from earlier tests. */
+function resetQueue() {
+    CONFIGURATOR.connection = false; // keeps the real executor interval from dequeuing
+    CONFIGURATOR.cliActive = false;
+    mspQueue.flush();
+    mspDeduplicationQueue.flush();
+    mspQueue.freeHardLock();
+    mspQueue.freeSoftLock();
+    mspQueue.unlock();
+}
+
+/** Puts the session back into "everything parsed fine" state. */
+function clearParseFailures() {
+    MSP.parseFailures.clear();
+}
+
+test('every write code is classified - none falls through unnoticed', () => {
+    // A write nobody classified would be refused wholesale the moment anything
+    // else fails to parse. That is the safe direction, but it is not the intended
+    // behaviour, so adding an MSP write command must fail here until it is either
+    // paired with its read or listed as carrying no FC-read data.
+    const writeNames = Object.keys(MSPCodes).filter(name => /SET_|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
+    assert.ok(writeNames.length > 60, 'sanity: the write codes must still be recognisable by name');
+
+    clearParseFailures();
+    // With nothing broken, blockedWriteSource() reports false for everything, so
+    // probe the classification with one arbitrary failure in place instead.
+    MSP.parseFailures.add(MSPCodes.MSP_BOARD_INFO); // a read no write hands back
+
+    const unclassified = writeNames.filter(name => MSP.blockedWriteSource(MSPCodes[name]) !== false);
+
+    clearParseFailures();
+    assert.deepEqual(
+        unclassified,
+        [],
+        `these write codes are neither paired with a read nor listed as carrying no FC data: ${unclassified.join(', ')}`
+    );
+});
+
+test('a write is blocked only by the read it hands back', () => {
+    clearParseFailures();
+    MSP.parseFailures.add(MSPCodes.MSP2_PID);
+
+    assert.equal(MSP.blockedWriteSource(MSPCodes.MSP2_SET_PID), MSPCodes.MSP2_PID,
+        'the write that sends FC.PIDs back must be refused');
+
+    // Everything else on the same page, and every other page, keeps saving.
+    const stillAllowed = [
+        'MSP_SET_RC_TUNING',
+        'MSPV2_INAV_SET_RATE_PROFILE',
+        'MSPV2_SET_SETTING',
+        'MSP_SET_FEATURE',
+        'MSP2_INAV_SET_MIXER',
+        'MSP2_INAV_SET_SAFEHOME',
+        'MSP_SET_WP',
+    ];
+    for (const name of stillAllowed) {
+        assert.equal(MSP.blockedWriteSource(MSPCodes[name]), false, `${name} must keep working`);
+    }
+
+    clearParseFailures();
+});
+
+test('the pairing holds for the irregularly named writes', () => {
+    // These do not pair up by name alone (plural reads, VERTEX vs VERTICE), so a
+    // rename upstream would silently unpair them without this.
+    const pairs = [
+        ['MSP_SET_MODE_RANGE', 'MSP_MODE_RANGES'],
+        ['MSP_SET_ADJUSTMENT_RANGE', 'MSP_ADJUSTMENT_RANGES'],
+        ['MSP2_INAV_OSD_SET_LAYOUT_ITEM', 'MSP2_INAV_OSD_LAYOUTS'],
+        ['MSP2_INAV_SET_GEOZONE_VERTICE', 'MSP2_INAV_GEOZONE_VERTEX'],
+    ];
+
+    for (const [write, read] of pairs) {
+        clearParseFailures();
+        assert.notEqual(MSPCodes[read], undefined, `${read} must still exist in MSPCodes`);
+        MSP.parseFailures.add(MSPCodes[read]);
+        assert.equal(MSP.blockedWriteSource(MSPCodes[write]), MSPCodes[read], `${write} must pair with ${read}`);
+    }
+
+    clearParseFailures();
+});
+
+test('reads, reboot and live commands are never blocked', () => {
+    clearParseFailures();
+    // Every read this Configurator makes, at once - the worst case.
+    for (const name of Object.keys(MSPCodes)) {
+        MSP.parseFailures.add(MSPCodes[name]);
+    }
+
+    const neverBlocked = [
+        'MSP_STATUS',
+        'MSP2_PID',
+        'MSP_RC_TUNING',
+        'MSP_FC_VERSION',
+        // Stores nothing, and is how the user gets the FC back to a known-good state.
+        'MSP_SET_REBOOT',
+        // stopMotors() stops a running motor test with this - refusing it would
+        // strand the motors spinning.
+        'MSP_SET_MOTOR',
+        'MSP_SET_RAW_RC',
+        // Persists what is already on the FC; a refused write never got there.
+        'MSP_EEPROM_WRITE',
+    ];
+    for (const name of neverBlocked) {
+        assert.notEqual(MSPCodes[name], undefined, `${name} must still exist in MSPCodes`);
+        assert.equal(MSP.blockedWriteSource(MSPCodes[name]), false, `${name} must never be blocked`);
+    }
+
+    // The other half of the guarantee: with every read broken, every write that
+    // does carry FC-read data must be refused. Together with the "none falls
+    // through unnoticed" test above this pins both directions - an empty pairing
+    // map would pass one of them but never both.
+    const writeNames = Object.keys(MSPCodes).filter(name => /SET_|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
+    const blocked = writeNames.filter(name => MSP.blockedWriteSource(MSPCodes[name]) !== false);
+    assert.ok(blocked.length > 50, `expected the bulk of writes to be refused, got ${blocked.length}`);
+    assert.ok(blocked.includes('MSP2_SET_PID'));
+    assert.ok(blocked.includes('MSPV2_SET_SETTING'));
+    assert.ok(!blocked.includes('MSP_EEPROM_WRITE'));
+
+    clearParseFailures();
+});
+
+test('positive control: writes go out normally while parsing is healthy', () => {
+    resetQueue();
+    clearParseFailures();
+
+    const sent = MSP.send_message(MSPCodes.MSP2_SET_PID, [1, 2, 3, 4], false, () => {});
+
+    assert.equal(sent, true);
+    assert.equal(mspQueue.getLength(), 1, 'a healthy session must still queue its writes');
+});
+
+test('a blocked write reaches neither the wire nor a silent dead end', () => {
+    resetQueue();
+    clearParseFailures();
+    MSP.parseFailures.add(MSPCodes.MSP2_PID);
+    GUI.logged.length = 0;
+
+    let result = 'not called';
+    const sent = MSP.send_message(MSPCodes.MSP2_SET_PID, [1, 2, 3, 4], false, (r) => { result = r; });
+
+    assert.equal(sent, false, 'send_message must report the refusal');
+    assert.equal(mspQueue.getLength(), 0, 'nothing may be queued for the FC');
+    assert.equal(result, false, 'the caller must be told, or its save chain hangs like the original bug');
+    assert.ok(
+        GUI.logged.includes('mspWriteBlockedAfterParseFailure'),
+        'a silent refusal is worse than none - the user would believe the settings were saved'
+    );
+
+    clearParseFailures();
+});
+
+test('an unrelated page keeps saving after another page failed to load', () => {
+    resetQueue();
+    clearParseFailures();
+    MSP.parseFailures.add(MSPCodes.MSP2_PID);
+
+    assert.equal(MSP.send_message(MSPCodes.MSP_STATUS, false, false, () => {}), true, 'reads must keep working');
+    assert.equal(MSP.send_message(MSPCodes.MSP_SET_FEATURE, [1], false, () => {}), true, 'other settings must keep saving');
+    assert.equal(MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, () => {}), true, 'the save must still be committable');
+    assert.equal(mspQueue.getLength(), 3);
+
+    clearParseFailures();
+});
+
+test('reconnecting clears the block', () => {
+    resetQueue();
+    clearParseFailures();
+    MSP.parseFailures.add(MSPCodes.MSP2_PID);
+
+    // What serial_backend.js does at the start of every session, right after
+    // FC.resetState() - everything gets re-read from the FC from scratch.
+    MSP.disconnect_cleanup();
+    assert.equal(MSP.parseFailures.size, 0);
+
+    resetQueue();
+    assert.equal(MSP.send_message(MSPCodes.MSP2_SET_PID, [1, 2, 3, 4], false, () => {}), true);
+    assert.equal(mspQueue.getLength(), 1, 'writes must work again after a reconnect');
+
+    resetQueue();
 });

--- a/tests/msp-parse-failure-recovery.test.mjs
+++ b/tests/msp-parse-failure-recovery.test.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for a single unparseable MSP response locking up the GUI.
+ *
+ * Bug: MSPHelper's processData() is one big switch over the MSP code, and the
+ * code that *completes* the request - clearing the response timeout, removing
+ * the code from the deduplication queue, recording the round-trip and firing
+ * the registered onFinish callback - sat after that switch in the same
+ * function. Any parser case that threw skipped all of it, so:
+ *   - the tab waiting on that response never got its callback and never
+ *     finished loading, leaving the GUI stuck mid tab-switch (no tab changes,
+ *     only a disconnect gets you out),
+ *   - the request timed out and kept retrying,
+ *   - the MSP code stayed flagged in-flight, so retries were rejected as
+ *     duplicates,
+ *   - and back in msp.js the queue's hard lock was never released either,
+ *     because that also sat after the processData() call.
+ *
+ * Hit in practice with an FC built from a branch whose PID_ITEM_COUNT had
+ * grown by one: MSP2_PID walked one bank past FC.PIDs (fixed at 11 entries in
+ * serial_backend.js) and threw "Cannot set properties of undefined".
+ *
+ * Fix under test:
+ *   - MSP2_PID grows FC.PIDs to the bank count the FC actually reports
+ *   - processData() wraps the parse and completes the request regardless
+ *   - msp.js releases the hard lock in a finally
+ *
+ * The tests execute the REAL production files. This codebase uses Vite-style
+ * extensionless relative imports which plain Node's ESM resolver refuses to
+ * load, so - like tests/cli-tab-msp-polling.test.mjs - the sources are read
+ * fresh off disk and only their *import specifiers* are rewritten. Everything
+ * the code under test actually touches (MSPCodes, the MSP queue, the
+ * deduplication queue, statistics) stays wired to the real modules; the
+ * remaining imports, which no executed path reaches, become inert stubs. No
+ * statement, expression or ordering in the code under test is touched.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'msp-parse-failure-'));
+process.on('exit', () => rmSync(tmpDir, { recursive: true, force: true }));
+
+function dataModule(code) {
+    // encodeURIComponent leaves ' ( ) ! * unescaped; the generated specifiers are
+    // embedded in single-quoted string literals, so escape those too.
+    const encoded = encodeURIComponent(code).replace(/['()!*]/g, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+    return 'data:text/javascript,' + encoded;
+}
+
+function realModuleUrl(relPath) {
+    return pathToFileURL(join(repoRoot, relPath)).href;
+}
+
+/**
+ * Rewrite the listed import specifiers in a real source file and write the
+ * result to a temp module. Throws loudly if a pattern stops matching, so a
+ * future reshuffle of those imports fails the test instead of passing
+ * vacuously.
+ */
+function rewriteAndWrite(relSrcPath, rules, outName) {
+    let source = readFileSync(join(repoRoot, relSrcPath), 'utf8');
+    for (const [regex, replacement, label] of rules) {
+        if (!regex.test(source)) {
+            throw new Error(
+                `msp-parse-failure-recovery.test.mjs: expected to find and replace "${label}" in ${relSrcPath} ` +
+                `but the pattern ${regex} did not match. Update the test's substitution rules.`
+            );
+        }
+        source = source.replace(regex, replacement);
+    }
+    const outPath = join(tmpDir, outName);
+    writeFileSync(outPath, source, 'utf8');
+    return pathToFileURL(outPath).href;
+}
+
+// --- real, import-free leaf modules, loadable straight by absolute URL -------
+const realMspCodesUrl = realModuleUrl('js/msp/MSPCodes.js');
+const realTimeoutsUrl = realModuleUrl('js/timeouts.js');
+const realConfiguratorUrl = realModuleUrl('js/data_storage.js');
+const realDedupUrl = realModuleUrl('js/msp/mspDeduplicationQueue.js');
+const realStatisticsUrl = realModuleUrl('js/msp/mspStatistics.js');
+const realSmoothFilterUrl = realModuleUrl('js/simple_smooth_filter.js');
+const realInjectedMethodsUrl = realModuleUrl('js/injected_methods.js');
+
+// eventFrequencyAnalyzer and serial_queue start un-refed intervals in their
+// IIFEs. `.unref()` changes nothing about whether or how they run - it only
+// stops Node from waiting on them to decide when the process may exit, which
+// would otherwise hang `node --test` forever.
+const realEventFrequencyAnalyzerUrl = rewriteAndWrite('js/eventFrequencyAnalyzer.js', [
+    [/privateScope\.intervalHandler = setInterval\(publicScope\.analyze, bufferPeriod\);/g, 'privateScope.intervalHandler = setInterval(publicScope.analyze, bufferPeriod).unref();', "analyze setInterval"],
+], 'eventFrequencyAnalyzer-generated.mjs');
+
+const realMspQueueUrl = rewriteAndWrite('js/serial_queue.js', [
+    [/^import CONFIGURATOR from '\.\/data_storage';$/m, `import CONFIGURATOR from '${realConfiguratorUrl}';`, "import CONFIGURATOR"],
+    [/^import MSPCodes from '\.\/msp\/MSPCodes';$/m, `import MSPCodes from '${realMspCodesUrl}';`, "import MSPCodes"],
+    [/^import SimpleSmoothFilter from '\.\/simple_smooth_filter';$/m, `import SimpleSmoothFilter from '${realSmoothFilterUrl}';`, "import SimpleSmoothFilter"],
+    [/^import eventFrequencyAnalyzer from '\.\/eventFrequencyAnalyzer';$/m, `import eventFrequencyAnalyzer from '${realEventFrequencyAnalyzerUrl}';`, "import eventFrequencyAnalyzer"],
+    [/^import mspDeduplicationQueue from '\.\/msp\/mspDeduplicationQueue';$/m, `import mspDeduplicationQueue from '${realDedupUrl}';`, "import mspDeduplicationQueue"],
+    [/setInterval\(publicScope\.executor, Math\.round\(1000 \/ privateScope\.handlerFrequency\)\);/, 'setInterval(publicScope.executor, Math.round(1000 / privateScope.handlerFrequency)).unref();', "executor setInterval"],
+    [/setInterval\(publicScope\.balancer, Math\.round\(1000 \/ privateScope\.balancerFrequency\)\);/, 'setInterval(publicScope.balancer, Math.round(1000 / privateScope.balancerFrequency)).unref();', "balancer setInterval"],
+], 'serial_queue-generated.mjs');
+
+const realMspUrl = rewriteAndWrite('js/msp.js', [
+    [/^import MSPCodes from '\.\/msp\/MSPCodes';$/m, `import MSPCodes from '${realMspCodesUrl}';`, "import MSPCodes"],
+    [/^import mspQueue from '\.\/serial_queue';$/m, `import mspQueue from '${realMspQueueUrl}';`, "import mspQueue"],
+    [/^import eventFrequencyAnalyzer from '\.\/eventFrequencyAnalyzer';$/m, `import eventFrequencyAnalyzer from '${realEventFrequencyAnalyzerUrl}';`, "import eventFrequencyAnalyzer"],
+    [/^import timeout from '\.\/timeouts';$/m, `import timeout from '${realTimeoutsUrl}';`, "import timeout"],
+    [/^import CONFIGURATOR from '\.\/data_storage';$/m, `import CONFIGURATOR from '${realConfiguratorUrl}';`, "import CONFIGURATOR"],
+], 'msp-generated.mjs');
+
+// FC has to be controllable (the tests set up PID banks); everything below it
+// is only referenced from switch cases these tests never reach, so those
+// imports just have to resolve.
+const FC_STATE_ID = '__mspParseFailureFcState';
+globalThis[FC_STATE_ID] = { PIDs: [], FC_CONFIG: undefined };
+
+const fcStubUrl = dataModule(`
+    const FC = globalThis['${FC_STATE_ID}'];
+    export default FC;
+`);
+const inertDefaultUrl = dataModule('export default {};');
+const inertFwApproachUrl = dataModule('export const FwApproach = class {};');
+const inertGeozoneUrl = dataModule(`
+    export const Geozone = class {};
+    export const GeozoneVertex = class {};
+    export const GeozoneShapes = {};
+`);
+
+const realMspHelperUrl = rewriteAndWrite('js/msp/MSPHelper.js', [
+    [/^import semver from 'semver';$/m, `import semver from '${inertDefaultUrl}';`, "import semver"],
+    [/^import '\.\/\.\.\/injected_methods';$/m, `import '${realInjectedMethodsUrl}';`, "import injected_methods"],
+    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${inertDefaultUrl}';`, "import GUI"],
+    [/^import MSP from '\.\/\.\.\/msp';$/m, `import MSP from '${realMspUrl}';`, "import MSP"],
+    [/^import MSPCodes from '\.\/MSPCodes';$/m, `import MSPCodes from '${realMspCodesUrl}';`, "import MSPCodes"],
+    [/^import FC from '\.\/\.\.\/fc';$/m, `import FC from '${fcStubUrl}';`, "import FC"],
+    [/^import VTX from '\.\/\.\.\/vtx';$/m, `import VTX from '${inertDefaultUrl}';`, "import VTX"],
+    [/^import mspQueue from '\.\/\.\.\/serial_queue';$/m, `import mspQueue from '${realMspQueueUrl}';`, "import mspQueue"],
+    [/^import ServoMixRule from '\.\/\.\.\/servoMixRule';$/m, `import ServoMixRule from '${inertDefaultUrl}';`, "import ServoMixRule"],
+    [/^import MotorMixRule from '\.\/\.\.\/motorMixRule';$/m, `import MotorMixRule from '${inertDefaultUrl}';`, "import MotorMixRule"],
+    [/^import LogicCondition from '\.\/\.\.\/logicCondition';$/m, `import LogicCondition from '${inertDefaultUrl}';`, "import LogicCondition"],
+    [/^import BitHelper from '\.\.\/bitHelper';$/m, `import BitHelper from '${inertDefaultUrl}';`, "import BitHelper"],
+    [/^import serialPortHelper from '\.\/\.\.\/serialPortHelper';$/m, `import serialPortHelper from '${inertDefaultUrl}';`, "import serialPortHelper"],
+    [/^import ProgrammingPid from '\.\/\.\.\/programmingPid';$/m, `import ProgrammingPid from '${inertDefaultUrl}';`, "import ProgrammingPid"],
+    [/^import Safehome from '\.\/\.\.\/safehome';$/m, `import Safehome from '${inertDefaultUrl}';`, "import Safehome"],
+    [/^import \{ FwApproach \} from '\.\/\.\.\/fwApproach';$/m, `import { FwApproach } from '${inertFwApproachUrl}';`, "import FwApproach"],
+    [/^import Waypoint from '\.\/\.\.\/waypoint';$/m, `import Waypoint from '${inertDefaultUrl}';`, "import Waypoint"],
+    [/^import mspDeduplicationQueue from '\.\/mspDeduplicationQueue';$/m, `import mspDeduplicationQueue from '${realDedupUrl}';`, "import mspDeduplicationQueue"],
+    [/^import mspStatistics from '\.\/mspStatistics';$/m, `import mspStatistics from '${realStatisticsUrl}';`, "import mspStatistics"],
+    [/^import settingsCache from '\.\/\.\.\/settingsCache';$/m, `import settingsCache from '${inertDefaultUrl}';`, "import settingsCache"],
+    [/^import \{Geozone, GeozoneVertex, GeozoneShapes \} from '\.\/\.\.\/geozone';$/m, `import { Geozone, GeozoneVertex, GeozoneShapes } from '${inertGeozoneUrl}';`, "import Geozone"],
+], 'MSPHelper-generated.mjs');
+
+const { default: mspHelper } = await import(realMspHelperUrl);
+const { default: MSPCodes } = await import(realMspCodesUrl);
+const { default: MSP } = await import(realMspUrl);
+const { default: mspQueue } = await import(realMspQueueUrl);
+const { default: mspDeduplicationQueue } = await import(realDedupUrl);
+
+const FC = globalThis[FC_STATE_ID];
+
+/** Stand-in for the MSP decoder object processData() reads its message off. */
+function makeDataHandler(code, payloadBytes, onFinish) {
+    const buffer = new Uint8Array(payloadBytes).buffer;
+    const entry = {
+        code,
+        onFinish,
+        createdOn: Date.now(),
+        sentOn: Date.now(),
+        timerFired: false,
+    };
+    entry.timer = setTimeout(() => { entry.timerFired = true; }, 25);
+
+    return {
+        code,
+        unsupported: false,
+        message_buffer: buffer,
+        message_length_expected: payloadBytes.length,
+        callbacks: [entry],
+        entry,
+    };
+}
+
+function elevenEmptyBanks() {
+    return Array.from({ length: 11 }, () => new Array(4));
+}
+
+/** message_length_expected / 4 banks of ascending, distinguishable bytes. */
+function pidPayload(bankCount) {
+    const bytes = [];
+    for (let bank = 0; bank < bankCount; bank++) {
+        bytes.push(bank * 4 + 1, bank * 4 + 2, bank * 4 + 3, bank * 4 + 4);
+    }
+    return bytes;
+}
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+test('MSP2_PID: an FC reporting more banks than we know must not throw', () => {
+    FC.PIDs = elevenEmptyBanks();
+
+    let response = null;
+    // 12 banks: PID_ITEM_COUNT grew by one (PID_AUTO_SPEED) while
+    // serial_backend.js still pre-sizes FC.PIDs to 11.
+    const handler = makeDataHandler(MSPCodes.MSP2_PID, pidPayload(12), (resp) => { response = resp; });
+
+    assert.doesNotThrow(() => mspHelper.processData(handler));
+
+    assert.equal(FC.PIDs.length, 12, 'FC.PIDs must grow to the bank count the FC reported');
+    assert.deepEqual(FC.PIDs[0], [1, 2, 3, 4], 'the first bank must still be parsed');
+    assert.deepEqual(FC.PIDs[11], [45, 46, 47, 48], 'the extra bank must be kept, not dropped');
+    assert.notEqual(response, null, 'the request must complete');
+});
+
+test('MSP2_PID positive control: a matching bank count parses unchanged', () => {
+    FC.PIDs = elevenEmptyBanks();
+
+    let response = null;
+    const handler = makeDataHandler(MSPCodes.MSP2_PID, pidPayload(11), (resp) => { response = resp; });
+    mspHelper.processData(handler);
+
+    assert.equal(FC.PIDs.length, 11, 'a matching FC must not change the bank count');
+    assert.deepEqual(FC.PIDs[10], [41, 42, 43, 44]);
+    assert.notEqual(response, null);
+});
+
+test('a parser that throws must still complete the request', async () => {
+    // MSP_LOOP_TIME's case does data.getInt16(0) and writes into FC.FC_CONFIG.
+    // With an empty payload from a mismatched FC that throws mid-parse - which
+    // is the shape of every "FC and Configurator disagree about a payload" bug.
+    FC.FC_CONFIG = undefined;
+
+    let response = null;
+    const handler = makeDataHandler(MSPCodes.MSP_LOOP_TIME, [], (resp) => { response = resp; });
+    mspDeduplicationQueue.put(MSPCodes.MSP_LOOP_TIME);
+
+    assert.doesNotThrow(
+        () => mspHelper.processData(handler),
+        'a failed parse must not propagate out of processData()'
+    );
+
+    assert.notEqual(response, null, 'the waiting tab must still get its callback, or it hangs forever');
+    assert.equal(response.command, MSPCodes.MSP_LOOP_TIME);
+    assert.equal(handler.callbacks.length, 0, 'the request must be removed from the pending list');
+    assert.equal(
+        mspDeduplicationQueue.check(MSPCodes.MSP_LOOP_TIME),
+        false,
+        'the code must be released, or every retry is rejected as a duplicate'
+    );
+
+    await wait(60);
+    assert.equal(handler.entry.timerFired, false, 'the response timeout must have been cleared');
+});
+
+test('a throwing processData must not leave the MSP queue hard-locked', async () => {
+    const originalProcessData = MSP.processData;
+    mspQueue.setLockMethod('hard');
+    mspQueue.setHardLock();
+    assert.equal(mspQueue.isLocked(), true, 'sanity: the queue starts locked');
+
+    MSP.setProcessData(() => { throw new Error('parser blew up'); });
+    MSP.message_checksum = 7;
+    MSP.message_length_received = 12;
+    MSP.state = MSP.decoder_states.PAYLOAD_V2;
+
+    try {
+        // The exception itself is expected to propagate - the connection's receive
+        // dispatch catches it. What must not happen is the cleanup being skipped.
+        assert.throws(() => MSP._dispatch_message(7), /parser blew up/);
+
+        assert.equal(MSP.state, MSP.decoder_states.IDLE, 'the decoder state must be reset');
+        assert.equal(MSP.message_length_received, 0);
+
+        await wait(60); // the hard lock is released on a 10ms timeout
+        assert.equal(mspQueue.isLocked(), false, 'the hard lock must be released even when the parser throws');
+    } finally {
+        MSP.setProcessData(originalProcessData);
+        mspQueue.freeHardLock();
+        mspQueue.setLockMethod('soft');
+    }
+});


### PR DESCRIPTION
# Fix Configurator soft-locks caused by connection and MSP-parse failures

**Target: `maintenance-9.x`.** Nothing here is version-specific — it should port to `maintenance-10.x` cleanly, happy to open that PR too or leave it to a maintainer up-port.

Four related failures that all end the same way: the Configurator stops responding and only a restart or a disconnect gets you out. Each is a separate commit.

## 1. The send queue wedges permanently when the port disappears

**Symptom:** flashing fails and the app soft-locks — Connect stops responding, only a restart helps. Workaround: connect normally over MSP once and disconnect, then flashing works.

`Connection.send()` advances its output buffer only from the callback it hands to `sendImplementation()` — that callback shifts the sent entry off the buffer and clears `_transmitting`. In `connectionSerial/Tcp/Udp` that callback was only reachable inside `if (this._connectionId)`, and none of the three `electronAPI` promises had a `.catch()`. A port that vanishes (FC rebooting into DFU, cable pulled, port busy during USB re-enumeration) loses the callback, and `_transmitting` stays `true` forever. Since `CONFIGURATOR.connection` is a session-wide singleton, the object stays wedged for the rest of the app's lifetime — every later `send()` only pushes into the buffer and returns.

`disconnect()` could not heal it either: `emptyOutputBuffer()`, the only place resetting `_transmitting`, sits inside the same `_connectionId` branch that is false in exactly this situation.

`connectionBle` already fired its callback on both paths and needed no change — its shape is what the other three now follow.

## 2. One throwing receive listener kills the whole chain

Every transport dispatched incoming data with a bare `this._onReceiveListeners.forEach(listener => listener(info))`. One listener throwing aborts the `forEach`, so every listener behind it misses that chunk and all later ones, and the exception escapes uncaught into the IPC handler.

The flasher hit this: `FC.CONFIG` stays `null` in `js/fc.js` until the first normal connect calls `FC.resetState()`, so going straight to the flasher after startup and running a pre-flash backup threw `Cannot set properties of null (setting 'flightControllerVersion')` inside MSPHelper's `MSP_FC_VERSION` handler — i.e. inside the dispatch loop. `MSP.read()` never processed the response, the flasher waited forever and `GUI.connect_lock` stayed `true`. That also explains the workaround in #1: connecting normally first runs `resetState()`, so nothing throws.

Both halves are fixed — fault-isolated dispatch in the base class for all four transports, and the restore flow seeds `FC.CONFIG` before its MSP version query (guarded on `!FC.CONFIG` so it cannot wipe the cached version the query's 3 s timeout path falls back on).

## 3. One unparseable MSP response locks up the GUI (OPTIONAL, since its technically unsupported and affects mainly development with wrong FW Major version)

`MSPHelper.processData()` is one big switch over the MSP code, and the part that *completes* a request — clearing the response timeout, releasing the code in the deduplication queue, recording the round-trip and firing `onFinish` — sat after that switch in the same function. Any parser case that threw skipped all of it at once:

- the tab waiting on that response never got its callback and never finished loading, so the GUI stayed stuck mid tab-switch with no way out but disconnecting
- the request timed out and retried, while the code stayed flagged in-flight so every retry was rejected as a duplicate
- in `msp.js` the queue's hard lock was never released either — that also sat after the `processData()` call

The parse is split out so the completion runs either way, and the hard lock is released from a `finally`. The parse itself is unchanged — only the function boundaries moved.

**The trigger** was `MSP2_PID` against an FC whose `PID_ITEM_COUNT` had grown by one (`PID_AUTO_SPEED`, 11 → 12): the loop runs over the payload length while `serial_backend.js` pre-sizes `FC.PIDs` to 11 banks, so it wrote past the array and threw. It now grows `FC.PIDs` to the count the FC reports rather than dropping the extra bank — the FC only accepts `MSP2_SET_PID` at its exact bank count, so dropping it would make every PID save fail silently.

## 4. Refuse the saves that would carry half-parsed values (OPTIONAL, follows Number 3)

Keeping the GUI alive after a failed parse is not enough on its own: the FC state that message fills is then half fresh and half stale, with no way to tell which fields are which, and the next Save would hand exactly those values back to the aircraft. Wrong settings silently written to a flight controller are a safety problem.

`MSP.send_message()` is the single choke point every write passes through, so it now refuses a write whose own source response could not be read, until the next connect has re-read everything. **Only that write** — a broken `MSP2_PID` disables saving PIDs and nothing else; the rest of the page and every other tab keep working.

The write/read pairing is derived from the code names — 59 of the 69 write codes are their read code with `SET_` inserted (`MSP2_SET_PID` ← `MSP2_PID`, `MSPV2_INAV_SET_MISC` ← `MSPV2_INAV_MISC`, …) — so a write command added later pairs up on its own. Four irregular ones (plural reads, `VERTEX` vs `VERTICE`) are listed explicitly. A write that pairs with nothing is refused outright while anything is unreadable: over-blocking costs a refused save, under-blocking puts wrong values into the aircraft. A test asserts that no write code falls through unclassified, so adding an MSP write command fails the suite until it is classified.

Writes carrying nothing read off the FC stay allowed, and that is deliberate: refusing the live ones would be a hazard of its own — `mixer.js`'s `stopMotors()` stops a running motor test by sending `MSP_SET_MOTOR` — and `MSP_SET_REBOOT` is how the user gets back to a known-good state. `MSP_EEPROM_WRITE` is allowed too: it persists what is already on the FC, and a refused write never got there.

The refusal is reported, not silent — a quiet refusal would be worse than the write, because the user would believe the settings were saved. Two new strings in `locale/en/messages.json`, rate-limited to one per save burst. The callback still fires with a failure so the caller's save chain completes instead of hanging.

Note this does **not** fire for the generic settings API: `MSPV2_SETTING` and `MSP2_COMMON_SETTING_INFO` are empty cases in the switch and are parsed in the promise handler, which already degrades to "no value" (unknown setting type → `null` → field skipped) rather than a wrong one.

## Testing

`yarn test` — 73 tests pass, up from 49 on `maintenance-9.x`. 24 new tests across four files, executing the real production modules with only their import specifiers rewritten (the pattern established by `tests/cli-tab-msp-polling.test.mjs`), so they fail if the real code regresses rather than testing a reimplementation. Every new test was checked to fail against unpatched `maintenance-9.x`, with positive controls that stay green.

On hardware (MATEKF765, real flash cycle): #1 and #2 verified — the soft-lock is gone and flashing works from a cold start without the connect-first workaround. #3 was reproduced live with a 10.x dev build reporting 12 PID banks. #4 is covered by tests but **not yet flown/verified on hardware** — the review of that one matters most. But hard to actually trigger manually by causing bad MSP messages on purpose. 

## Deliberately not in this PR

- `pidCount = 11` in `serial_backend.js` and the 11 names in `FC.getPidNames()` are unchanged. The 12th bank is read and written back untouched but has no UI row — a separate question of when the Configurator should learn about it.
- The 3 s fallback timer in `js/protocols/stm32.js` ("the serial port may vanish before disconnect() runs…") is left in place. It was a workaround for #1, but it still guards a case the fix does not cover: an IPC promise that neither resolves nor rejects.
- CLI-based backup/restore bypasses MSP entirely and is not covered by the write guard. Different risk class — it writes from a file, not from parsed FC state.
