### PR TITLE
Google Location Services & Weather Conditions for Mission Control

### DIFF
--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -2,6 +2,7 @@ import '../src/css/styles.css'
 
 import $ from 'jquery';
 import 'jquery-ui-dist/jquery-ui';
+import jBox from 'jbox';
 import * as THREE from 'three'
 
 import GUI, { TABS } from './gui';
@@ -55,6 +56,152 @@ import dialog from './dialog'
 
 window.$ = $;
 
+function showGoogleApiTestResult($result, messages) {
+    $result.empty();
+    messages.forEach((message, index) => {
+        if (index > 0) {
+            $result.append($('<br>'));
+        }
+        $result.append(document.createTextNode(message));
+    });
+}
+
+async function readGoogleApiResponse(response) {
+    const data = await response.json();
+    if (!response.ok) {
+        throw new Error(data.error?.message || response.statusText || String(response.status));
+    }
+    return data;
+}
+
+function createGoogleApiUrl(baseUrl, parameters) {
+    const url = new URL(baseUrl);
+    Object.entries(parameters).forEach(([name, value]) => {
+        url.searchParams.set(name, value);
+    });
+    return url;
+}
+
+function getGoogleApiErrorMessage(error, apiKey) {
+    return String(error.message || error).replaceAll(apiKey, '');
+}
+
+async function testGoogleApiKey(event) {
+    event.preventDefault();
+
+    const apiKey = String($('#google-api-key').val() || '').trim();
+    const $result = $('#google-api-key-result');
+    if (!apiKey) {
+        showGoogleApiTestResult($result, [i18n.getMessage('googleLocationTestNoKey')]);
+        return;
+    }
+
+    showGoogleApiTestResult($result, [i18n.getMessage('googleLocationTestPending')]);
+
+    try {
+        const locationUrl = createGoogleApiUrl('https://www.googleapis.com/geolocation/v1/geolocate', {
+            key: apiKey,
+        });
+        const locationResponse = await fetch(locationUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ considerIp: true }),
+        });
+        const locationData = await readGoogleApiResponse(locationResponse);
+        if (!locationData.location) {
+            throw new Error(locationData.error?.message || JSON.stringify(locationData));
+        }
+
+        const latitude = locationData.location.lat;
+        const longitude = locationData.location.lng;
+        const locationMessage = i18n.getMessage('googleLocationTestSuccess', [
+            latitude.toFixed(4),
+            longitude.toFixed(4),
+            Math.round(locationData.accuracy),
+        ]);
+        const resultMessages = [locationMessage];
+
+        try {
+            const geocodingUrl = createGoogleApiUrl('https://maps.googleapis.com/maps/api/geocode/json', {
+                latlng: `${latitude},${longitude}`,
+                key: apiKey,
+            });
+            const geocodingData = await readGoogleApiResponse(await fetch(geocodingUrl));
+            if (geocodingData.status !== 'OK') {
+                throw new Error(geocodingData.error_message || geocodingData.status);
+            }
+        } catch (geocodingError) {
+            resultMessages.push(i18n.getMessage('googleLocationTestGeocodingFail', [
+                getGoogleApiErrorMessage(geocodingError, apiKey),
+            ]));
+        }
+
+        try {
+            const weatherUrl = createGoogleApiUrl('https://weather.googleapis.com/v1/currentConditions:lookup', {
+                key: apiKey,
+                'location.latitude': latitude,
+                'location.longitude': longitude,
+            });
+            const weatherData = await readGoogleApiResponse(await fetch(weatherUrl));
+            if (weatherData.wind?.speed) {
+                const windUnit = weatherData.wind.speed.unit === 'KILOMETERS_PER_HOUR' ? 'km/h' : 'mph';
+                resultMessages.push(i18n.getMessage('googleLocationTestWeather', [
+                    weatherData.wind.speed.value,
+                    windUnit,
+                ]));
+            } else {
+                resultMessages.push(i18n.getMessage('googleLocationTestWeatherSuccess'));
+            }
+        } catch (weatherError) {
+            resultMessages.push(i18n.getMessage('googleLocationTestWeatherFail', [
+                getGoogleApiErrorMessage(weatherError, apiKey),
+            ]));
+        }
+        showGoogleApiTestResult($result, resultMessages);
+    } catch (error) {
+        const errorMessage = getGoogleApiErrorMessage(error, apiKey);
+        showGoogleApiTestResult($result, [i18n.getMessage('googleLocationTestError', [errorMessage])]);
+    }
+}
+
+function showGoogleApiHelp(event) {
+    event.preventDefault();
+
+    const $content = $('<div class="modal__content"></div>');
+    $content.append($('<p class="modal__text"></p>').text(i18n.getMessage('googleLocationHelpBenefit')));
+    $content.append($('<p class="modal__text"></p>').text(i18n.getMessage('googleLocationHelpHowTitle')));
+
+    const $steps = $('<ol class="modal__text"></ol>');
+    for (let step = 1; step <= 5; step++) {
+        $steps.append($('<li></li>').html(i18n.getMessage(`googleLocationHelpStep${step}`)));
+    }
+    $steps.find('a[target="_blank"]').attr('rel', 'noopener noreferrer');
+    $content.append($steps);
+    $content.append($('<p class="modal__text"></p>').text(i18n.getMessage('googleLocationHelpNote')));
+
+    const $buttons = $('<div class="modal__buttons"></div>');
+    const $closeButton = $('<a class="modal__button modal__button--main" href="#"></a>')
+        .text(i18n.getMessage('googleLocationHelpClose'));
+    $buttons.append($closeButton);
+    $content.append($buttons);
+
+    const helpModal = new jBox('Modal', {
+        title: i18n.getMessage('googleLocationHelpTitle'),
+        animation: false,
+        closeOnClick: false,
+        closeOnEsc: true,
+        content: $content,
+        onCloseComplete: function () {
+            this.destroy();
+        },
+    });
+    $closeButton.on('click', function (closeEvent) {
+        closeEvent.preventDefault();
+        helpModal.close();
+    });
+    helpModal.open();
+}
+
 // Set how the units render on the configurator only
 $(function() {
     i18n.init( () => {
@@ -75,6 +222,7 @@ $(function() {
         globalSettings.unitType = store.get('unit_type', UnitType.none);
         globalSettings.mapProviderType = store.get('map_provider_type', 'osm'); 
         globalSettings.assistnowApiKey = store.get('assistnow_api_key', '');
+        globalSettings.googleApiKey = store.get('google_api_key', '');
         globalSettings.proxyURL = store.get('proxyurl', 'http://192.168.1.222/mapproxy/service?');
         globalSettings.proxyLayer = store.get('proxylayer', 'your_proxy_layer_name');
         globalSettings.showProfileParameters = store.get('show_profile_parameters', 1);
@@ -435,6 +583,7 @@ $(function() {
                     $('#showProfileParameters').prop('checked', globalSettings.showProfileParameters);
                     $('#cliAutocomplete').prop('checked', globalSettings.cliAutocomplete);
                     $('#assistnow-api-key').val(globalSettings.assistnowApiKey);
+                    $('#google-api-key').val(globalSettings.googleApiKey);
                     
                     i18n.getLanguages().forEach(lng => {
                         $('#languageOption').append("<option value='{0}'>{1}</option>".format(lng, i18n.getMessage("language_" + lng)));
@@ -480,6 +629,12 @@ $(function() {
                         store.set('assistnow_api_key', $(this).val());
                         globalSettings.assistnowApiKey = $(this).val();
                     });
+                    $('#google-api-key').on('change', function () {
+                        store.set('google_api_key', $(this).val());
+                        globalSettings.googleApiKey = $(this).val();
+                    });
+                    $('#google-api-key-test').on('click', testGoogleApiKey);
+                    $('#google-api-key-help').on('click', showGoogleApiHelp);
  
                     $('#demoModeReset').on('click', function () {
                         SITLProcess.deleteEepromFile('demo.bin');

--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -630,8 +630,10 @@ $(function() {
                         globalSettings.assistnowApiKey = $(this).val();
                     });
                     $('#google-api-key').on('change', function () {
-                        store.set('google_api_key', $(this).val());
-                        globalSettings.googleApiKey = $(this).val();
+                        const apiKey = String($(this).val() || '').trim();
+                        $(this).val(apiKey);
+                        store.set('google_api_key', apiKey);
+                        globalSettings.googleApiKey = apiKey;
                     });
                     $('#google-api-key-test').on('click', testGoogleApiKey);
                     $('#google-api-key-help').on('click', showGoogleApiHelp);

--- a/js/globalSettings.js
+++ b/js/globalSettings.js
@@ -22,6 +22,7 @@ var globalSettings = {
     configuratorTreeLocation: 'master',
     cliAutocomplete: true,
     assistnowApiKey: null,
+    googleApiKey: null,
     assistnowOfflineData: [],
     assistnowOfflineDate: 0,
     store: null,

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6712,6 +6712,144 @@
     "gpsOptionsAssistnowToken": {
         "message": "AssitNow Token"
     },
+    "googleLocationServices": {
+        "message": "Google Location & Weather Services"
+    },
+    "googleLocationApiKey": {
+        "message": "API Key"
+    },
+    "googleLocationTestButton": {
+        "message": "Test API key"
+    },
+    "googleLocationHelpButton": {
+        "message": "Help and setup instructions"
+    },
+    "googleLocationTestPending": {
+        "message": "Testing…"
+    },
+    "googleLocationTestSuccess": {
+        "message": "Success! Location: $1, $2 (accuracy: $3 m)"
+    },
+    "googleLocationTestNoKey": {
+        "message": "Please enter an API key first."
+    },
+    "googleLocationTestError": {
+        "message": "Error: $1"
+    },
+    "googleLocationTestGeocodingFail": {
+        "message": "Google Geocoding API unavailable: $1 — address search will use OpenStreetMap instead."
+    },
+    "googleLocationTestWeatherSuccess": {
+        "message": "Weather API OK"
+    },
+    "googleLocationTestWeather": {
+        "message": "Weather API OK — Wind: $1 $2"
+    },
+    "googleLocationTestWeatherFail": {
+        "message": "Weather API failed: $1 — Enable the Weather API in Google Cloud Console."
+    },
+    "googleLocationHelpTitle": {
+        "message": "Google Location & Weather Services"
+    },
+    "googleLocationHelpBenefit": {
+        "message": "With a Google API key, Mission Control can determine your approximate IP-based location before the flight controller has a GPS fix. It can also show current weather conditions for offline mission planning or the aircraft's GPS position."
+    },
+    "googleLocationHelpHowTitle": {
+        "message": "How to configure an API key:"
+    },
+    "googleLocationHelpStep1": {
+        "message": "Open the <a href='https://console.cloud.google.com/' target='_blank'>Google Cloud Console</a>."
+    },
+    "googleLocationHelpStep2": {
+        "message": "Create a project or select an existing project."
+    },
+    "googleLocationHelpStep3": {
+        "message": "Enable the Geolocation API, Geocoding API, and Weather API."
+    },
+    "googleLocationHelpStep4": {
+        "message": "Create an API key under APIs &amp; Services → Credentials."
+    },
+    "googleLocationHelpStep5": {
+        "message": "Restrict the key to the Geolocation, Geocoding, and Weather APIs, then paste it here."
+    },
+    "googleLocationHelpNote": {
+        "message": "The key is stored locally. Google API usage may be subject to quotas or billing; review your Google Cloud settings before enabling these services."
+    },
+    "googleLocationHelpClose": {
+        "message": "Close"
+    },
+    "apiLocationBannerPrefix": {
+        "message": "API location (IP-based)"
+    },
+    "apiLocationBannerCoordinates": {
+        "message": "Lat: $1  Lon: $2  (~$3 km)"
+    },
+    "apiLocationBannerWarning": {
+        "message": "accuracy may be low"
+    },
+    "addressSearchTitle": {
+        "message": "Search for Location"
+    },
+    "addressSearchPlaceholder": {
+        "message": "Enter address, city, or coordinates"
+    },
+    "addressSearchCancel": {
+        "message": "Cancel"
+    },
+    "addressSearchSubmit": {
+        "message": "Search"
+    },
+    "addressSearchConfirmation": {
+        "message": "Found: $1\nSource: $2\n\nMove to this location?"
+    },
+    "addressSearchNotFound": {
+        "message": "Address not found."
+    },
+    "addressSearchFailed": {
+        "message": "Search failed. Check your connection."
+    },
+    "conditionsInfoHead": {
+        "message": "Weather Conditions"
+    },
+    "conditionsWaiting": {
+        "message": "Waiting for location…"
+    },
+    "conditionsWind": {
+        "message": "Wind: "
+    },
+    "conditionsGusts": {
+        "message": "Gusts: "
+    },
+    "conditionsWindDir": {
+        "message": "Direction: "
+    },
+    "conditionsTemp": {
+        "message": "Temperature: "
+    },
+    "conditionsFeelsLike": {
+        "message": "Feels like: "
+    },
+    "conditionsHumidity": {
+        "message": "Humidity: "
+    },
+    "conditionsUV": {
+        "message": "UV index: "
+    },
+    "conditionsPrecip": {
+        "message": "Precipitation: "
+    },
+    "conditionsThunder": {
+        "message": "Thunderstorm: "
+    },
+    "conditionsVisibility": {
+        "message": "Visibility: "
+    },
+    "conditionsCloud": {
+        "message": "Cloud cover: "
+    },
+    "conditionsUnavailable": {
+        "message": "Weather data unavailable"
+    },
     "gpsLoadAssistnowOfflineButton": {
         "message": "Load AssistNow Offline"
     },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6811,6 +6811,18 @@
     "conditionsInfoHead": {
         "message": "Weather Conditions"
     },
+    "conditionsInfoHeadSource": {
+        "message": "Weather — $1"
+    },
+    "conditionsSourceAircraft": {
+        "message": "Aircraft"
+    },
+    "conditionsSourceWaypoint": {
+        "message": "WP1"
+    },
+    "conditionsSourceMapCenter": {
+        "message": "Map Center"
+    },
     "conditionsWaiting": {
         "message": "Waiting for location…"
     },

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -651,6 +651,70 @@
                         </div> -->
                     </div>
                 </div>
+
+                <div id="missionPlannerConditions" class="gui_box grey is-hidden">
+                    <div class="gui_box_titlebar">
+                        <div class="spacer_box_title" data-i18n="conditionsInfoHead"></div>
+                        <div class="btnMenu btnMenuIcon show_btn" id="showHideConditionsButton">
+                            <a class="ic_hide" href="#" i18n_title="missionTitleHide">
+                                <span class="sr-only" data-i18n="missionTitleHide"></span>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="spacer" id="ConditionsContent">
+                        <div id="conditionsLoading" data-i18n="conditionsWaiting"></div>
+                        <div id="conditionsData" class="is-hidden">
+                            <div class="point">
+                                <span id="condWeather"></span>
+                            </div>
+                            <div class="point">
+                                <span class="point-label" data-i18n="conditionsWind"></span>
+                                <span id="condWind"></span>
+                            </div>
+                            <div class="point">
+                                <span class="point-label" data-i18n="conditionsGusts"></span>
+                                <span id="condGusts"></span>
+                            </div>
+                            <div class="point">
+                                <span class="point-label" data-i18n="conditionsWindDir"></span>
+                                <span id="condWindDir"></span>
+                            </div>
+                            <div class="point">
+                                <span class="point-label" data-i18n="conditionsTemp"></span>
+                                <span id="condTemp"></span>
+                            </div>
+                            <div class="point">
+                                <span class="point-label" data-i18n="conditionsFeelsLike"></span>
+                                <span id="condFeelsLike"></span>
+                            </div>
+                            <div class="point">
+                                <span class="point-label" data-i18n="conditionsHumidity"></span>
+                                <span id="condHumidity"></span>
+                            </div>
+                            <div class="point">
+                                <span class="point-label" data-i18n="conditionsUV"></span>
+                                <span id="condUV"></span>
+                            </div>
+                            <div class="point">
+                                <span class="point-label" data-i18n="conditionsPrecip"></span>
+                                <span id="condPrecip"></span>
+                            </div>
+                            <div class="point">
+                                <span class="point-label" data-i18n="conditionsThunder"></span>
+                                <span id="condThunder"></span>
+                            </div>
+                            <div class="point">
+                                <span class="point-label" data-i18n="conditionsVisibility"></span>
+                                <span id="condVisibility"></span>
+                            </div>
+                            <div class="point">
+                                <span class="point-label" data-i18n="conditionsCloud"></span>
+                                <span id="condCloud"></span>
+                            </div>
+                        </div>
+                        <div id="conditionsError" class="is-hidden" data-i18n="conditionsUnavailable"></div>
+                    </div>
+                </div>
             </div>
         </div>
         <div class="cf_column threefourth_left" style="height: 100%;">

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -654,7 +654,7 @@
 
                 <div id="missionPlannerConditions" class="gui_box grey is-hidden">
                     <div class="gui_box_titlebar">
-                        <div class="spacer_box_title" data-i18n="conditionsInfoHead"></div>
+                        <div id="conditionsTitle" class="spacer_box_title" data-i18n="conditionsInfoHead"></div>
                         <div class="btnMenu btnMenuIcon show_btn" id="showHideConditionsButton">
                             <a class="ic_hide" href="#" i18n_title="missionTitleHide">
                                 <span class="sr-only" data-i18n="missionTitleHide"></span>

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -223,6 +223,66 @@ function getLocationDistanceMeters(first, second) {
     return 6371000 * 2 * Math.atan2(Math.sqrt(boundedHaversine), Math.sqrt(1 - boundedHaversine));
 }
 
+function isWeatherSourceMateriallyChanged(currentSource, nextSource) {
+    if (!currentSource || !nextSource || currentSource.type !== nextSource.type) {
+        return true;
+    }
+    const minimumDistances = {
+        gps: WEATHER_GPS_MIN_DISTANCE_METERS,
+        map: WEATHER_MAP_CENTER_MIN_DISTANCE_METERS,
+        waypoint: WEATHER_WAYPOINT_MIN_DISTANCE_METERS,
+    };
+    const minimumDistance = minimumDistances[nextSource.type];
+    return getLocationDistanceMeters(currentSource, nextSource) >= minimumDistance;
+}
+
+function updateConditionsTitle(source) {
+    const titleKeys = {
+        gps: 'conditionsSourceAircraft',
+        waypoint: 'conditionsSourceWaypoint',
+        map: 'conditionsSourceMapCenter',
+    };
+    $('#conditionsTitle').text(i18n.getMessage('conditionsInfoHeadSource', [
+        i18n.getMessage(titleKeys[source.type]),
+    ]));
+}
+
+function clearWeatherRetry() {
+    clearTimeout(weatherRetryTimer);
+    weatherRetryTimer = null;
+}
+
+async function parseWeatherResponse(response) {
+    let data;
+    try {
+        data = await response.json();
+    } catch (error) {
+        if (!response.ok) {
+            throw createWeatherResponseError(response, null);
+        }
+        throw error;
+    }
+    if (!response.ok || data?.error) {
+        throw createWeatherResponseError(response, data);
+    }
+    return data;
+}
+
+function isCurrentWeatherRequest(requestController, apiKey, locationLifecycleId) {
+    return missionControlLocationLifecycleId === locationLifecycleId
+        && weatherAbortController === requestController
+        && String(globalSettings.googleApiKey || '').trim() === apiKey;
+}
+
+function normalizeWeatherRequestError(error, requestTimedOut) {
+    if (error.name !== 'AbortError') {
+        return error;
+    }
+    return requestTimedOut
+        ? createWeatherRequestError('Weather API request timed out', true)
+        : null;
+}
+
 function toTitleCase(value) {
     return String(value || '').replaceAll('_', ' ').toLowerCase()
         .replace(/\b\w/g, function (character) { return character.toUpperCase(); });
@@ -662,39 +722,10 @@ missionControlTab.initialize = function (callback) {
         return getFirstMissionLocation() || getMapCenterWeatherLocation();
     }
 
-    function isWeatherSourceMateriallyChanged(currentSource, nextSource) {
-        if (!currentSource || !nextSource || currentSource.type !== nextSource.type) {
-            return true;
-        }
-        const minimumDistances = {
-            gps: WEATHER_GPS_MIN_DISTANCE_METERS,
-            map: WEATHER_MAP_CENTER_MIN_DISTANCE_METERS,
-            waypoint: WEATHER_WAYPOINT_MIN_DISTANCE_METERS,
-        };
-        const minimumDistance = minimumDistances[nextSource.type];
-        return getLocationDistanceMeters(currentSource, nextSource) >= minimumDistance;
-    }
-
-    function updateConditionsTitle(source) {
-        const titleKeys = {
-            gps: 'conditionsSourceAircraft',
-            waypoint: 'conditionsSourceWaypoint',
-            map: 'conditionsSourceMapCenter',
-        };
-        $('#conditionsTitle').text(i18n.getMessage('conditionsInfoHeadSource', [
-            i18n.getMessage(titleKeys[source.type]),
-        ]));
-    }
-
-    function clearWeatherRetry() {
-        clearTimeout(weatherRetryTimer);
-        weatherRetryTimer = null;
-    }
-
     function syncWeatherApiKey() {
         const apiKey = String(globalSettings.googleApiKey || '').trim();
         if (apiKey === weatherApiKey) {
-            return apiKey;
+            return false;
         }
 
         weatherApiKey = apiKey;
@@ -704,7 +735,7 @@ missionControlTab.initialize = function (callback) {
         clearWeatherRetry();
         weatherAbortController?.abort();
         weatherAbortController = null;
-        return apiKey;
+        return true;
     }
 
     function scheduleWeatherRetry(source, apiKey, retryDelayMs) {
@@ -764,21 +795,8 @@ missionControlTab.initialize = function (callback) {
 
         try {
             const response = await fetch(url, { signal: requestController.signal });
-            let data;
-            try {
-                data = await response.json();
-            } catch (error) {
-                if (!response.ok) {
-                    throw createWeatherResponseError(response, null);
-                }
-                throw error;
-            }
-            if (!response.ok || data?.error) {
-                throw createWeatherResponseError(response, data);
-            }
-            if (missionControlLocationLifecycleId !== locationLifecycleId
-                || weatherAbortController !== requestController
-                || String(globalSettings.googleApiKey || '').trim() !== apiKey) {
+            const data = await parseWeatherResponse(response);
+            if (!isCurrentWeatherRequest(requestController, apiKey, locationLifecycleId)) {
                 return false;
             }
 
@@ -790,16 +808,8 @@ missionControlTab.initialize = function (callback) {
             blockedWeatherApiKey = null;
             return true;
         } catch (error) {
-            let weatherError = error;
-            if (error.name === 'AbortError') {
-                if (!requestTimedOut) {
-                    return false;
-                }
-                weatherError = createWeatherRequestError('Weather API request timed out', true);
-            }
-            if (missionControlLocationLifecycleId !== locationLifecycleId
-                || weatherAbortController !== requestController
-                || String(globalSettings.googleApiKey || '').trim() !== apiKey) {
+            const weatherError = normalizeWeatherRequestError(error, requestTimedOut);
+            if (!weatherError || !isCurrentWeatherRequest(requestController, apiKey, locationLifecycleId)) {
                 return false;
             }
 
@@ -825,9 +835,8 @@ missionControlTab.initialize = function (callback) {
         if (missionControlLocationLifecycleId !== locationLifecycleId) {
             return false;
         }
-        const previousApiKey = weatherApiKey;
-        const apiKey = syncWeatherApiKey();
-        const apiKeyChanged = apiKey !== previousApiKey;
+        const apiKeyChanged = syncWeatherApiKey();
+        const apiKey = weatherApiKey;
         if (!apiKey) {
             showConditionsPanel(false);
             return false;

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -123,6 +123,195 @@ const iconNames = [
 
 const icons = Object.create(null)
 
+const missionControlLocationNamespace = '.missionControlLocation';
+let googleLocationAbortController = null;
+let weatherAbortController = null;
+let addressSearchAbortController = null;
+
+function cleanupMissionControlLocationResources() {
+    googleLocationAbortController?.abort();
+    googleLocationAbortController = null;
+    weatherAbortController?.abort();
+    weatherAbortController = null;
+    addressSearchAbortController?.abort();
+    addressSearchAbortController = null;
+
+    $(document).off(missionControlLocationNamespace);
+    $('#searchAddress, #centerOnDrone, #showHideConditionsButton').off(missionControlLocationNamespace);
+    $('#addressSearchDialog, #addressSearchBackdrop').remove();
+
+    const apiOverlayEl = document.getElementById('geo_info');
+    if (apiOverlayEl) {
+        apiOverlayEl.textContent = '';
+        apiOverlayEl.style.visibility = 'hidden';
+    }
+}
+
+function showConditionsPanel(isVisible) {
+    $('#missionPlannerConditions').toggleClass('is-hidden', !isVisible);
+}
+
+function toTitleCase(value) {
+    return String(value || '').replaceAll('_', ' ').toLowerCase()
+        .replace(/\b\w/g, function (character) { return character.toUpperCase(); });
+}
+
+function applyThresholdColor(selector, value, lowThreshold, mediumThreshold) {
+    $(selector).css('color', '');
+    if (!Number.isFinite(value)) {
+        return;
+    }
+
+    if (value < lowThreshold) {
+        $(selector).css('color', '#4caf50');
+    } else if (value < mediumThreshold) {
+        $(selector).css('color', '#ff9800');
+    } else {
+        $(selector).css('color', '#f44336');
+    }
+}
+
+function applyUvColor(uv) {
+    $('#condUV').css('color', '');
+    if (!Number.isFinite(uv)) {
+        return;
+    }
+
+    if (uv > 7) {
+        $('#condUV').css('color', '#f44336');
+    } else if (uv > 5) {
+        $('#condUV').css('color', '#f57c00');
+    } else {
+        applyThresholdColor('#condUV', uv, 3, 6);
+    }
+}
+
+function applyThunderColor(thunder) {
+    $('#condThunder').css('color', '');
+    if (!Number.isFinite(thunder)) {
+        return;
+    }
+
+    if (thunder > 30) {
+        $('#condThunder').css('color', '#f44336');
+    } else if (thunder > 10) {
+        $('#condThunder').css('color', '#ff9800');
+    }
+}
+
+function formatConditionsValue(value, unit = '') {
+    if (value == null || value === '') {
+        return '—';
+    }
+
+    return unit ? `${value} ${unit}` : String(value);
+}
+
+function renderConditionsInfo(data) {
+    if (!data || typeof data !== 'object' || data.error) {
+        return false;
+    }
+
+    const windSpeed = data.wind?.speed?.value;
+    const windUnit = data.wind?.speed?.unit;
+    const gustSpeed = data.wind?.gust?.value;
+    const windDirection = data.wind?.direction?.degrees;
+    const windCardinal = data.wind?.direction?.cardinal;
+    const windUnitLabels = {
+        KILOMETERS_PER_HOUR: 'km/h',
+        MILES_PER_HOUR: 'mph',
+    };
+    const windUnitLabel = windUnitLabels[windUnit] || '';
+    const windArrows = ['↓', '↙', '←', '↖', '↑', '↗', '→', '↘'];
+    const windArrow = Number.isFinite(windDirection)
+        ? windArrows[Math.round(windDirection / 45) % windArrows.length]
+        : '';
+    const windDirectionParts = [windArrow, toTitleCase(windCardinal)].filter(Boolean);
+    if (Number.isFinite(windDirection)) {
+        windDirectionParts.push(`(${windDirection}°)`);
+    }
+
+    const temperature = data.temperature?.degrees;
+    const temperatureUnit = data.temperature?.unit === 'CELSIUS'
+        ? '°C'
+        : data.temperature?.unit === 'FAHRENHEIT' ? '°F' : '';
+    const feelsLike = data.feelsLikeTemperature?.degrees;
+    const uv = data.uvIndex;
+    const precipitation = data.precipitation?.qpf?.quantity;
+    const precipitationUnit = data.precipitation?.qpf?.unit === 'INCHES' ? 'in' : 'mm';
+    const thunder = data.thunderstormProbability;
+    const visibility = data.visibility?.distance;
+    const visibilityUnit = data.visibility?.unit === 'KILOMETERS'
+        ? 'km'
+        : data.visibility?.unit === 'MILES' ? 'mi' : '';
+    const cloudCover = data.cloudCover;
+
+    $('#condWeather').text(data.weatherCondition?.description?.text || '—');
+    $('#condWind').text(formatConditionsValue(windSpeed, windUnitLabel));
+    $('#condGusts').text(formatConditionsValue(gustSpeed, windUnitLabel));
+    $('#condWindDir').text(windDirectionParts.join(' ') || '—');
+    $('#condTemp').text(formatConditionsValue(temperature, temperatureUnit));
+    $('#condFeelsLike').text(formatConditionsValue(feelsLike, temperatureUnit));
+    $('#condHumidity').text(formatConditionsValue(data.relativeHumidity, '%'));
+    $('#condUV').text(formatConditionsValue(uv));
+    $('#condPrecip').text(formatConditionsValue(precipitation, precipitationUnit));
+    $('#condThunder').text(formatConditionsValue(thunder, '%'));
+    $('#condVisibility').text(formatConditionsValue(visibility, visibilityUnit));
+    $('#condCloud').text(formatConditionsValue(cloudCover, '%'));
+
+    const windSpeedKmh = Number.isFinite(windSpeed)
+        ? (windUnit === 'MILES_PER_HOUR' ? windSpeed * 1.609 : windSpeed)
+        : Number.NaN;
+    const gustSpeedKmh = Number.isFinite(gustSpeed)
+        ? (windUnit === 'MILES_PER_HOUR' ? gustSpeed * 1.609 : gustSpeed)
+        : Number.NaN;
+    applyUvColor(uv);
+    applyThunderColor(thunder);
+    applyThresholdColor('#condWind', windSpeedKmh, 20, 35);
+    applyThresholdColor('#condGusts', gustSpeedKmh, 25, 45);
+
+    showConditionsPanel(true);
+    $('#conditionsLoading').hide();
+    $('#conditionsError').hide();
+    $('#conditionsData').removeClass('is-hidden').show();
+    return true;
+}
+
+function showApiLocationBanner(apiOverlayEl, infoOverlayEl, googleGeoPos) {
+    if (!apiOverlayEl || !googleGeoPos) {
+        return;
+    }
+
+    if (infoOverlayEl) {
+        infoOverlayEl.style.visibility = 'hidden';
+    }
+
+    const accuracyKm = Number.isFinite(googleGeoPos.accuracy)
+        ? (googleGeoPos.accuracy / 1000).toFixed(0)
+        : '—';
+    apiOverlayEl.textContent =
+        `${i18n.getMessage('apiLocationBannerPrefix')}  ` +
+        `${i18n.getMessage('apiLocationBannerCoordinates', [
+            googleGeoPos.lat.toFixed(4),
+            googleGeoPos.lng.toFixed(4),
+            accuracyKm,
+        ])} — ${i18n.getMessage('apiLocationBannerWarning')}`;
+    apiOverlayEl.style.visibility = 'visible';
+}
+
+function getGoogleLocationZoom(googleGeoPos) {
+    if (!googleGeoPos) {
+        return 14;
+    }
+    if (googleGeoPos.accuracy > 5000) {
+        return 10;
+    }
+    if (googleGeoPos.accuracy > 1000) {
+        return 12;
+    }
+    return 14;
+}
+
 function rotateGridPoint(point, angleRad) {
     const cosAngle = Math.cos(angleRad);
     const sinAngle = Math.sin(angleRad);
@@ -275,6 +464,8 @@ missionControlTab.isYmapLoad = false;
 let elevationChartInstance = null;
 missionControlTab.initialize = function (callback) {
 
+    cleanupMissionControlLocationResources();
+
     let cursorInitialized = false;
     let curPosStyle;
     let curPosGeo;
@@ -286,8 +477,10 @@ missionControlTab.initialize = function (callback) {
     let breadCrumbVector;
     let autoCenteredOnFix = false;
     let lastGpsPos = null;
+    let googleGeoPos = null;
     let infoOverlayEl;
     let infoOverlaySpans;
+    let apiOverlayEl;
     let isOffline = false;
     let selectedSafehome;
     let $safehomeContentBox;
@@ -297,6 +490,195 @@ missionControlTab.initialize = function (callback) {
     let invalidGeoZones = false;
     let isGeozoneEnabeld = false;
     let settings = {speed: 0, alt: 5000, safeRadiusSH: 50, fwApproachAlt: 60, fwLandAlt: 5, maxDistSH: 0, fwApproachLength: 0, fwLoiterRadius: 0};
+    let googleLocationRequestStarted = false;
+    let conditionsFetched = false;
+    const conditionsSourcesAttempted = new Set();
+
+    function getCurrentDroneLocation() {
+        const lat = FC.GPS_DATA?.lat / 10000000;
+        const lng = FC.GPS_DATA?.lon / 10000000;
+        if (FC.GPS_DATA?.fix < 2 || !Number.isFinite(lat) || !Number.isFinite(lng)
+            || Math.abs(lat) > 90 || Math.abs(lng) > 180) {
+            return null;
+        }
+
+        return {
+            lat,
+            lng,
+            coord: fromLonLat([lng, lat]),
+        };
+    }
+
+    function getFirstMissionCoordinate() {
+        const firstWaypoint = mission.get().find(function (waypoint) {
+            return !waypoint.isAttached();
+        });
+        if (!firstWaypoint) {
+            return null;
+        }
+
+        const lat = firstWaypoint.getLatMap();
+        const lng = firstWaypoint.getLonMap();
+        if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+            return null;
+        }
+
+        return fromLonLat([lng, lat]);
+    }
+
+    function showConditionsUnavailable() {
+        showConditionsPanel(true);
+        $('#conditionsLoading').hide();
+        $('#conditionsData').addClass('is-hidden').hide();
+        $('#conditionsError').text(i18n.getMessage('conditionsUnavailable')).removeClass('is-hidden').show();
+    }
+
+    async function fetchConditionsInfo(lat, lng, source) {
+        if (!globalSettings.googleApiKey || conditionsSourcesAttempted.has(source)) {
+            return false;
+        }
+
+        conditionsSourcesAttempted.add(source);
+        const useImperial = globalSettings.unitType === 'imperial'
+            || (globalSettings.unitType === 'OSD' && globalSettings.osdUnits === 0);
+        const url = new URL('https://weather.googleapis.com/v1/currentConditions:lookup');
+        url.searchParams.set('key', globalSettings.googleApiKey);
+        url.searchParams.set('location.latitude', lat.toFixed(4));
+        url.searchParams.set('location.longitude', lng.toFixed(4));
+        if (useImperial) {
+            url.searchParams.set('unitsSystem', 'IMPERIAL');
+        }
+
+        weatherAbortController?.abort();
+        const requestController = new AbortController();
+        weatherAbortController = requestController;
+        showConditionsPanel(true);
+        $('#conditionsLoading').text(i18n.getMessage('conditionsWaiting')).show();
+        $('#conditionsData').addClass('is-hidden').hide();
+        $('#conditionsError').addClass('is-hidden').hide();
+
+        try {
+            const response = await fetch(url, { signal: requestController.signal });
+            const data = await response.json();
+            if (!response.ok || data?.error) {
+                throw new Error(data?.error?.message || `HTTP ${response.status}`);
+            }
+
+            conditionsFetched = renderConditionsInfo(data);
+            if (!conditionsFetched) {
+                showConditionsUnavailable();
+            }
+            return conditionsFetched;
+        } catch (error) {
+            if (error.name !== 'AbortError') {
+                conditionsFetched = false;
+                showConditionsUnavailable();
+                console.warn('Google Weather unavailable:', error.message);
+            }
+            return false;
+        } finally {
+            if (weatherAbortController === requestController) {
+                weatherAbortController = null;
+            }
+        }
+    }
+
+    function centerMapOnCurrentLocation(keepExistingZoom = false) {
+        const mapView = map?.getView();
+        if (!mapView) {
+            return false;
+        }
+
+        const droneLocation = getCurrentDroneLocation();
+        if (lastGpsPos || droneLocation) {
+            lastGpsPos = droneLocation?.coord || lastGpsPos;
+            mapView.setCenter(lastGpsPos);
+            if (!keepExistingZoom || mapView.getZoom() < 14) {
+                mapView.setZoom(14);
+            }
+            return true;
+        }
+
+        if (!googleGeoPos) {
+            return false;
+        }
+
+        mapView.setCenter(googleGeoPos.coord);
+        const zoom = getGoogleLocationZoom(googleGeoPos);
+        if (!keepExistingZoom || mapView.getZoom() < zoom) {
+            mapView.setZoom(zoom);
+        }
+        showApiLocationBanner(apiOverlayEl, infoOverlayEl, googleGeoPos);
+        return true;
+    }
+
+    function centerMapOnPreferredLocation(keepExistingZoom = false) {
+        const mapView = map?.getView();
+        if (!mapView) {
+            return false;
+        }
+
+        const firstWaypointCoord = getFirstMissionCoordinate();
+        if (firstWaypointCoord) {
+            mapView.setCenter(firstWaypointCoord);
+            if (!keepExistingZoom || mapView.getZoom() < 14) {
+                mapView.setZoom(14);
+            }
+            return true;
+        }
+
+        return centerMapOnCurrentLocation(keepExistingZoom);
+    }
+
+    async function requestGoogleApproximateLocation() {
+        if (googleLocationRequestStarted || !globalSettings.googleApiKey
+            || getFirstMissionCoordinate() || getCurrentDroneLocation()) {
+            return null;
+        }
+
+        googleLocationRequestStarted = true;
+        const url = new URL('https://www.googleapis.com/geolocation/v1/geolocate');
+        url.searchParams.set('key', globalSettings.googleApiKey);
+        const requestController = new AbortController();
+        googleLocationAbortController = requestController;
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ considerIp: true }),
+                signal: requestController.signal,
+            });
+            const data = await response.json();
+            if (!response.ok || !Number.isFinite(data?.location?.lat)
+                || !Number.isFinite(data?.location?.lng)) {
+                throw new Error(data?.error?.message || `HTTP ${response.status}`);
+            }
+
+            googleGeoPos = {
+                coord: fromLonLat([data.location.lng, data.location.lat]),
+                lat: data.location.lat,
+                lng: data.location.lng,
+                accuracy: Number(data.accuracy),
+            };
+
+            if (!getFirstMissionCoordinate() && !getCurrentDroneLocation() && !lastGpsPos) {
+                $('#centerOnDrone').show().css({ opacity: 1, pointerEvents: 'auto' });
+                centerMapOnPreferredLocation();
+                await fetchConditionsInfo(googleGeoPos.lat, googleGeoPos.lng, 'approximate');
+            }
+            return googleGeoPos;
+        } catch (error) {
+            if (error.name !== 'AbortError') {
+                console.warn('Google approximate location unavailable:', error.message);
+            }
+            return null;
+        } finally {
+            if (googleLocationAbortController === requestController) {
+                googleLocationAbortController = null;
+            }
+        }
+    }
 
     if (GUI.active_tab !== this) {
         GUI.active_tab = this;
@@ -612,6 +994,12 @@ function iconKey(filename) {
               curPosGeo.setCoordinates(gpsPos);
               lastGpsPos = gpsPos;
               $('#centerOnDrone').css({ opacity: 1, pointerEvents: 'auto' });
+              if (apiOverlayEl) {
+                  apiOverlayEl.style.visibility = 'hidden';
+              }
+              if (!conditionsFetched || !conditionsSourcesAttempted.has('gps')) {
+                  void fetchConditionsInfo(lat, lon, 'gps');
+              }
 
                             // Uncomment to auto-center/zoom once when GPS lock is first acquired
                             // if (!autoCenteredOnFix && map && map.getView()) {
@@ -657,7 +1045,11 @@ function iconKey(filename) {
                             }
           }
                     else if (infoOverlayEl) {
-                        $('#centerOnDrone').css({ opacity: 0.45, pointerEvents: 'none' });
+                        if (googleGeoPos) {
+                            $('#centerOnDrone').css({ opacity: 1, pointerEvents: 'auto' });
+                        } else {
+                            $('#centerOnDrone').css({ opacity: 0.45, pointerEvents: 'none' });
+                        }
                         infoOverlayEl.style.visibility = 'hidden';
                     }
         }
@@ -2921,6 +3313,12 @@ function iconKey(filename) {
             })
         });
 
+        apiOverlayEl = document.getElementById('geo_info');
+        if (apiOverlayEl) {
+            apiOverlayEl.textContent = '';
+            apiOverlayEl.style.visibility = 'hidden';
+        }
+
         //////////////////////////////////////////////////////////////////////////
         // Set the attribute link to open on an external browser window, so
         // it doesn't interfere with the configurator.
@@ -2968,7 +3366,19 @@ function iconKey(filename) {
         if (missionPlannerLastValues && missionPlannerLastValues.zoom && missionPlannerLastValues.center) {
             map.getView().setCenter(fromLonLat(missionPlannerLastValues.center));
             map.getView().setZoom(missionPlannerLastValues.zoom);
-        }         
+        }
+
+        const initialDroneLocation = getCurrentDroneLocation();
+        if (getFirstMissionCoordinate()) {
+            centerMapOnPreferredLocation();
+        } else if (initialDroneLocation) {
+            lastGpsPos = initialDroneLocation.coord;
+            $('#centerOnDrone').css({ opacity: 1, pointerEvents: 'auto' });
+            centerMapOnPreferredLocation();
+            void fetchConditionsInfo(initialDroneLocation.lat, initialDroneLocation.lng, 'gps');
+        } else {
+            void requestGoogleApproximateLocation();
+        }
 
         //////////////////////////////////////////////////////////////////////////
         // Load previously saved GEO files from electron store
@@ -4175,13 +4585,129 @@ function iconKey(filename) {
             }
         });
 
+        function closeAddressSearchDialog() {
+            $('#addressSearchDialog, #addressSearchBackdrop').remove();
+        }
+
+        async function readAddressSearchResponse(response) {
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            return data;
+        }
+
+        async function searchGoogleAddress(address, signal) {
+            if (!globalSettings.googleApiKey) {
+                return null;
+            }
+
+            const url = new URL('https://maps.googleapis.com/maps/api/geocode/json');
+            url.searchParams.set('address', address);
+            url.searchParams.set('key', globalSettings.googleApiKey);
+
+            try {
+                const data = await readAddressSearchResponse(await fetch(url, { signal }));
+                if (data.status !== 'OK' || !data.results?.length) {
+                    return null;
+                }
+
+                const result = data.results[0];
+                const lat = result.geometry?.location?.lat;
+                const lng = result.geometry?.location?.lng;
+                if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+                    return null;
+                }
+
+                return {
+                    coord: fromLonLat([lng, lat]),
+                    description: result.formatted_address,
+                    source: 'Google',
+                };
+            } catch (error) {
+                if (error.name === 'AbortError') {
+                    throw error;
+                }
+                return null;
+            }
+        }
+
+        async function searchNominatimAddress(address, signal) {
+            const url = new URL('https://nominatim.openstreetmap.org/search');
+            url.searchParams.set('format', 'json');
+            url.searchParams.set('q', address);
+            url.searchParams.set('limit', '1');
+
+            const data = await readAddressSearchResponse(await fetch(url, { signal }));
+            if (!Array.isArray(data) || data.length === 0) {
+                return null;
+            }
+
+            const result = data[0];
+            const lat = Number.parseFloat(result.lat);
+            const lng = Number.parseFloat(result.lon);
+            if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+                return null;
+            }
+
+            return {
+                coord: fromLonLat([lng, lat]),
+                description: result.display_name,
+                source: 'OpenStreetMap',
+            };
+        }
+
+        async function confirmAndCenterMap(result, signal) {
+            const confirmed = await dialog.confirm(
+                i18n.getMessage('addressSearchConfirmation', [result.description, result.source])
+            );
+            if (!confirmed || signal.aborted || !map?.getView()) {
+                return false;
+            }
+
+            map.getView().setCenter(result.coord);
+            return true;
+        }
+
+        async function runAddressSearch() {
+            const address = $('#addressInput').val().trim();
+            closeAddressSearchDialog();
+            if (!address) {
+                return;
+            }
+
+            addressSearchAbortController?.abort();
+            const requestController = new AbortController();
+            addressSearchAbortController = requestController;
+
+            try {
+                const googleResult = await searchGoogleAddress(address, requestController.signal);
+                const result = googleResult
+                    || await searchNominatimAddress(address, requestController.signal);
+                if (!result) {
+                    dialog.alert(i18n.getMessage('addressSearchNotFound'));
+                    return;
+                }
+
+                await confirmAndCenterMap(result, requestController.signal);
+            } catch (error) {
+                if (error.name !== 'AbortError') {
+                    console.error('Address search failed:', error.message);
+                    dialog.alert(i18n.getMessage('addressSearchFailed'));
+                }
+            } finally {
+                if (addressSearchAbortController === requestController) {
+                    addressSearchAbortController = null;
+                }
+            }
+        }
+
         // Address search button
-        $(document).on('click', '#searchAddressButton, #searchAddress', function (e) {
+        $('#searchAddress').off(missionControlLocationNamespace).on(`click${missionControlLocationNamespace}`, function (e) {
             e.preventDefault();
             e.stopPropagation();
 
-            // Remove any existing dialog
-            $('#addressSearchDialog, #addressSearchBackdrop').remove();
+            closeAddressSearchDialog();
 
             // Create dialog
             const addressDialog = $(`
@@ -4189,80 +4715,62 @@ function iconKey(filename) {
                      background: rgba(0,0,0,0.5); z-index: 10000;">
                     <div id="addressSearchDialog" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); 
                          background: white; padding: 20px; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.3);">
-                        <h3>Search for Location</h3>
+                        <h3></h3>
                         <input type="text" id="addressInput" style="width: 280px; padding: 8px 12px; margin: 10px 0; border: 1px solid #ccc; font-size: 14px;" 
-                               placeholder="Enter address, city, or coordinates" value="" autocomplete="off">
+                               value="" autocomplete="off">
                         <div style="margin-top: 15px; text-align: right;">
-                            <button id="searchCancel" style="padding: 8px 16px; margin-right: 10px;">Cancel</button>
-                            <button id="searchOK" style="padding: 8px 16px; background: #007cba; color: white; border: none;">Search</button>
+                            <button id="searchCancel" style="padding: 8px 16px; margin-right: 10px;"></button>
+                            <button id="searchOK" style="padding: 8px 16px; background: #007cba; color: white; border: none;"></button>
                         </div>
                     </div>
                 </div>
             `);
 
+            addressDialog.find('h3').text(i18n.getMessage('addressSearchTitle'));
+            addressDialog.find('#addressInput').attr('placeholder', i18n.getMessage('addressSearchPlaceholder'));
+            addressDialog.find('#searchCancel').text(i18n.getMessage('addressSearchCancel'));
+            addressDialog.find('#searchOK').text(i18n.getMessage('addressSearchSubmit'));
+
             $('body').append(addressDialog);
 
-          
-            // Search function
-            function doSearch() {
-                const address = $('#addressInput').val().trim();
-                $('#addressSearchBackdrop').remove();
-
-                if (address) {
-                    const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(address)}&limit=1`;
-                    
-                    fetch(url)
-                        .then(response => response.json())
-                        .then(data => {
-                            if (data && data.length > 0) {
-                                const result = data[0];
-                                const coord = fromLonLat([parseFloat(result.lon), parseFloat(result.lat)]);
-                                map.getView().setCenter(coord);
-                                dialog.alert(`Found: ${result.display_name}`);
-                            } else {
-                                dialog.alert('Address not found.');
-                            }
-                        })
-                        .catch(err => {
-                            console.error('Search failed:', err);
-                            dialog.alert('Search failed. Check your connection.');
-                        });
-                }
-
-                setTimeout(() => {
-                    const input = document.getElementById('addressInput');
-                    input?.focus();
-                    input?.select();
-                }, 50);
-
-            }
-
             // Event handlers
-            $('#searchOK').click(doSearch);
-            $('#searchCancel').click(() => $('#addressSearchBackdrop').remove());
-            $('#addressInput').keypress(function(e) {
-                if (e.which === 13) doSearch();
-            });
-            
-            // Only close on backdrop click, not dialog content click
-            $('#addressSearchBackdrop').click(function(e) {
-                if (e.target === this) {
-                    $('#addressSearchBackdrop').remove();
+            $('#searchOK').on(`click${missionControlLocationNamespace}`, runAddressSearch);
+            $('#searchCancel').on(`click${missionControlLocationNamespace}`, closeAddressSearchDialog);
+            $('#addressInput').on(`keydown${missionControlLocationNamespace}`, function(e) {
+                if (e.key === 'Enter') {
+                    void runAddressSearch();
                 }
             });
-            
+
+            // Only close on backdrop click, not dialog content click
+            $('#addressSearchBackdrop').on(`click${missionControlLocationNamespace}`, function(e) {
+                if (e.target === this) {
+                    closeAddressSearchDialog();
+                }
+            });
+
             // Prevent clicks inside the dialog from closing it
-            $('#addressSearchDialog').click(function(e) {
+            $('#addressSearchDialog').on(`click${missionControlLocationNamespace}`, function(e) {
                 e.stopPropagation();
             });
+
+            const input = document.getElementById('addressInput');
+            input?.focus();
+            input?.select();
         });
 
-        $(document).on('click', '#centerOnDroneButton, #centerOnDrone', function (e) {
+        $('#centerOnDrone').off(missionControlLocationNamespace).on(`click${missionControlLocationNamespace}`, function (e) {
             e.preventDefault();
             e.stopPropagation();
-            if (lastGpsPos && map && map.getView()) {
-                map.getView().setCenter(lastGpsPos);
-            }
+            centerMapOnCurrentLocation();
+        });
+
+        $('#showHideConditionsButton').off(missionControlLocationNamespace).on(`click${missionControlLocationNamespace}`, function (e) {
+            e.preventDefault();
+            const $icon = $(this).children('a');
+            const showContent = $icon.hasClass('ic_show');
+            $icon.toggleClass('ic_show', !showContent).toggleClass('ic_hide', showContent);
+            $('#ConditionsContent').stop(true, true)[showContent ? 'fadeIn' : 'fadeOut'](300);
         });
 
         /////////////////////////////////////////////
@@ -4604,8 +5112,8 @@ function iconKey(filename) {
                 return;
             }
 
-            if (!e.repeat && key === 'c' && lastGpsPos && map?.getView()) {
-                map.getView().setCenter(lastGpsPos);
+            if (!e.repeat && key === 'c') {
+                centerMapOnCurrentLocation(true);
             }
 
             if (handleMissionControlCtrlShortcut(e, key)) {
@@ -5575,6 +6083,7 @@ missionControlTab.setBit = function(bits, bit, value) {
 // }
 
 missionControlTab.cleanup = function (callback) {
+    cleanupMissionControlLocationResources();
     if (elevationChartInstance) {
         elevationChartInstance.destroy();
         elevationChartInstance = null;

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -124,17 +124,31 @@ const iconNames = [
 const icons = Object.create(null)
 
 const missionControlLocationNamespace = '.missionControlLocation';
+const WEATHER_RETRY_DELAY_MS = 5 * 60 * 1000;
+const WEATHER_REQUEST_TIMEOUT_MS = 30 * 1000;
+const WEATHER_MAP_REFRESH_DELAY_MS = 1000;
+const WEATHER_GPS_MIN_DISTANCE_METERS = 1000;
+const WEATHER_MAP_CENTER_MIN_DISTANCE_METERS = 1000;
+const WEATHER_WAYPOINT_MIN_DISTANCE_METERS = 10;
 let googleLocationAbortController = null;
 let weatherAbortController = null;
 let addressSearchAbortController = null;
+let weatherRetryTimer = null;
+let weatherMapRefreshTimer = null;
+let missionControlLocationLifecycleId = 0;
 
 function cleanupMissionControlLocationResources() {
+    missionControlLocationLifecycleId++;
     googleLocationAbortController?.abort();
     googleLocationAbortController = null;
     weatherAbortController?.abort();
     weatherAbortController = null;
     addressSearchAbortController?.abort();
     addressSearchAbortController = null;
+    clearTimeout(weatherRetryTimer);
+    weatherRetryTimer = null;
+    clearTimeout(weatherMapRefreshTimer);
+    weatherMapRefreshTimer = null;
 
     $(document).off(missionControlLocationNamespace);
     $('#searchAddress, #centerOnDrone, #showHideConditionsButton').off(missionControlLocationNamespace);
@@ -149,6 +163,64 @@ function cleanupMissionControlLocationResources() {
 
 function showConditionsPanel(isVisible) {
     $('#missionPlannerConditions').toggleClass('is-hidden', !isVisible);
+}
+
+function parseRetryAfterMs(retryAfter) {
+    if (!retryAfter) {
+        return WEATHER_RETRY_DELAY_MS;
+    }
+
+    const retryAfterSeconds = Number(retryAfter);
+    if (Number.isFinite(retryAfterSeconds)) {
+        return Math.max(WEATHER_RETRY_DELAY_MS, retryAfterSeconds * 1000);
+    }
+
+    const retryAt = Date.parse(retryAfter);
+    if (Number.isNaN(retryAt)) {
+        return WEATHER_RETRY_DELAY_MS;
+    }
+    return Math.max(WEATHER_RETRY_DELAY_MS, retryAt - Date.now());
+}
+
+function createWeatherRequestError(message, retryable, retryDelayMs = WEATHER_RETRY_DELAY_MS) {
+    const error = new Error(message);
+    error.weatherRetryable = retryable;
+    error.weatherRetryDelayMs = retryDelayMs;
+    return error;
+}
+
+function createWeatherResponseError(response, data) {
+    const status = response.status || Number(data?.error?.code);
+    const apiStatus = data?.error?.status;
+    const retryableApiStatuses = new Set([
+        'ABORTED',
+        'DEADLINE_EXCEEDED',
+        'INTERNAL',
+        'RESOURCE_EXHAUSTED',
+        'UNAVAILABLE',
+    ]);
+    const retryable = status === 408 || status === 429 || status >= 500
+        || retryableApiStatuses.has(apiStatus);
+    const retryDelayMs = status === 429
+        ? parseRetryAfterMs(response.headers?.get('Retry-After'))
+        : WEATHER_RETRY_DELAY_MS;
+    return createWeatherRequestError(
+        data?.error?.message || `HTTP ${status || response.status}`,
+        retryable,
+        retryDelayMs,
+    );
+}
+
+function getLocationDistanceMeters(first, second) {
+    const degreesToRadians = Math.PI / 180;
+    const latitudeDelta = (second.lat - first.lat) * degreesToRadians;
+    const longitudeDelta = (second.lng - first.lng) * degreesToRadians;
+    const firstLatitude = first.lat * degreesToRadians;
+    const secondLatitude = second.lat * degreesToRadians;
+    const haversine = Math.sin(latitudeDelta / 2) ** 2
+        + Math.cos(firstLatitude) * Math.cos(secondLatitude) * Math.sin(longitudeDelta / 2) ** 2;
+    const boundedHaversine = Math.min(1, Math.max(0, haversine));
+    return 6371000 * 2 * Math.atan2(Math.sqrt(boundedHaversine), Math.sqrt(1 - boundedHaversine));
 }
 
 function toTitleCase(value) {
@@ -495,6 +567,7 @@ let elevationChartInstance = null;
 missionControlTab.initialize = function (callback) {
 
     cleanupMissionControlLocationResources();
+    const locationLifecycleId = missionControlLocationLifecycleId;
 
     let cursorInitialized = false;
     let curPosStyle;
@@ -522,7 +595,9 @@ missionControlTab.initialize = function (callback) {
     let settings = {speed: 0, alt: 5000, safeRadiusSH: 50, fwApproachAlt: 60, fwLandAlt: 5, maxDistSH: 0, fwApproachLength: 0, fwLoiterRadius: 0};
     let googleLocationRequestStarted = false;
     let conditionsFetched = false;
-    const conditionsSourcesAttempted = new Set();
+    let activeWeatherSource = null;
+    let weatherApiKey = String(globalSettings.googleApiKey || '').trim();
+    let blockedWeatherApiKey = null;
 
     function getCurrentDroneLocation() {
         const lat = FC.GPS_DATA?.lat / 10000000;
@@ -539,7 +614,7 @@ missionControlTab.initialize = function (callback) {
         };
     }
 
-    function getFirstMissionCoordinate() {
+    function getFirstMissionLocation() {
         const firstWaypoint = mission.get().find(function (waypoint) {
             return !waypoint.isAttached();
         });
@@ -553,21 +628,122 @@ missionControlTab.initialize = function (callback) {
             return null;
         }
 
-        return fromLonLat([lng, lat]);
+        return {
+            type: 'waypoint',
+            lat,
+            lng,
+            coord: fromLonLat([lng, lat]),
+        };
     }
 
-    async function fetchConditionsInfo(lat, lng, source) {
-        if (!globalSettings.googleApiKey || conditionsSourcesAttempted.has(source)) {
+    function getFirstMissionCoordinate() {
+        return getFirstMissionLocation()?.coord || null;
+    }
+
+    function getMapCenterWeatherLocation() {
+        const center = map?.getView()?.getCenter();
+        if (!center) {
+            return null;
+        }
+
+        const [lng, lat] = toLonLat(center);
+        if (!Number.isFinite(lat) || !Number.isFinite(lng)
+            || Math.abs(lat) > 90 || Math.abs(lng) > 180) {
+            return null;
+        }
+        return { type: 'map', lat, lng };
+    }
+
+    function getPreferredWeatherSource() {
+        const droneLocation = getCurrentDroneLocation();
+        if (droneLocation) {
+            return { type: 'gps', lat: droneLocation.lat, lng: droneLocation.lng };
+        }
+        return getFirstMissionLocation() || getMapCenterWeatherLocation();
+    }
+
+    function isWeatherSourceMateriallyChanged(currentSource, nextSource) {
+        if (!currentSource || !nextSource || currentSource.type !== nextSource.type) {
+            return true;
+        }
+        const minimumDistances = {
+            gps: WEATHER_GPS_MIN_DISTANCE_METERS,
+            map: WEATHER_MAP_CENTER_MIN_DISTANCE_METERS,
+            waypoint: WEATHER_WAYPOINT_MIN_DISTANCE_METERS,
+        };
+        const minimumDistance = minimumDistances[nextSource.type];
+        return getLocationDistanceMeters(currentSource, nextSource) >= minimumDistance;
+    }
+
+    function updateConditionsTitle(source) {
+        const titleKeys = {
+            gps: 'conditionsSourceAircraft',
+            waypoint: 'conditionsSourceWaypoint',
+            map: 'conditionsSourceMapCenter',
+        };
+        $('#conditionsTitle').text(i18n.getMessage('conditionsInfoHeadSource', [
+            i18n.getMessage(titleKeys[source.type]),
+        ]));
+    }
+
+    function clearWeatherRetry() {
+        clearTimeout(weatherRetryTimer);
+        weatherRetryTimer = null;
+    }
+
+    function syncWeatherApiKey() {
+        const apiKey = String(globalSettings.googleApiKey || '').trim();
+        if (apiKey === weatherApiKey) {
+            return apiKey;
+        }
+
+        weatherApiKey = apiKey;
+        blockedWeatherApiKey = null;
+        activeWeatherSource = null;
+        conditionsFetched = false;
+        clearWeatherRetry();
+        weatherAbortController?.abort();
+        weatherAbortController = null;
+        return apiKey;
+    }
+
+    function scheduleWeatherRetry(source, apiKey, retryDelayMs) {
+        clearWeatherRetry();
+        weatherRetryTimer = setTimeout(function () {
+            weatherRetryTimer = null;
+            if (missionControlLocationLifecycleId !== locationLifecycleId
+                || String(globalSettings.googleApiKey || '').trim() !== apiKey
+                || blockedWeatherApiKey === apiKey) {
+                return;
+            }
+
+            const preferredSource = getPreferredWeatherSource();
+            if (!preferredSource) {
+                return;
+            }
+            if (isWeatherSourceMateriallyChanged(source, preferredSource)) {
+                evaluateWeatherSource();
+                return;
+            }
+
+            activeWeatherSource = preferredSource;
+            updateConditionsTitle(preferredSource);
+            void fetchConditionsInfo(preferredSource, apiKey);
+        }, retryDelayMs);
+    }
+
+    async function fetchConditionsInfo(source, apiKey) {
+        if (!apiKey || blockedWeatherApiKey === apiKey
+            || missionControlLocationLifecycleId !== locationLifecycleId) {
             return false;
         }
 
-        conditionsSourcesAttempted.add(source);
         const useImperial = globalSettings.unitType === 'imperial'
             || (globalSettings.unitType === 'OSD' && globalSettings.osdUnits === 0);
         const url = new URL('https://weather.googleapis.com/v1/currentConditions:lookup');
-        url.searchParams.set('key', globalSettings.googleApiKey);
-        url.searchParams.set('location.latitude', lat.toFixed(4));
-        url.searchParams.set('location.longitude', lng.toFixed(4));
+        url.searchParams.set('key', apiKey);
+        url.searchParams.set('location.latitude', source.lat.toFixed(4));
+        url.searchParams.set('location.longitude', source.lng.toFixed(4));
         if (useImperial) {
             url.searchParams.set('unitsSystem', 'IMPERIAL');
         }
@@ -575,6 +751,12 @@ missionControlTab.initialize = function (callback) {
         weatherAbortController?.abort();
         const requestController = new AbortController();
         weatherAbortController = requestController;
+        let requestTimedOut = false;
+        const timeoutTimer = setTimeout(function () {
+            requestTimedOut = true;
+            requestController.abort();
+        }, WEATHER_REQUEST_TIMEOUT_MS);
+        updateConditionsTitle(source);
         showConditionsPanel(true);
         $('#conditionsLoading').text(i18n.getMessage('conditionsWaiting')).show();
         $('#conditionsData').addClass('is-hidden').hide();
@@ -582,28 +764,117 @@ missionControlTab.initialize = function (callback) {
 
         try {
             const response = await fetch(url, { signal: requestController.signal });
-            const data = await response.json();
+            let data;
+            try {
+                data = await response.json();
+            } catch (error) {
+                if (!response.ok) {
+                    throw createWeatherResponseError(response, null);
+                }
+                throw error;
+            }
             if (!response.ok || data?.error) {
-                throw new Error(data?.error?.message || `HTTP ${response.status}`);
+                throw createWeatherResponseError(response, data);
+            }
+            if (missionControlLocationLifecycleId !== locationLifecycleId
+                || weatherAbortController !== requestController
+                || String(globalSettings.googleApiKey || '').trim() !== apiKey) {
+                return false;
             }
 
             conditionsFetched = renderConditionsInfo(data);
             if (!conditionsFetched) {
-                showConditionsUnavailable();
+                throw createWeatherRequestError('Invalid Weather API response', true);
             }
-            return conditionsFetched;
+            clearWeatherRetry();
+            blockedWeatherApiKey = null;
+            return true;
         } catch (error) {
-            if (error.name !== 'AbortError') {
-                conditionsFetched = false;
-                showConditionsUnavailable();
-                console.warn('Google Weather unavailable:', error.message);
+            let weatherError = error;
+            if (error.name === 'AbortError') {
+                if (!requestTimedOut) {
+                    return false;
+                }
+                weatherError = createWeatherRequestError('Weather API request timed out', true);
+            }
+            if (missionControlLocationLifecycleId !== locationLifecycleId
+                || weatherAbortController !== requestController
+                || String(globalSettings.googleApiKey || '').trim() !== apiKey) {
+                return false;
+            }
+
+            conditionsFetched = false;
+            showConditionsUnavailable();
+            console.warn('Google Weather unavailable:', weatherError.message);
+            if (weatherError.weatherRetryable !== false) {
+                scheduleWeatherRetry(source, apiKey, weatherError.weatherRetryDelayMs || WEATHER_RETRY_DELAY_MS);
+            } else {
+                clearWeatherRetry();
+                blockedWeatherApiKey = apiKey;
             }
             return false;
         } finally {
+            clearTimeout(timeoutTimer);
             if (weatherAbortController === requestController) {
                 weatherAbortController = null;
             }
         }
+    }
+
+    function evaluateWeatherSource({ allowMapCenterRefresh = true } = {}) {
+        if (missionControlLocationLifecycleId !== locationLifecycleId) {
+            return false;
+        }
+        const previousApiKey = weatherApiKey;
+        const apiKey = syncWeatherApiKey();
+        const apiKeyChanged = apiKey !== previousApiKey;
+        if (!apiKey) {
+            showConditionsPanel(false);
+            return false;
+        }
+
+        const preferredSource = getPreferredWeatherSource();
+        if (!preferredSource) {
+            return false;
+        }
+        if (!allowMapCenterRefresh && !apiKeyChanged && preferredSource.type === 'map'
+            && (!activeWeatherSource || activeWeatherSource.type === 'map')) {
+            return conditionsFetched;
+        }
+        if (preferredSource.type !== 'map') {
+            clearTimeout(weatherMapRefreshTimer);
+            weatherMapRefreshTimer = null;
+        }
+        updateConditionsTitle(preferredSource);
+        if (blockedWeatherApiKey === apiKey) {
+            return false;
+        }
+        if (!isWeatherSourceMateriallyChanged(activeWeatherSource, preferredSource)) {
+            return conditionsFetched;
+        }
+
+        clearWeatherRetry();
+        weatherAbortController?.abort();
+        activeWeatherSource = preferredSource;
+        conditionsFetched = false;
+        void fetchConditionsInfo(preferredSource, apiKey);
+        return true;
+    }
+
+    function scheduleMapCenterWeatherRefresh() {
+        clearTimeout(weatherMapRefreshTimer);
+        weatherMapRefreshTimer = null;
+        if (missionControlLocationLifecycleId !== locationLifecycleId
+            || getCurrentDroneLocation() || getFirstMissionLocation()) {
+            return;
+        }
+
+        weatherMapRefreshTimer = setTimeout(function () {
+            weatherMapRefreshTimer = null;
+            if (missionControlLocationLifecycleId === locationLifecycleId) {
+                evaluateWeatherSource();
+            }
+        }, WEATHER_MAP_REFRESH_DELAY_MS);
     }
 
     function centerMapOnCurrentLocation(keepExistingZoom = false) {
@@ -688,7 +959,6 @@ missionControlTab.initialize = function (callback) {
             if (!getFirstMissionCoordinate() && !getCurrentDroneLocation() && !lastGpsPos) {
                 $('#centerOnDrone').show().css({ opacity: 1, pointerEvents: 'auto' });
                 centerMapOnPreferredLocation();
-                await fetchConditionsInfo(googleGeoPos.lat, googleGeoPos.lng, 'approximate');
             }
             return googleGeoPos;
         } catch (error) {
@@ -707,16 +977,19 @@ missionControlTab.initialize = function (callback) {
         const initialDroneLocation = getCurrentDroneLocation();
         if (getFirstMissionCoordinate()) {
             centerMapOnPreferredLocation();
+            evaluateWeatherSource();
             return;
         }
         if (initialDroneLocation) {
             lastGpsPos = initialDroneLocation.coord;
             $('#centerOnDrone').css({ opacity: 1, pointerEvents: 'auto' });
             centerMapOnPreferredLocation();
-            void fetchConditionsInfo(initialDroneLocation.lat, initialDroneLocation.lng, 'gps');
+            evaluateWeatherSource();
             return;
         }
-        void requestGoogleApproximateLocation();
+        void requestGoogleApproximateLocation().then(function () {
+            evaluateWeatherSource();
+        });
     }
 
     if (GUI.active_tab !== this) {
@@ -1036,9 +1309,6 @@ function iconKey(filename) {
               if (apiOverlayEl) {
                   apiOverlayEl.style.visibility = 'hidden';
               }
-              if (!conditionsFetched || !conditionsSourcesAttempted.has('gps')) {
-                  void fetchConditionsInfo(lat, lon, 'gps');
-              }
 
                             // Uncomment to auto-center/zoom once when GPS lock is first acquired
                             // if (!autoCenteredOnFix && map && map.getView()) {
@@ -1091,6 +1361,7 @@ function iconKey(filename) {
                         }
                         infoOverlayEl.style.visibility = 'hidden';
                     }
+          evaluateWeatherSource({ allowMapCenterRefresh: false });
         }
 
         /*
@@ -2579,6 +2850,7 @@ function iconKey(filename) {
     function refreshLayers() {
         cleanLayers();
         redrawLayers();
+        evaluateWeatherSource();
     }
 
     function cleanLayers() {
@@ -3397,6 +3669,7 @@ function iconKey(filename) {
                 center: toLonLat(map.getView().getCenter()),
                 zoom: map.getView().getZoom()
             });
+            scheduleMapCenterWeatherRefresh();
         });
         //////////////////////////////////////////////////////////////////////////
         // load map view settings on startup

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -207,6 +207,44 @@ function formatConditionsValue(value, unit = '') {
     return unit ? `${value} ${unit}` : String(value);
 }
 
+function getTemperatureUnit(unit) {
+    const temperatureUnits = {
+        CELSIUS: '°C',
+        FAHRENHEIT: '°F',
+    };
+    return temperatureUnits[unit] || '';
+}
+
+function getVisibilityUnit(unit) {
+    const visibilityUnits = {
+        KILOMETERS: 'km',
+        MILES: 'mi',
+    };
+    return visibilityUnits[unit] || '';
+}
+
+function convertWindSpeedToKmh(speed, unit) {
+    if (!Number.isFinite(speed)) {
+        return Number.NaN;
+    }
+    return unit === 'MILES_PER_HOUR' ? speed * 1.609 : speed;
+}
+
+function showConditionsUnavailable() {
+    showConditionsPanel(true);
+    $('#conditionsLoading').hide();
+    $('#conditionsData').addClass('is-hidden').hide();
+    $('#conditionsError').text(i18n.getMessage('conditionsUnavailable')).removeClass('is-hidden').show();
+}
+
+async function readAddressSearchResponse(response) {
+    const data = await response.json();
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+    }
+    return data;
+}
+
 function renderConditionsInfo(data) {
     if (!data || typeof data !== 'object' || data.error) {
         return false;
@@ -232,18 +270,14 @@ function renderConditionsInfo(data) {
     }
 
     const temperature = data.temperature?.degrees;
-    const temperatureUnit = data.temperature?.unit === 'CELSIUS'
-        ? '°C'
-        : data.temperature?.unit === 'FAHRENHEIT' ? '°F' : '';
+    const temperatureUnit = getTemperatureUnit(data.temperature?.unit);
     const feelsLike = data.feelsLikeTemperature?.degrees;
     const uv = data.uvIndex;
     const precipitation = data.precipitation?.qpf?.quantity;
     const precipitationUnit = data.precipitation?.qpf?.unit === 'INCHES' ? 'in' : 'mm';
     const thunder = data.thunderstormProbability;
     const visibility = data.visibility?.distance;
-    const visibilityUnit = data.visibility?.unit === 'KILOMETERS'
-        ? 'km'
-        : data.visibility?.unit === 'MILES' ? 'mi' : '';
+    const visibilityUnit = getVisibilityUnit(data.visibility?.unit);
     const cloudCover = data.cloudCover;
 
     $('#condWeather').text(data.weatherCondition?.description?.text || '—');
@@ -259,12 +293,8 @@ function renderConditionsInfo(data) {
     $('#condVisibility').text(formatConditionsValue(visibility, visibilityUnit));
     $('#condCloud').text(formatConditionsValue(cloudCover, '%'));
 
-    const windSpeedKmh = Number.isFinite(windSpeed)
-        ? (windUnit === 'MILES_PER_HOUR' ? windSpeed * 1.609 : windSpeed)
-        : Number.NaN;
-    const gustSpeedKmh = Number.isFinite(gustSpeed)
-        ? (windUnit === 'MILES_PER_HOUR' ? gustSpeed * 1.609 : gustSpeed)
-        : Number.NaN;
+    const windSpeedKmh = convertWindSpeedToKmh(windSpeed, windUnit);
+    const gustSpeedKmh = convertWindSpeedToKmh(gustSpeed, windUnit);
     applyUvColor(uv);
     applyThunderColor(thunder);
     applyThresholdColor('#condWind', windSpeedKmh, 20, 35);
@@ -526,13 +556,6 @@ missionControlTab.initialize = function (callback) {
         return fromLonLat([lng, lat]);
     }
 
-    function showConditionsUnavailable() {
-        showConditionsPanel(true);
-        $('#conditionsLoading').hide();
-        $('#conditionsData').addClass('is-hidden').hide();
-        $('#conditionsError').text(i18n.getMessage('conditionsUnavailable')).removeClass('is-hidden').show();
-    }
-
     async function fetchConditionsInfo(lat, lng, source) {
         if (!globalSettings.googleApiKey || conditionsSourcesAttempted.has(source)) {
             return false;
@@ -678,6 +701,22 @@ missionControlTab.initialize = function (callback) {
                 googleLocationAbortController = null;
             }
         }
+    }
+
+    function initializeMapLocation() {
+        const initialDroneLocation = getCurrentDroneLocation();
+        if (getFirstMissionCoordinate()) {
+            centerMapOnPreferredLocation();
+            return;
+        }
+        if (initialDroneLocation) {
+            lastGpsPos = initialDroneLocation.coord;
+            $('#centerOnDrone').css({ opacity: 1, pointerEvents: 'auto' });
+            centerMapOnPreferredLocation();
+            void fetchConditionsInfo(initialDroneLocation.lat, initialDroneLocation.lng, 'gps');
+            return;
+        }
+        void requestGoogleApproximateLocation();
     }
 
     if (GUI.active_tab !== this) {
@@ -3368,17 +3407,7 @@ function iconKey(filename) {
             map.getView().setZoom(missionPlannerLastValues.zoom);
         }
 
-        const initialDroneLocation = getCurrentDroneLocation();
-        if (getFirstMissionCoordinate()) {
-            centerMapOnPreferredLocation();
-        } else if (initialDroneLocation) {
-            lastGpsPos = initialDroneLocation.coord;
-            $('#centerOnDrone').css({ opacity: 1, pointerEvents: 'auto' });
-            centerMapOnPreferredLocation();
-            void fetchConditionsInfo(initialDroneLocation.lat, initialDroneLocation.lng, 'gps');
-        } else {
-            void requestGoogleApproximateLocation();
-        }
+        initializeMapLocation();
 
         //////////////////////////////////////////////////////////////////////////
         // Load previously saved GEO files from electron store
@@ -4587,14 +4616,6 @@ function iconKey(filename) {
 
         function closeAddressSearchDialog() {
             $('#addressSearchDialog, #addressSearchBackdrop').remove();
-        }
-
-        async function readAddressSearchResponse(response) {
-            const data = await response.json();
-            if (!response.ok) {
-                throw new Error(`HTTP ${response.status}`);
-            }
-            return data;
         }
 
         async function searchGoogleAddress(address, signal) {

--- a/tabs/options.html
+++ b/tabs/options.html
@@ -108,5 +108,24 @@
                 </div>
             </div>
         </div>
+        <div class="options-section gui_box grey">
+            <div class="gui_box_titlebar">
+                <div class="spacer_box_title" data-i18n="googleLocationServices"></div>
+            </div>
+
+            <div class="spacer_box settings">
+                <div class="number">
+                    <input type="password" id="google-api-key" autocomplete="off" />
+                    <label for="google-api-key" data-i18n="googleLocationApiKey"></label>
+                </div>
+                <div class="default_btn">
+                    <a id="google-api-key-test" href="#" data-i18n="googleLocationTestButton"></a>
+                </div>
+                <div class="default_btn">
+                    <a id="google-api-key-help" href="#" data-i18n="googleLocationHelpButton"></a>
+                </div>
+                <div id="google-api-key-result" role="status" aria-live="polite"></div>
+            </div>
+        </div>
     </div>
 </div>

--- a/tabs/options.html
+++ b/tabs/options.html
@@ -116,15 +116,15 @@
             <div class="spacer_box settings">
                 <div class="number">
                     <input type="password" id="google-api-key" autocomplete="off" />
-                    <label for="google-api-key" data-i18n="googleLocationApiKey"></label>
+                    <label for="google-api-key" data-i18n="googleLocationApiKey">API Key</label>
                 </div>
                 <div class="default_btn">
-                    <a id="google-api-key-test" href="#" data-i18n="googleLocationTestButton"></a>
+                    <a id="google-api-key-test" href="#" data-i18n="googleLocationTestButton">Test API key</a>
                 </div>
                 <div class="default_btn">
-                    <a id="google-api-key-help" href="#" data-i18n="googleLocationHelpButton"></a>
+                    <a id="google-api-key-help" href="#" data-i18n="googleLocationHelpButton">Help and setup instructions</a>
                 </div>
-                <div id="google-api-key-result" role="status" aria-live="polite"></div>
+                <output id="google-api-key-result" aria-live="polite"></output>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Supersedes #2592 and ports the Google Location Services / Weather Conditions work to `maintenance-10.x`.

This implementation is based on the current Mission Control code after #2703 was merged and manually ports the feature rather than merging the old 9.x branch.

### Features
- Google approximate/IP-based location when no mission waypoint or valid GPS position is available
- Google Weather current conditions in Mission Control
- Google Geocoding with OpenStreetMap/Nominatim fallback
- Address search confirmation before moving the map
- Google API key configuration, testing, and setup help
- Initial map centering priority: waypoint → GPS → approximate Google location
- Center-on-Drone behavior remains GPS → approximate location
- Localized location/weather/address-search UI

### Review items addressed
- Fixed the address-search Cancel path so Cancel does not move the map
- `showApiLocationBanner()` is always called with the required arguments
- Corrected wind-direction arrows
- Uses current 10.x behavior rather than the old `reloadActiveTab()` implementation
- Mission Control location handlers are namespaced and cleaned up to prevent duplicate API requests
- Pending Google location, weather, and address requests are aborted during tab cleanup
- Weather rendering tolerates missing optional fields
- `conditionsFetched` reflects the actual render result

### Validation
- 28/28 transpiler tests passed
- 62/62 Node tests passed
- JavaScript syntax checks passed
- Locale JSON validation passed
- Electron Forge packaging completed successfully
- Local Configurator smoke test completed successfully, including live Weather Conditions display
- Existing #2703 grid, keyboard, marker validation, and remaining-waypoint-capacity behavior preserved