### PR TITLE
MZTC: MassZero thermal camera support

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -108,6 +108,29 @@ var FC = {
         return true; // Currently all platforms use D term
     },
     resetState: function () {
+        // MassZero thermal camera. MZTC_CONFIG mirrors the 15 byte
+        // MSP2_MZTC_CONFIG payload. MZTC_STATUS stays null until the flight
+        // controller answers MSP2_MZTC_STATUS.
+        this.MZTC_CONFIG = {
+            enabled: 0,
+            port: 1,
+            baudrate: 8,
+            mode: 1,
+            update_rate: 9,
+            palette_mode: 0,
+            auto_shutter: 2,
+            digital_enhancement: 50,
+            spatial_denoise: 50,
+            temporal_denoise: 50,
+            brightness: 50,
+            contrast: 50,
+            zoom_level: 0,
+            mirror_mode: 0,
+            ffc_interval: 5
+        };
+
+        this.MZTC_STATUS = null;
+
         this.SENSOR_STATUS = {
             isHardwareHealthy: 0,
             gyroHwStatus: 0,

--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -252,7 +252,22 @@ var MSPCodes = {
     MSP2_INAV_GEOZONE:                  0x2210,
     MSP2_INAV_SET_GEOZONE:              0x2211,
     MSP2_INAV_GEOZONE_VERTEX:           0x2212,
-    MSP2_INAV_SET_GEOZONE_VERTICE:      0x2213
+    MSP2_INAV_SET_GEOZONE_VERTICE:      0x2213,
+
+    // MassZero Thermal Camera.
+    // These sit in INAV's own 0x2000-0x2FFF range. The 0x3000 block belongs to
+    // the Betaflight compatibility commands. MSP2_BETAFLIGHT_BIND is 0x3000.
+    // MSP2_RX_BIND is 0x3001.
+    MSP2_MZTC_CONFIG:                   0x2240,
+    MSP2_MZTC_STATUS:                   0x2241,
+    MSP2_SET_MZTC_CONFIG:               0x2242,
+    MSP2_SET_MZTC_MODE:                 0x2243,
+    MSP2_SET_MZTC_PALETTE:              0x2244,
+    MSP2_SET_MZTC_ZOOM:                 0x2245,
+    MSP2_SET_MZTC_SHUTTER:              0x2246,
+    MSP2_SET_MZTC_IMAGE_PARAMS:         0x2247,
+    MSP2_SET_MZTC_CORRECTION:           0x2248,
+    MSP2_SET_MZTC_VIGNETTING:           0x2249
 
 };
 

--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -261,7 +261,7 @@ var MSPCodes = {
     MSP2_MZTC_CONFIG:                   0x2240,
     MSP2_MZTC_STATUS:                   0x2241,
     MSP2_SET_MZTC_CONFIG:               0x2242,
-    MSP2_SET_MZTC_MODE:                 0x2243,
+    MSP2_SET_MZTC_PRESET:               0x2243,
     MSP2_SET_MZTC_PALETTE:              0x2244,
     MSP2_SET_MZTC_ZOOM:                 0x2245,
     MSP2_SET_MZTC_SHUTTER:              0x2246,

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -9,6 +9,12 @@ import MSPCodes from './MSPCodes';
 import FC from './../fc';
 import VTX from './../vtx';
 import mspQueue from './../serial_queue';
+
+// Fixed MZTC payload sizes, mirroring MSP2_MZTC_CONFIG_PAYLOAD_SIZE and
+// MSP2_MZTC_STATUS_PAYLOAD_SIZE in the firmware's msp_mztc.h. Naming them here
+// keeps the parse and the build path from drifting apart.
+const MZTC_CONFIG_BYTES = 12;
+const MZTC_STATUS_BYTES = 7;
 import ServoMixRule from './../servoMixRule';
 import MotorMixRule from './../motorMixRule';
 import LogicCondition from './../logicCondition';
@@ -1727,36 +1733,36 @@ var mspHelper = (function () {
                 break;    
 
             case MSPCodes.MSP2_MZTC_CONFIG:
-                // Fixed 15 byte payload, little endian, one field at a time.
+                // Fixed 12 byte payload, little endian, one field at a time.
                 // The firmware writes it with the sbufWrite helpers, so there
-                // is no compiler padding to account for here.
-                if (data.byteLength >= 15) {
+                // is no compiler padding to account for here. The serial port
+                // and its baud rate are not in this payload. They live in the
+                // Ports tab.
+                if (data.byteLength >= MZTC_CONFIG_BYTES) {
                     FC.MZTC_CONFIG = {
-                        enabled: data.getUint8(0),
-                        port: data.getUint8(1),
-                        baudrate: data.getUint8(2),
-                        mode: data.getUint8(3),
-                        update_rate: data.getUint8(4),
-                        palette_mode: data.getUint8(5),
-                        auto_shutter: data.getUint8(6),
-                        digital_enhancement: data.getUint8(7),
-                        spatial_denoise: data.getUint8(8),
-                        temporal_denoise: data.getUint8(9),
-                        brightness: data.getUint8(10),
-                        contrast: data.getUint8(11),
-                        zoom_level: data.getUint8(12),
-                        mirror_mode: data.getUint8(13),
-                        ffc_interval: data.getUint8(14)
+                        mode: data.getUint8(0),
+                        update_rate: data.getUint8(1),
+                        palette_mode: data.getUint8(2),
+                        auto_shutter: data.getUint8(3),
+                        digital_enhancement: data.getUint8(4),
+                        spatial_denoise: data.getUint8(5),
+                        temporal_denoise: data.getUint8(6),
+                        brightness: data.getUint8(7),
+                        contrast: data.getUint8(8),
+                        zoom_level: data.getUint8(9),
+                        mirror_mode: data.getUint8(10),
+                        ffc_interval: data.getUint8(11)
                     };
                 } else {
-                    console.log('MZTC_CONFIG payload too short: ' + data.byteLength + ' bytes, expected 15');
+                    console.log('MZTC_CONFIG payload too short: ' + data.byteLength +
+                                ' bytes, expected ' + MZTC_CONFIG_BYTES);
                 }
                 break;
 
             case MSPCodes.MSP2_MZTC_STATUS:
                 // Fixed 7 byte payload. connected is set only after the camera
                 // has answered a command. An open UART does not set it.
-                if (data.byteLength >= 7) {
+                if (data.byteLength >= MZTC_STATUS_BYTES) {
                     FC.MZTC_STATUS = {
                         status: data.getUint8(0),
                         mode: data.getUint8(1),
@@ -1766,7 +1772,7 @@ var mspHelper = (function () {
                         error_flags: data.getUint8(6)
                     };
                 } else {
-                    console.log('MZTC_STATUS payload too short: ' + data.byteLength + ' bytes, expected 7');
+                    console.log('MZTC_STATUS payload too short: ' + data.byteLength + ' bytes, expected ' + MZTC_STATUS_BYTES);
                     FC.MZTC_STATUS = null;
                 }
                 break;
@@ -2379,12 +2385,9 @@ var mspHelper = (function () {
 
 
             case MSPCodes.MSP2_SET_MZTC_CONFIG:
-                // Fixed 15 byte payload matching MSP2_MZTC_CONFIG. The firmware
+                // Fixed 12 byte payload matching MSP2_MZTC_CONFIG. The firmware
                 // validates the whole request before applying any of it, so an
                 // out of range value is rejected in full.
-                buffer.push(FC.MZTC_CONFIG.enabled ? 1 : 0);
-                buffer.push(FC.MZTC_CONFIG.port);
-                buffer.push(FC.MZTC_CONFIG.baudrate);
                 buffer.push(FC.MZTC_CONFIG.mode);
                 buffer.push(FC.MZTC_CONFIG.update_rate);
                 buffer.push(FC.MZTC_CONFIG.palette_mode);

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -2388,18 +2388,22 @@ var mspHelper = (function () {
                 // Fixed 12 byte payload matching MSP2_MZTC_CONFIG. The firmware
                 // validates the whole request before applying any of it, so an
                 // out of range value is rejected in full.
-                buffer.push(FC.MZTC_CONFIG.mode);
-                buffer.push(FC.MZTC_CONFIG.update_rate);
-                buffer.push(FC.MZTC_CONFIG.palette_mode);
-                buffer.push(FC.MZTC_CONFIG.auto_shutter);
-                buffer.push(FC.MZTC_CONFIG.digital_enhancement);
-                buffer.push(FC.MZTC_CONFIG.spatial_denoise);
-                buffer.push(FC.MZTC_CONFIG.temporal_denoise);
-                buffer.push(FC.MZTC_CONFIG.brightness);
-                buffer.push(FC.MZTC_CONFIG.contrast);
-                buffer.push(FC.MZTC_CONFIG.zoom_level);
-                buffer.push(FC.MZTC_CONFIG.mirror_mode);
-                buffer.push(FC.MZTC_CONFIG.ffc_interval);
+                // One push in field order. The field order is the wire order,
+                // and it has to match MSP2_MZTC_CONFIG in the firmware.
+                buffer.push(
+                    FC.MZTC_CONFIG.mode,
+                    FC.MZTC_CONFIG.update_rate,
+                    FC.MZTC_CONFIG.palette_mode,
+                    FC.MZTC_CONFIG.auto_shutter,
+                    FC.MZTC_CONFIG.digital_enhancement,
+                    FC.MZTC_CONFIG.spatial_denoise,
+                    FC.MZTC_CONFIG.temporal_denoise,
+                    FC.MZTC_CONFIG.brightness,
+                    FC.MZTC_CONFIG.contrast,
+                    FC.MZTC_CONFIG.zoom_level,
+                    FC.MZTC_CONFIG.mirror_mode,
+                    FC.MZTC_CONFIG.ffc_interval
+                );
                 break;
 
             default:

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -13,7 +13,7 @@ import mspQueue from './../serial_queue';
 // Fixed MZTC payload sizes, mirroring MSP2_MZTC_CONFIG_PAYLOAD_SIZE and
 // MSP2_MZTC_STATUS_PAYLOAD_SIZE in the firmware's msp_mztc.h. Naming them here
 // keeps the parse and the build path from drifting apart.
-const MZTC_CONFIG_BYTES = 12;
+const MZTC_CONFIG_BYTES = 11;
 const MZTC_STATUS_BYTES = 7;
 import ServoMixRule from './../servoMixRule';
 import MotorMixRule from './../motorMixRule';
@@ -1740,18 +1740,17 @@ var mspHelper = (function () {
                 // Ports tab.
                 if (data.byteLength >= MZTC_CONFIG_BYTES) {
                     FC.MZTC_CONFIG = {
-                        mode: data.getUint8(0),
-                        update_rate: data.getUint8(1),
-                        palette_mode: data.getUint8(2),
-                        auto_shutter: data.getUint8(3),
-                        digital_enhancement: data.getUint8(4),
-                        spatial_denoise: data.getUint8(5),
-                        temporal_denoise: data.getUint8(6),
-                        brightness: data.getUint8(7),
-                        contrast: data.getUint8(8),
-                        zoom_level: data.getUint8(9),
-                        mirror_mode: data.getUint8(10),
-                        ffc_interval: data.getUint8(11)
+                        preset: data.getUint8(0),
+                        palette_mode: data.getUint8(1),
+                        auto_shutter: data.getUint8(2),
+                        digital_enhancement: data.getUint8(3),
+                        spatial_denoise: data.getUint8(4),
+                        temporal_denoise: data.getUint8(5),
+                        brightness: data.getUint8(6),
+                        contrast: data.getUint8(7),
+                        zoom_level: data.getUint8(8),
+                        mirror_mode: data.getUint8(9),
+                        ffc_interval: data.getUint8(10)
                     };
                 } else {
                     console.log('MZTC_CONFIG payload too short: ' + data.byteLength +
@@ -1765,7 +1764,7 @@ var mspHelper = (function () {
                 if (data.byteLength >= MZTC_STATUS_BYTES) {
                     FC.MZTC_STATUS = {
                         status: data.getUint8(0),
-                        mode: data.getUint8(1),
+                        preset: data.getUint8(1),
                         connected: data.getUint8(2),
                         connection_quality: data.getUint8(3),
                         last_calibration: data.getUint16(4, true),
@@ -2391,8 +2390,7 @@ var mspHelper = (function () {
                 // One push in field order. The field order is the wire order,
                 // and it has to match MSP2_MZTC_CONFIG in the firmware.
                 buffer.push(
-                    FC.MZTC_CONFIG.mode,
-                    FC.MZTC_CONFIG.update_rate,
+                    FC.MZTC_CONFIG.preset,
                     FC.MZTC_CONFIG.palette_mode,
                     FC.MZTC_CONFIG.auto_shutter,
                     FC.MZTC_CONFIG.digital_enhancement,

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1726,6 +1726,55 @@ var mspHelper = (function () {
                 console.log("Geozone saved")
                 break;    
 
+            case MSPCodes.MSP2_MZTC_CONFIG:
+                // Fixed 15 byte payload, little endian, one field at a time.
+                // The firmware writes it with the sbufWrite helpers, so there
+                // is no compiler padding to account for here.
+                if (data.byteLength >= 15) {
+                    FC.MZTC_CONFIG = {
+                        enabled: data.getUint8(0),
+                        port: data.getUint8(1),
+                        baudrate: data.getUint8(2),
+                        mode: data.getUint8(3),
+                        update_rate: data.getUint8(4),
+                        palette_mode: data.getUint8(5),
+                        auto_shutter: data.getUint8(6),
+                        digital_enhancement: data.getUint8(7),
+                        spatial_denoise: data.getUint8(8),
+                        temporal_denoise: data.getUint8(9),
+                        brightness: data.getUint8(10),
+                        contrast: data.getUint8(11),
+                        zoom_level: data.getUint8(12),
+                        mirror_mode: data.getUint8(13),
+                        ffc_interval: data.getUint8(14)
+                    };
+                } else {
+                    console.log('MZTC_CONFIG payload too short: ' + data.byteLength + ' bytes, expected 15');
+                }
+                break;
+
+            case MSPCodes.MSP2_MZTC_STATUS:
+                // Fixed 7 byte payload. connected is set only after the camera
+                // has answered a command. An open UART does not set it.
+                if (data.byteLength >= 7) {
+                    FC.MZTC_STATUS = {
+                        status: data.getUint8(0),
+                        mode: data.getUint8(1),
+                        connected: data.getUint8(2),
+                        connection_quality: data.getUint8(3),
+                        last_calibration: data.getUint16(4, true),
+                        error_flags: data.getUint8(6)
+                    };
+                } else {
+                    console.log('MZTC_STATUS payload too short: ' + data.byteLength + ' bytes, expected 7');
+                    FC.MZTC_STATUS = null;
+                }
+                break;
+
+            case MSPCodes.MSP2_SET_MZTC_CONFIG:
+                console.log("MZTC config saved");
+                break;
+
             default:
                 console.log('Unknown code detected: 0x' + dataHandler.code.toString(16));
         } else {
@@ -2328,6 +2377,27 @@ var mspHelper = (function () {
                 buffer.push(FC.EZ_TUNE.snappiness);
                 break;
 
+
+            case MSPCodes.MSP2_SET_MZTC_CONFIG:
+                // Fixed 15 byte payload matching MSP2_MZTC_CONFIG. The firmware
+                // validates the whole request before applying any of it, so an
+                // out of range value is rejected in full.
+                buffer.push(FC.MZTC_CONFIG.enabled ? 1 : 0);
+                buffer.push(FC.MZTC_CONFIG.port);
+                buffer.push(FC.MZTC_CONFIG.baudrate);
+                buffer.push(FC.MZTC_CONFIG.mode);
+                buffer.push(FC.MZTC_CONFIG.update_rate);
+                buffer.push(FC.MZTC_CONFIG.palette_mode);
+                buffer.push(FC.MZTC_CONFIG.auto_shutter);
+                buffer.push(FC.MZTC_CONFIG.digital_enhancement);
+                buffer.push(FC.MZTC_CONFIG.spatial_denoise);
+                buffer.push(FC.MZTC_CONFIG.temporal_denoise);
+                buffer.push(FC.MZTC_CONFIG.brightness);
+                buffer.push(FC.MZTC_CONFIG.contrast);
+                buffer.push(FC.MZTC_CONFIG.zoom_level);
+                buffer.push(FC.MZTC_CONFIG.mirror_mode);
+                buffer.push(FC.MZTC_CONFIG.ffc_interval);
+                break;
 
             default:
                 return false;
@@ -2983,6 +3053,18 @@ var mspHelper = (function () {
 
     self.queryFcStatus = function (callback) {
         MSP.send_message(MSPCodes.MSPV2_INAV_STATUS, false, false, callback);
+    };
+
+    self.loadMZTCConfig = function (callback) {
+        MSP.send_message(MSPCodes.MSP2_MZTC_CONFIG, false, false, callback);
+    };
+
+    self.loadMZTCStatus = function (callback) {
+        MSP.send_message(MSPCodes.MSP2_MZTC_STATUS, false, false, callback);
+    };
+
+    self.saveMZTCConfig = function (callback) {
+        MSP.send_message(MSPCodes.MSP2_SET_MZTC_CONFIG, mspHelper.crunch(MSPCodes.MSP2_SET_MZTC_CONFIG), false, callback);
     };
 
     self.loadMiscV2 = function (callback) {

--- a/js/serialPortHelper.js
+++ b/js/serialPortHelper.js
@@ -133,6 +133,12 @@ const serialPortHelper = (function () {
             defaultBaud: 115200
         },
         {
+            name: 'MZTC_CAMERA',
+            groups: ['peripherals'],
+            defaultBaud: 115200,
+            isUnique: true
+        },
+        {
             name: 'CRSF_SENSOR',
             groups: ['sensors'],
             defaultBaud: 420000,
@@ -169,7 +175,8 @@ const serialPortHelper = (function () {
         'CRSF_SENSOR': 24,
         'MSP_DISPLAYPORT': 25,
         'GIMBAL': 26,
-        'HEADTRACKER': 27
+        'HEADTRACKER': 27,
+        'MZTC_CAMERA': 28
     };
 
     privateScope.identifierToName = {

--- a/js/settings.js
+++ b/js/settings.js
@@ -648,12 +648,33 @@ var Settings = (function () {
                     value = Math.round((parseFloat(input.val()) * multiplier) * Math.pow(10, precision)) / Math.pow(10, precision);
                 }
 
-                if (value > parseInt(input.data('default-max'))) {
-                    value = parseInt(input.data('default-max'));
+                // data-default-min and data-default-max only exist once a unit
+                // multiplier has rewritten the min and max attributes, so they
+                // hold the bounds in firmware units. Settings without a
+                // multiplier never get them, and parseInt(undefined) is NaN,
+                // which makes both comparisons false and skips the clamp
+                // entirely. Falling back to the attributes covers those,
+                // because without a multiplier the attributes already carry
+                // the firmware-unit bounds.
+                //
+                // This matters because the value is serialized with push8 and
+                // friends, which mask rather than reject. An out-of-range
+                // entry would otherwise wrap into a different in-range value
+                // that the flight controller then accepts as valid.
+                let clampMax = parseInt(input.data('default-max'));
+                if (isNaN(clampMax)) {
+                    clampMax = parseInt(input.attr('max'));
+                }
+                if (!isNaN(clampMax) && value > clampMax) {
+                    value = clampMax;
                 }
 
-                if (value < parseInt(input.data('default-min'))) {
-                    value = parseInt(input.data('default-min'));
+                let clampMin = parseInt(input.data('default-min'));
+                if (isNaN(clampMin)) {
+                    clampMin = parseInt(input.attr('min'));
+                }
+                if (!isNaN(clampMin) && value < clampMin) {
+                    value = clampMin;
                 }
             }
         }

--- a/js/settings.js
+++ b/js/settings.js
@@ -661,19 +661,19 @@ var Settings = (function () {
                 // friends, which mask rather than reject. An out-of-range
                 // entry would otherwise wrap into a different in-range value
                 // that the flight controller then accepts as valid.
-                let clampMax = parseInt(input.data('default-max'));
-                if (isNaN(clampMax)) {
-                    clampMax = parseInt(input.attr('max'));
+                let clampMax = Number.parseInt(input.data('default-max'));
+                if (Number.isNaN(clampMax)) {
+                    clampMax = Number.parseInt(input.attr('max'));
                 }
-                if (!isNaN(clampMax) && value > clampMax) {
+                if (!Number.isNaN(clampMax) && value > clampMax) {
                     value = clampMax;
                 }
 
-                let clampMin = parseInt(input.data('default-min'));
-                if (isNaN(clampMin)) {
-                    clampMin = parseInt(input.attr('min'));
+                let clampMin = Number.parseInt(input.data('default-min'));
+                if (Number.isNaN(clampMin)) {
+                    clampMin = Number.parseInt(input.attr('min'));
                 }
-                if (!isNaN(clampMin) && value < clampMin) {
+                if (!Number.isNaN(clampMin) && value < clampMin) {
                     value = clampMin;
                 }
             }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -4435,6 +4435,9 @@
     "osdGroupAltitude": {
         "message": "Altitude"
     },
+    "osdGroupThermalCamera": {
+        "message": "Thermal Camera"
+    },
     "osdGroupTimers": {
         "message": "Timers"
     },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1627,6 +1627,54 @@
     "portsFunction_HEADTRACKER": {
         "message": "Serial Headtracker"
     },
+    "portsFunction_MZTC_CAMERA": {
+        "message": "MassZero Thermal Camera"
+    },
+    "osdElement_MZTC_STATUS": {
+        "message": "Thermal Camera Status"
+    },
+    "configurationThermalCamera": {
+        "message": "MassZero Thermal Camera"
+    },
+    "configurationThermalCameraNote": {
+        "message": "Assign MZTC_CAMERA to a UART in the Ports tab to enable the camera. The port and its baud rate are set there. The camera ships at 115200."
+    },
+    "configurationThermalCameraMode": {
+        "message": "Operating mode"
+    },
+    "configurationThermalCameraPalette": {
+        "message": "Colour palette"
+    },
+    "configurationThermalCameraZoom": {
+        "message": "Digital zoom"
+    },
+    "configurationThermalCameraMirror": {
+        "message": "Image mirroring"
+    },
+    "configurationThermalCameraBrightness": {
+        "message": "Brightness [0-100]"
+    },
+    "configurationThermalCameraContrast": {
+        "message": "Contrast [0-100]"
+    },
+    "configurationThermalCameraEnhancement": {
+        "message": "Digital enhancement [0-100]"
+    },
+    "configurationThermalCameraSpatialDenoise": {
+        "message": "Spatial denoising [0-100]"
+    },
+    "configurationThermalCameraTemporalDenoise": {
+        "message": "Temporal denoising [0-100]"
+    },
+    "configurationThermalCameraAutoShutter": {
+        "message": "Automatic shutter mode"
+    },
+    "configurationThermalCameraFFCInterval": {
+        "message": "Shutter interval [minutes]"
+    },
+    "configurationThermalCameraUpdateRate": {
+        "message": "Driver poll rate [Hz]"
+    },
     "portsFunction_CRSF_SENSOR": {
         "message": "CRSF Sensor"
     },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1639,14 +1639,17 @@
     "configurationThermalCameraNote": {
         "message": "Assign MZTC_CAMERA to a UART in the Ports tab to enable the camera. The port and its baud rate are set there. The camera ships at 115200."
     },
-    "configurationThermalCameraMode": {
-        "message": "Operating mode"
+    "configurationThermalCameraPreset": {
+        "message": "Purpose preset"
     },
     "configurationThermalCameraPalette": {
         "message": "Colour palette"
     },
     "configurationThermalCameraZoom": {
         "message": "Digital zoom"
+    },
+    "configurationThermalCameraAdvanced": {
+        "message": "Advanced image tuning"
     },
     "configurationThermalCameraMirror": {
         "message": "Image mirroring"
@@ -1671,9 +1674,6 @@
     },
     "configurationThermalCameraFFCInterval": {
         "message": "Shutter interval [minutes]"
-    },
-    "configurationThermalCameraUpdateRate": {
-        "message": "Driver poll rate [Hz]"
     },
     "portsFunction_CRSF_SENSOR": {
         "message": "CRSF Sensor"

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -405,9 +405,9 @@
                         </div>
                     </div>
                     <div class="select">
-                        <select id="mztc_mode" data-setting="mztc_mode"></select>
-                        <label for="mztc_mode">
-                            <span data-i18n="configurationThermalCameraMode"></span>
+                        <select id="mztc_preset" data-setting="mztc_preset"></select>
+                        <label for="mztc_preset">
+                            <span data-i18n="configurationThermalCameraPreset"></span>
                         </label>
                     </div>
                     <div class="select">
@@ -422,22 +422,18 @@
                             <span data-i18n="configurationThermalCameraZoom"></span>
                         </label>
                     </div>
+                    <details class="mztc-advanced">
+                        <summary data-i18n="configurationThermalCameraAdvanced"></summary>
                     <div class="select">
-                        <select id="mztc_mirror_mode" data-setting="mztc_mirror_mode"></select>
-                        <label for="mztc_mirror_mode">
-                            <span data-i18n="configurationThermalCameraMirror"></span>
+                        <select id="mztc_auto_shutter" data-setting="mztc_auto_shutter"></select>
+                        <label for="mztc_auto_shutter">
+                            <span data-i18n="configurationThermalCameraAutoShutter"></span>
                         </label>
                     </div>
                     <div class="number">
-                        <input type="number" id="mztc_brightness" data-setting="mztc_brightness" />
-                        <label for="mztc_brightness">
-                            <span data-i18n="configurationThermalCameraBrightness"></span>
-                        </label>
-                    </div>
-                    <div class="number">
-                        <input type="number" id="mztc_contrast" data-setting="mztc_contrast" />
-                        <label for="mztc_contrast">
-                            <span data-i18n="configurationThermalCameraContrast"></span>
+                        <input type="number" id="mztc_ffc_interval" data-setting="mztc_ffc_interval" />
+                        <label for="mztc_ffc_interval">
+                            <span data-i18n="configurationThermalCameraFFCInterval"></span>
                         </label>
                     </div>
                     <div class="number">
@@ -458,24 +454,25 @@
                             <span data-i18n="configurationThermalCameraTemporalDenoise"></span>
                         </label>
                     </div>
+                    <div class="number">
+                        <input type="number" id="mztc_brightness" data-setting="mztc_brightness" />
+                        <label for="mztc_brightness">
+                            <span data-i18n="configurationThermalCameraBrightness"></span>
+                        </label>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="mztc_contrast" data-setting="mztc_contrast" />
+                        <label for="mztc_contrast">
+                            <span data-i18n="configurationThermalCameraContrast"></span>
+                        </label>
+                    </div>
                     <div class="select">
-                        <select id="mztc_auto_shutter" data-setting="mztc_auto_shutter"></select>
-                        <label for="mztc_auto_shutter">
-                            <span data-i18n="configurationThermalCameraAutoShutter"></span>
+                        <select id="mztc_mirror_mode" data-setting="mztc_mirror_mode"></select>
+                        <label for="mztc_mirror_mode">
+                            <span data-i18n="configurationThermalCameraMirror"></span>
                         </label>
                     </div>
-                    <div class="number">
-                        <input type="number" id="mztc_ffc_interval" data-setting="mztc_ffc_interval" />
-                        <label for="mztc_ffc_interval">
-                            <span data-i18n="configurationThermalCameraFFCInterval"></span>
-                        </label>
-                    </div>
-                    <div class="number">
-                        <input type="number" id="mztc_update_rate" data-setting="mztc_update_rate" />
-                        <label for="mztc_update_rate">
-                            <span data-i18n="configurationThermalCameraUpdateRate"></span>
-                        </label>
-                    </div>
+                    </details>
                 </div>
             </div>
         </div>

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -393,6 +393,91 @@
                     </div>
                 </div>
             </div>
+
+            <div class="config-section gui_box grey config-mztc">
+                <div class="gui_box_titlebar">
+                    <div class="spacer_box_title" data-i18n="configurationThermalCamera"></div>
+                </div>
+                <div class="spacer_box">
+                    <div class="note">
+                        <div class="note_spacer">
+                            <p data-i18n="configurationThermalCameraNote"></p>
+                        </div>
+                    </div>
+                    <div class="select">
+                        <select id="mztc_mode" data-setting="mztc_mode"></select>
+                        <label for="mztc_mode">
+                            <span data-i18n="configurationThermalCameraMode"></span>
+                        </label>
+                    </div>
+                    <div class="select">
+                        <select id="mztc_palette_mode" data-setting="mztc_palette_mode"></select>
+                        <label for="mztc_palette_mode">
+                            <span data-i18n="configurationThermalCameraPalette"></span>
+                        </label>
+                    </div>
+                    <div class="select">
+                        <select id="mztc_zoom_level" data-setting="mztc_zoom_level"></select>
+                        <label for="mztc_zoom_level">
+                            <span data-i18n="configurationThermalCameraZoom"></span>
+                        </label>
+                    </div>
+                    <div class="select">
+                        <select id="mztc_mirror_mode" data-setting="mztc_mirror_mode"></select>
+                        <label for="mztc_mirror_mode">
+                            <span data-i18n="configurationThermalCameraMirror"></span>
+                        </label>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="mztc_brightness" data-setting="mztc_brightness" />
+                        <label for="mztc_brightness">
+                            <span data-i18n="configurationThermalCameraBrightness"></span>
+                        </label>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="mztc_contrast" data-setting="mztc_contrast" />
+                        <label for="mztc_contrast">
+                            <span data-i18n="configurationThermalCameraContrast"></span>
+                        </label>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="mztc_digital_enhancement" data-setting="mztc_digital_enhancement" />
+                        <label for="mztc_digital_enhancement">
+                            <span data-i18n="configurationThermalCameraEnhancement"></span>
+                        </label>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="mztc_spatial_denoise" data-setting="mztc_spatial_denoise" />
+                        <label for="mztc_spatial_denoise">
+                            <span data-i18n="configurationThermalCameraSpatialDenoise"></span>
+                        </label>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="mztc_temporal_denoise" data-setting="mztc_temporal_denoise" />
+                        <label for="mztc_temporal_denoise">
+                            <span data-i18n="configurationThermalCameraTemporalDenoise"></span>
+                        </label>
+                    </div>
+                    <div class="select">
+                        <select id="mztc_auto_shutter" data-setting="mztc_auto_shutter"></select>
+                        <label for="mztc_auto_shutter">
+                            <span data-i18n="configurationThermalCameraAutoShutter"></span>
+                        </label>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="mztc_ffc_interval" data-setting="mztc_ffc_interval" />
+                        <label for="mztc_ffc_interval">
+                            <span data-i18n="configurationThermalCameraFFCInterval"></span>
+                        </label>
+                    </div>
+                    <div class="number">
+                        <input type="number" id="mztc_update_rate" data-setting="mztc_update_rate" />
+                        <label for="mztc_update_rate">
+                            <span data-i18n="configurationThermalCameraUpdateRate"></span>
+                        </label>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <div class="clear-both"></div>

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -31,6 +31,49 @@ function updateIna226SettingsVisibility() {
     $('.adc-current-setting').toggle(!usesIna226Current);
 }
 
+function isMztcPortAssigned() {
+    const ports = FC.SERIAL_CONFIG?.ports;
+    if (!Array.isArray(ports)) {
+        return false;
+    }
+
+    return ports.some(port => port.functions?.includes('MZTC_CAMERA'));
+}
+
+function updateMztcSettingsVisibility() {
+    // The camera settings only reach the firmware over a UART, so the card is
+    // meaningless until the peripheral is assigned in the Ports tab.
+    $('.config-mztc').toggle(isMztcPortAssigned());
+}
+
+// Applying a preset is an action on the firmware, not a stored value. The
+// firmware writes the palette, brightness, contrast, enhancement, both denoise
+// levels, the shutter mode and the correction interval, then reports them back.
+// Sending MSP2_SET_MZTC_PRESET is what makes that happen. Saving the setting on
+// its own would only record the label.
+function applyMztcPreset(presetIndex, onDone) {
+    MSP.send_message(MSPCodes.MSP2_SET_MZTC_PRESET, [presetIndex], false, function () {
+        // Re-read every setting so the advanced fields show what the firmware
+        // actually applied instead of the values the user was looking at.
+        Settings.processHtml(onDone || function () {})();
+    });
+}
+
+function bindMztcPresetSelector() {
+    const $preset = $('#mztc_preset');
+    if (!$preset.length) {
+        return;
+    }
+
+    $preset.on('change', function () {
+        const value = Number.parseInt($(this).val(), 10);
+        if (Number.isNaN(value)) {
+            return;
+        }
+        applyMztcPreset(value);
+    });
+}
+
 configurationTab.initialize = function (callback, scrollPosition) {
 
     if (GUI.active_tab !== this) {
@@ -47,7 +90,8 @@ configurationTab.initialize = function (callback, scrollPosition) {
         mspHelper.loadVTXConfig,
         mspHelper.loadBoardAlignment,
         mspHelper.loadCurrentMeterConfig,
-        mspHelper.loadMiscV2
+        mspHelper.loadMiscV2,
+        mspHelper.loadSerialPorts
     ];
 
     loadChainer.setChain(loadChain);
@@ -283,6 +327,8 @@ configurationTab.initialize = function (callback, scrollPosition) {
             $i2cSpeed.trigger('change');
             $('#vbat_meter_type, #current_meter_type').on('change', updateIna226SettingsVisibility);
             updateIna226SettingsVisibility();
+            updateMztcSettingsVisibility();
+            bindMztcPresetSelector();
         }).catch(function(error) {
             console.error('Settings load failed, dependent controls not initialized:', error);
         });

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -1648,6 +1648,14 @@ OSD.constants = {
                     }
                 },
                 {
+                    name: 'MZTC_STATUS',
+                    id: 171,
+                    min_version: '10.0.0',
+                    preview: function(osd_data) {
+                        return 'IR OK ';
+                    }
+                },
+                {
                     name: 'GPS_MAX_SPEED',
                     id: 125,
                     preview: function(osd_data) {

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -1416,6 +1416,9 @@ OSD.constants = {
         },
         {
             name: 'osdGroupThermalCamera',
+            enabled: function() {
+                return HARDWARE.capabilities.useMztcCamera;
+            },
             items: [
                 {
                     name: 'MZTC_STATUS',
@@ -3591,7 +3594,8 @@ HARDWARE.init = function() {
         useRx: false,
         useCRSF: false,
         useBaro: false,
-        usePitot: false
+        usePitot: false,
+        useMztcCamera: false
     };
 };
 
@@ -3609,6 +3613,9 @@ HARDWARE.update = function(callback) {
             }
             if (port.functions.includes('ESC')) {
                 HARDWARE.capabilities.useESCTelemetry = true;
+            }
+            if (port.functions.includes('MZTC_CAMERA')) {
+                HARDWARE.capabilities.useMztcCamera = true;
             }
         });
 

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -1415,6 +1415,24 @@ OSD.constants = {
             ]
         },
         {
+            name: 'osdGroupThermalCamera',
+            items: [
+                {
+                    name: 'MZTC_STATUS',
+                    id: 171,
+                    // min_version stays commented out until the firmware
+                    // version is bumped, matching AUTO SPEED. The
+                    // maintenance-10.x firmware still reports 9.x, so a
+                    // 10.0.0 gate would hide the element on the builds that
+                    // actually support it.
+                    // min_version: '10.0.0',
+                    preview: function(osd_data) {
+                        return 'IR OK ';
+                    }
+                },
+            ]
+        },
+        {
             name: 'osdGroupTimers',
             items: [
                 {
@@ -1645,14 +1663,6 @@ OSD.constants = {
                             default: // Metric
                                 return FONT.embed_dot('G:204') + FONT.symbol(SYM.KMH_3D);
                         }
-                    }
-                },
-                {
-                    name: 'MZTC_STATUS',
-                    id: 171,
-                    min_version: '10.0.0',
-                    preview: function(osd_data) {
-                        return 'IR OK ';
                     }
                 },
                 {


### PR DESCRIPTION
## What this is

Configurator support for the MassZero thermal camera. This is the companion to
the firmware in iNavFlight/inav#11837. The two are being opened in parallel.

The camera is a UART-controlled thermal core with a composite video output. The
firmware drives its control protocol. This side exposes the settings, registers
the serial function and adds the OSD element.

## Serial port

`MZTC_CAMERA` is registered as a peripheral serial function. Assigning it to a
UART in the Ports tab is what enables the camera.

The firmware finds the port and its baud rate through
`findSerialPortConfig(FUNCTION_MZTC_CAMERA)`, the same way gimbal, headtracker
and every other serial peripheral work. There is no separate enable, port or
baud rate setting to fall out of step with the Ports tab. The camera ships at
115200.

## MSP

Ten commands, contiguous from `0x2240` to `0x2249`, inside INAV's own range.
The `0x3000` block was not usable, since `MSP2_BETAFLIGHT_BIND` is `0x3000` and
`MSP2_RX_BIND` is `0x3001`.

| Command | Code | Direction | Payload |
| --- | --- | --- | --- |
| `MSP2_MZTC_CONFIG` | 0x2240 | Out | 12 bytes |
| `MSP2_MZTC_STATUS` | 0x2241 | Out | 7 bytes |
| `MSP2_SET_MZTC_CONFIG` | 0x2242 | In | 12 bytes |
| `MSP2_SET_MZTC_MODE` | 0x2243 | In | 1 byte |
| `MSP2_SET_MZTC_PALETTE` | 0x2244 | In | 1 byte |
| `MSP2_SET_MZTC_ZOOM` | 0x2245 | In | 1 byte |
| `MSP2_SET_MZTC_SHUTTER` | 0x2246 | In | 0 or 1 bytes |
| `MSP2_SET_MZTC_IMAGE_PARAMS` | 0x2247 | In | 3 bytes |
| `MSP2_SET_MZTC_CORRECTION` | 0x2248 | In | 2 bytes |
| `MSP2_SET_MZTC_VIGNETTING` | 0x2249 | In | 0 or 1 bytes |

Both payloads are read and written one field at a time. No compiler padding
reaches the wire. `connected` in the status payload is set only after the
camera has answered a command. An open UART on its own does not report a camera
present.

The payload layouts are documented in `docs/development/msp/msp_messages.json`
in the firmware PR.

## Configuration tab

A declarative section carrying `data-setting` attributes, in the same style as
the existing gimbal and headtracker sections. The Settings framework handles
load and save. The section needs no JavaScript.

All twelve firmware settings are exposed and nothing else is. I cross-checked
the `data-setting` names against the generated `docs/Settings.md` in both
directions. No field here lacks a firmware setting behind it. No firmware setting is
missing from the tab.

## OSD

One element, `MZTC_STATUS` at id 171, matching `OSD_MZTC_STATUS` in the
firmware. It shows a three letter link state: `OK`, `INI`, `FFC`, `REC`, `ALT`,
`ERR` or `OFF`.

There is no temperature element. The camera reports no temperature over its
serial protocol. There is nothing to display.

## One framework fix rides along

Review raised that the new numeric fields rely on the HTML `min` and `max`
attributes, while `encodeSetting()` clamps only against `data-default-min` and
`data-default-max`. That is correct. It is also worse than it first looks.

Those data attributes are written only when a unit multiplier rewrites the min
and max attributes. They carry the bounds in firmware units. A setting
without a multiplier never gets them. `parseInt(undefined)` is `NaN`. Both
comparisons against `NaN` are false. The clamp is skipped.

The value is then serialized with `push8` and friends. Those mask the value
into range. An out-of-range entry does not fail. It *wraps* into a different
in-range value. `mspSetSettingCommand()` on the flight controller then accepts
it, because all it ever sees is the wrapped byte. Its own bounds check cannot
help.

| Typed | Bounds | Byte sent before | After |
| --- | --- | --- | --- |
| 300 | 0 to 100 | 44 | 100 |
| -5 | 0 to 100 | 251 | 0 |
| 999 | 1 to 30 | 231 | 30 |
| 256 | 1 to 60 | **0** | 60 |

The 256 case is the sharp one: a shutter interval bounded 1 to 60 silently
becomes 0.

The clamp now falls back to the `min` and `max` attributes when the data
attributes are absent. Without a multiplier those attributes already hold the
firmware-unit bounds. The fallback is therefore exact. Settings that do carry a
multiplier keep their existing path untouched.

This is pre-existing. It applies to every multiplier-free numeric setting in
the app, `gimbal_sensitivity` among them. This branch inherits it. It is a separate commit so it can be split into its own PR if you
would rather keep this one to the camera.

## SonarCloud

The first analysis reported 31 new issues. 19 are fixed. The quality gate
passes.

`javascript:S7778` wanted a single `Array#push` call where the config crunch
had twelve consecutive ones. The single call keeps its arguments in field
order. That is also the wire order. It still reads as the payload layout.

`javascript:S7773` wanted `Number.parseInt` over the bare global in the clamp.
`Number.parseInt` is the same function object as `parseInt`. Behaviour is
unchanged. The `NaN` guards moved to `Number.isNaN` to match.

The remaining 12 are `Web:S6853`, "a form label must be associated with a
control and have accessible text", one per label in the new section. I have
left them. Here is the reasoning.

Every label uses the pattern the file already uses:

```html
<label for="mztc_mode">
    <span data-i18n="configurationThermalCameraMode"></span>
</label>
```

That is copied from the gimbal and headtracker sections immediately above it.
The same construct appears 41 times in the untouched parts of this one file.
`for` is present. The association half of the rule is satisfied. The text
half cannot be. `i18n.localize()` fills the element with
`element.html(translated)` at runtime. No label in this application has static
text.

The obvious way to silence it is an `aria-label`, but that would hard-code
English into markup whose visible text is translated. A Spanish user would get
Spanish on screen and English in a screen reader. That is a worse
accessibility outcome than the warning describes.

The alternatives, in case you would rather take one:

- Move `data-i18n` onto the `<label>` itself, as `tabs/calibration.html` does.
  That gives the label real text at runtime. The text is still absent
  statically. The rule would very likely still fire.
- Teach `i18n.localize()` to set `aria-label` from the same translation
  whenever it fills a `<label>`. That fixes all 53 occurrences in this file at
  once and is a genuine improvement, but it is a change to shared i18n
  behaviour and does not belong in a camera PR.

Happy to do either, or to open the second one as its own PR.

## Notes for review

This branch is a re-land. The original work sat on a June 2025 base, roughly
665 commits behind, and the tree has moved to ES modules since. Replaying it
produced conflicts in every file it touched. `package-lock.json` no longer
exists upstream at all. Rebuilding the integration against current
`maintenance-10.x` produced a much smaller and cleaner change than the replay
would have.

Three things from the original branch were deliberately dropped. `js/main.js`
had been edited to force DevTools open on every launch with an F12 toggle. That
is debug tooling. `js/localization.js` had an unrelated i18n tweak. `package.json` had gained
`electron-prebuilt-compile`. Nothing referenced it and it dragged in 13,385
lines of lockfile churn.

## Testing

The repository has no test runner and its `lint` script is a stub. I packaged
the app instead and ran it headless under Xvfb against a SITL build of the
firmware branch, driving it over the Chrome DevTools Protocol.

| Check | Result |
| --- | --- |
| Connects to SITL over TCP | connected, MSP v2, 25 ms round trip |
| `MassZero Thermal Camera` in the Ports peripheral list | present |
| Configuration tab renders the camera section | present |
| All 12 settings bound to `data-setting` | 12 of 12 |
| Every label resolves a locale string | no empty labels |
| Enum dropdowns populated from firmware | mode 8, palette 14, shutter 3 |
| Numeric fields carry firmware values | brightness 50, contrast 50, ffc_interval 5, update_rate 9 |
| OSD element offered | `Thermal Camera Status` |
| OSD element bound to the firmware id | renders as `display-field field-171` |
| OSD checkbox toggles | toggles and restores |

The dropdown contents and the numeric values come from the firmware over MSP.
Those rows exercise the whole path end to end.

Running it caught two bugs that static checking had missed, both fixed in the
second commit. The OSD element carried `min_version: '10.0.0'`. The maintenance-10.x
firmware still reports 9.1.0 until the release bump. That gate hid the element
on the builds that support it. The element had also been placed inside
`osdGroupGPS`. That group carries a GPS feature gate. The element vanished
whenever GPS was off.

Static checks alongside that: `node --check` on every touched JavaScript file,
a JSON parse and duplicate-key check on `messages.json`, and the settings
cross-check described above.

This targets `maintenance-10.x` to match the firmware PR, since the MSP change
requires coordinated firmware and configurator updates.
