### PR TITLE
Name the multi mission label's text without the trailing dot

### DIFF
--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -164,7 +164,7 @@
                             </div>
                             <hr>
                             <div style="display: inline-block">
-                                <label for="multimissionOptionList" data-i18n="missionMultiMissionNo."></label>
+                                <label for="multimissionOptionList" data-i18n="missionMultiMissionNo"></label>
                                 <select name="Number" id="multimissionOptionList" style="width: 50px">
                                     <option value="0">ALL</option>
                                 </select>


### PR DESCRIPTION
The label above the multi mission selector asks the localiser for `missionMultiMissionNo.` while the string is filed under `missionMultiMissionNo`.

Nothing answers to the name with the trailing dot, so the label renders empty in every language and the selector sits there unnamed. The text itself already exists and is translated in every locale; only the lookup was off by one character.

Before: the selector has no label at all.
After: it reads "Mission No." in English, "Mission Nr." in German, and so on.

One character in `tabs/mission_control.html`; no locale file is touched.
