### PR TITLE
fix(connection): guard against a legitimately-zero connectionId

### DIFF
--- a/js/connection/connection.js
+++ b/js/connection/connection.js
@@ -11,8 +11,8 @@ const ConnectionType = {
 
 class Connection {
 
-    constructor() {       
-        this._connectionId   = 0;
+    constructor() {
+        this._connectionId   = null;
         this._openRequested  = false;
         this._openCanceled   = false;
         this._bitrate        = 0;
@@ -128,8 +128,14 @@ class Connection {
         throw new TypeError("Abstract method");
     }
 
+    // _connectionId can legitimately be 0 for some transports, so callers must
+    // not test it for truthiness - only null/false mean "not connected".
+    hasConnectionId() {
+        return this._connectionId !== null && this._connectionId !== false;
+    }
+
     disconnect(callback) {
-        if (this._connectionId) {
+        if (this.hasConnectionId()) {
             this.emptyOutputBuffer();
             this.removeAllListeners();
 

--- a/js/connection/connectionSerial.js
+++ b/js/connection/connectionSerial.js
@@ -94,11 +94,11 @@ class ConnectionSerial extends Connection {
     }
 
     disconnectImplementation(callback) {
-        this.completeClose('serial', this._connectionId ? window.electronAPI.serialClose() : null, callback);
+        this.completeClose('serial', this.hasConnectionId() ? window.electronAPI.serialClose() : null, callback);
     }
 
     sendImplementation(data, callback) {
-        this.completeSend('Serial', this._connectionId ? window.electronAPI.serialSend(data) : null, callback);
+        this.completeSend('Serial', this.hasConnectionId() ? window.electronAPI.serialSend(data) : null, callback);
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionTcp.js
+++ b/js/connection/connectionTcp.js
@@ -93,8 +93,8 @@ class ConnectionTcp extends Connection {
     }
 
     disconnectImplementation(callback) {
-        
-        if (this._connectionId) {
+
+        if (this.hasConnectionId()) {
             window.electronAPI.tcpClose();
         }
 
@@ -107,7 +107,7 @@ class ConnectionTcp extends Connection {
     }
 
     sendImplementation(data, callback) {
-        this.completeSend('TCP', this._connectionId ? window.electronAPI.tcpSend(data) : null, callback);
+        this.completeSend('TCP', this.hasConnectionId() ? window.electronAPI.tcpSend(data) : null, callback);
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionUdp.js
+++ b/js/connection/connectionUdp.js
@@ -86,11 +86,11 @@ class ConnectionUdp extends Connection {
     }
 
     disconnectImplementation(callback) {
-        this.completeClose('UDP', this._connectionId ? window.electronAPI.udpClose() : null, callback);
+        this.completeClose('UDP', this.hasConnectionId() ? window.electronAPI.udpClose() : null, callback);
     }
 
     sendImplementation(data, callback) {
-        this.completeSend('UDP', this._connectionId ? window.electronAPI.udpSend(data) : null, callback);
+        this.completeSend('UDP', this.hasConnectionId() ? window.electronAPI.udpSend(data) : null, callback);
     }
 
     addOnReceiveCallback(callback){


### PR DESCRIPTION
## Summary

Follow-up to #2716. `Connection.disconnect()` and every transport's `disconnectImplementation()`/`sendImplementation()` gate on `if (this._connectionId)`, which silently no-ops (or, after #2716's refactor, feeds `null` into `completeClose()`/`completeSend()`) whenever the id is falsy - not just when there's genuinely no connection, but also for a legitimate id of `0`.

Each transport's id counter here starts at 1, so this can't actually fire on this branch today. But #2716 just duplicated the same truthiness check into three more `completeSend()`/`completeClose()` call sites, and other configurator branches already have a transport where `0` is a real, live id (a WASM-hosted SITL port) - so the pattern is a latent bug waiting for the next transport that doesn't start counting at 1.

- Adds a shared `hasConnectionId()` helper on the base `Connection` class and uses it everywhere instead of testing `_connectionId` for truthiness.
- Changes the "never connected" sentinel from `0` to `null`, so a real id of `0` stays distinguishable from that initial state.

## Test plan

- [ ] `node -c` syntax check on the four touched files (done locally)
- [ ] Connect/disconnect over serial and confirm no regression
- [ ] Connect/disconnect over TCP (SITL) and confirm no regression

https://claude.ai/code/session_01231ETgELxNn2b4Ue4DhtUt