### PR TITLE
Merge maintenance-9.x into maintenance-10.x

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - maintenance-8.x.x
+      - maintenance-*
 #  pull_request:
 
 jobs:

--- a/js/connection/connection.js
+++ b/js/connection/connection.js
@@ -153,6 +153,18 @@ class Connection {
             });
         } else {
             this._openCanceled = true;
+
+            // The port can already be gone when disconnect() runs (FC rebooting into
+            // DFU, cable pulled). This connection object is a session-wide singleton,
+            // so without this it stays stuck with _transmitting true and every later
+            // send() only fills the buffer. Listener teardown is deliberately left to
+            // the branch above: the transports notify their error listeners after
+            // abort(), which lands here, and would then be talking to an empty list.
+            this.emptyOutputBuffer();
+
+            if (callback) {
+                callback(false);
+            }
         }
     }
     

--- a/js/connection/connection.js
+++ b/js/connection/connection.js
@@ -270,6 +270,65 @@ class Connection {
         });
     }
 
+    /*
+     * Bridge a transport's write promise onto sendImplementation()'s callback.
+     * send() advances its queue only from there, so every path has to report once.
+     * A null promise means there is no port left to write to.
+     */
+    completeSend(label, promise, callback) {
+        const report = (bytesSent, resultCode) => {
+            if (callback) {
+                callback({ bytesSent: bytesSent, resultCode: resultCode });
+            }
+        };
+
+        if (!promise) {
+            report(0, 1);
+            return;
+        }
+
+        promise.then(response => {
+            if (response.error) {
+                console.log(label + ' write error: ' + response.msg);
+                report(0, 1);
+            } else {
+                report(response.bytesWritten, 0);
+            }
+        }).catch(error => {
+            console.log(label + ' write failed: ' + error);
+            report(0, 1);
+        });
+    }
+
+    // Same for a transport's close promise - disconnect() has to hear back either way.
+    completeClose(label, promise, callback) {
+        if (!promise) {
+            if (callback) {
+                callback(false);
+            }
+            return;
+        }
+
+        promise.then(response => {
+            if (response.error) {
+                console.log('Unable to close ' + label + ': ' + response.msg);
+            }
+            if (callback) {
+                callback(!response.error);
+            }
+        }).catch(this.reportFailure('Unable to close ' + label, callback));
+    }
+
+    // Rejection handler that reports a failed transport call instead of losing its callback.
+    reportFailure(message, callback) {
+        return error => {
+            console.log(message + ': ' + error);
+            if (callback) {
+                callback(false);
+            }
+        };
+    }
+
     removeAllListeners() {
         this._onReceiveListeners.forEach(listener => this.removeOnReceiveCallback(listener));
         this._onReceiveListeners = [];

--- a/js/connection/connection.js
+++ b/js/connection/connection.js
@@ -154,12 +154,8 @@ class Connection {
         } else {
             this._openCanceled = true;
 
-            // The port can already be gone when disconnect() runs (FC rebooting into
-            // DFU, cable pulled). This connection object is a session-wide singleton,
-            // so without this it stays stuck with _transmitting true and every later
-            // send() only fills the buffer. Listener teardown is deliberately left to
-            // the branch above: the transports notify their error listeners after
-            // abort(), which lands here, and would then be talking to an empty list.
+            // Port already gone: without this the singleton stays stuck with _transmitting
+            // true. No listener teardown here - transports notify them after abort().
             this.emptyOutputBuffer();
 
             if (callback) {
@@ -252,11 +248,8 @@ class Connection {
         // Note: Don't call addOnReceiveErrorCallback here - it would duplicate the push
     }
 
-    /**
-     * Hand received data to every listener. A listener that throws must not abort
-     * the loop: the remaining listeners would never see this or any later chunk,
-     * and the exception would escape uncaught into the IPC handler.
-     */
+    // A throwing listener must not abort the loop - the rest would never see this
+    // or any later chunk, and the exception would escape into the IPC handler.
     notifyReceiveListeners(info) {
         this._onReceiveListeners.forEach(listener => {
             try {

--- a/js/connection/connection.js
+++ b/js/connection/connection.js
@@ -252,6 +252,31 @@ class Connection {
         // Note: Don't call addOnReceiveErrorCallback here - it would duplicate the push
     }
 
+    /**
+     * Hand received data to every listener. A listener that throws must not abort
+     * the loop: the remaining listeners would never see this or any later chunk,
+     * and the exception would escape uncaught into the IPC handler.
+     */
+    notifyReceiveListeners(info) {
+        this._onReceiveListeners.forEach(listener => {
+            try {
+                listener(info);
+            } catch (error) {
+                console.error('Receive listener threw:', error);
+            }
+        });
+    }
+
+    notifyReceiveErrorListeners(error) {
+        this._onReceiveErrorListeners.forEach(listener => {
+            try {
+                listener(error);
+            } catch (listenerError) {
+                console.error('Receive error listener threw:', listenerError);
+            }
+        });
+    }
+
     removeAllListeners() {
         this._onReceiveListeners.forEach(listener => this.removeOnReceiveCallback(listener));
         this._onReceiveListeners = [];

--- a/js/connection/connectionBle.js
+++ b/js/connection/connectionBle.js
@@ -206,9 +206,7 @@ class ConnectionBle extends Connection {
                         data: buffer
                     };
 
-                    this._onReceiveListeners.forEach(listener => {
-                        listener(info);
-                    });
+                    this.notifyReceiveListeners(info);
                 };
 
                 this._readCharacteristic.addEventListener('characteristicvaluechanged', this._handleOnCharateristicValueChanged)

--- a/js/connection/connectionSerial.js
+++ b/js/connection/connectionSerial.js
@@ -36,11 +36,9 @@ class ConnectionSerial extends Connection {
         }
 
         this._ipcDataHandler = window.electronAPI.onSerialData(buffer => {
-            this._onReceiveListeners.forEach(listener => {
-                listener({
-                    connectionId: this._connectionId,
-                    data: buffer
-                });
+            this.notifyReceiveListeners({
+                connectionId: this._connectionId,
+                data: buffer
             });
         });
 
@@ -54,9 +52,7 @@ class ConnectionSerial extends Connection {
             console.log(error);
             this.abort();
 
-            this._onReceiveErrorListeners.forEach(listener => {
-                listener(error);
-            });
+            this.notifyReceiveErrorListeners(error);
         });
     }
 

--- a/js/connection/connectionSerial.js
+++ b/js/connection/connectionSerial.js
@@ -87,49 +87,79 @@ class ConnectionSerial extends Connection {
                         bitrate: options.bitrate,
                         connectionId: this._connectionId
                     });
-                } 
+                }
             } else {
                 console.log("Serial connection error: " + response.msg);
                 if (callback) {
                     callback(false);
                 }
             }
+        }).catch(error => {
+            console.log("Serial connection failed: " + error);
+            if (callback) {
+                callback(false);
+            }
         });
     }
 
-    disconnectImplementation(callback) {   
+    disconnectImplementation(callback) {
         if (this._connectionId) {
             window.electronAPI.serialClose().then(response => {
                 var ok = true;
                 if (response.error) {
                     console.log("Unable to close serial: " + response.msg);
                     ok = false;
-                }            
+                }
                 if (callback) {
                     callback(ok);
                 }
-            });  
-        }  
-    }
-
-    sendImplementation(data, callback) {        
-        if (this._connectionId) {
-            window.electronAPI.serialSend(data).then(response => {
-                var result = 0;
-                var sent = response.bytesWritten;
-                if (response.error) {
-                    console.log("Serial write error: " + response.msg);
-                    result = 1;
-                    sent = 0;
-                }
+            }).catch(error => {
+                console.log("Unable to close serial: " + error);
                 if (callback) {
-                    callback({
-                        bytesSent: sent,
-                        resultCode: result
-                    });
+                    callback(false);
                 }
             });
+        } else if (callback) {
+            callback(false);
         }
+    }
+
+    sendImplementation(data, callback) {
+        // Connection.send() advances its output queue only from this callback, so
+        // every path has to fire it - a lost callback stalls the queue for good.
+        if (!this._connectionId) {
+            if (callback) {
+                callback({
+                    bytesSent: 0,
+                    resultCode: 1
+                });
+            }
+            return;
+        }
+
+        window.electronAPI.serialSend(data).then(response => {
+            var result = 0;
+            var sent = response.bytesWritten;
+            if (response.error) {
+                console.log("Serial write error: " + response.msg);
+                result = 1;
+                sent = 0;
+            }
+            if (callback) {
+                callback({
+                    bytesSent: sent,
+                    resultCode: result
+                });
+            }
+        }).catch(error => {
+            console.log("Serial write failed: " + error);
+            if (callback) {
+                callback({
+                    bytesSent: 0,
+                    resultCode: 1
+                });
+            }
+        });
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionSerial.js
+++ b/js/connection/connectionSerial.js
@@ -121,8 +121,7 @@ class ConnectionSerial extends Connection {
     }
 
     sendImplementation(data, callback) {
-        // Connection.send() advances its output queue only from this callback, so
-        // every path has to fire it - a lost callback stalls the queue for good.
+        // Connection.send() advances its queue only from this callback - never drop it.
         if (!this._connectionId) {
             if (callback) {
                 callback({

--- a/js/connection/connectionSerial.js
+++ b/js/connection/connectionSerial.js
@@ -90,71 +90,15 @@ class ConnectionSerial extends Connection {
                     callback(false);
                 }
             }
-        }).catch(error => {
-            console.log("Serial connection failed: " + error);
-            if (callback) {
-                callback(false);
-            }
-        });
+        }).catch(this.reportFailure("Serial connection failed", callback));
     }
 
     disconnectImplementation(callback) {
-        if (this._connectionId) {
-            window.electronAPI.serialClose().then(response => {
-                var ok = true;
-                if (response.error) {
-                    console.log("Unable to close serial: " + response.msg);
-                    ok = false;
-                }
-                if (callback) {
-                    callback(ok);
-                }
-            }).catch(error => {
-                console.log("Unable to close serial: " + error);
-                if (callback) {
-                    callback(false);
-                }
-            });
-        } else if (callback) {
-            callback(false);
-        }
+        this.completeClose('serial', this._connectionId ? window.electronAPI.serialClose() : null, callback);
     }
 
     sendImplementation(data, callback) {
-        // Connection.send() advances its queue only from this callback - never drop it.
-        if (!this._connectionId) {
-            if (callback) {
-                callback({
-                    bytesSent: 0,
-                    resultCode: 1
-                });
-            }
-            return;
-        }
-
-        window.electronAPI.serialSend(data).then(response => {
-            var result = 0;
-            var sent = response.bytesWritten;
-            if (response.error) {
-                console.log("Serial write error: " + response.msg);
-                result = 1;
-                sent = 0;
-            }
-            if (callback) {
-                callback({
-                    bytesSent: sent,
-                    resultCode: result
-                });
-            }
-        }).catch(error => {
-            console.log("Serial write failed: " + error);
-            if (callback) {
-                callback({
-                    bytesSent: 0,
-                    resultCode: 1
-                });
-            }
-        });
+        this.completeSend('Serial', this._connectionId ? window.electronAPI.serialSend(data) : null, callback);
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionTcp.js
+++ b/js/connection/connectionTcp.js
@@ -89,12 +89,7 @@ class ConnectionTcp extends Connection {
                     callback(false);
                 }
             }
-        }).catch(error => {
-            console.log("TCP connection failed: " + error);
-            if (callback) {
-                callback(false);
-            }
-        });
+        }).catch(this.reportFailure("TCP connection failed", callback));
     }
 
     disconnectImplementation(callback) {
@@ -111,41 +106,8 @@ class ConnectionTcp extends Connection {
        }
     }
 
-   sendImplementation(data, callback) {
-        // Connection.send() advances its queue only from this callback - never drop it.
-        if (!this._connectionId) {
-            if (callback) {
-                callback({
-                    bytesSent: 0,
-                    resultCode: 1
-                });
-            }
-            return;
-        }
-
-        window.electronAPI.tcpSend(data).then(response => {
-            var result = 0;
-            var sent = response.bytesWritten;
-            if (response.error) {
-                console.log("TCP write error: " + response.msg);
-                result = 1;
-                sent = 0;
-            }
-            if (callback) {
-                callback({
-                    bytesSent: sent,
-                    resultCode: result
-                });
-            }
-        }).catch(error => {
-            console.log("TCP write failed: " + error);
-            if (callback) {
-                callback({
-                    bytesSent: 0,
-                    resultCode: 1
-                });
-            }
-        });
+    sendImplementation(data, callback) {
+        this.completeSend('TCP', this._connectionId ? window.electronAPI.tcpSend(data) : null, callback);
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionTcp.js
+++ b/js/connection/connectionTcp.js
@@ -93,6 +93,11 @@ class ConnectionTcp extends Connection {
                     callback(false);
                 }
             }
+        }).catch(error => {
+            console.log("TCP connection failed: " + error);
+            if (callback) {
+                callback(false);
+            }
         });
     }
 
@@ -110,24 +115,42 @@ class ConnectionTcp extends Connection {
        }
     }
 
-   sendImplementation(data, callback) {     
-        if (this._connectionId) {
-            window.electronAPI.tcpSend(data).then(response => {
-                var result = 0;
-                var sent = response.bytesWritten;
-                if (response.error) {
-                    console.log("Serial write error: " + response.msg);
-                    result = 1;
-                    sent = 0;
-                }
-                if (callback) {
-                    callback({
-                        bytesSent: sent,
-                        resultCode: result
-                    });
-                }
-            });
+   sendImplementation(data, callback) {
+        // Connection.send() advances its output queue only from this callback, so
+        // every path has to fire it - a lost callback stalls the queue for good.
+        if (!this._connectionId) {
+            if (callback) {
+                callback({
+                    bytesSent: 0,
+                    resultCode: 1
+                });
+            }
+            return;
         }
+
+        window.electronAPI.tcpSend(data).then(response => {
+            var result = 0;
+            var sent = response.bytesWritten;
+            if (response.error) {
+                console.log("TCP write error: " + response.msg);
+                result = 1;
+                sent = 0;
+            }
+            if (callback) {
+                callback({
+                    bytesSent: sent,
+                    resultCode: result
+                });
+            }
+        }).catch(error => {
+            console.log("TCP write failed: " + error);
+            if (callback) {
+                callback({
+                    bytesSent: 0,
+                    resultCode: 1
+                });
+            }
+        });
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionTcp.js
+++ b/js/connection/connectionTcp.js
@@ -112,8 +112,7 @@ class ConnectionTcp extends Connection {
     }
 
    sendImplementation(data, callback) {
-        // Connection.send() advances its output queue only from this callback, so
-        // every path has to fire it - a lost callback stalls the queue for good.
+        // Connection.send() advances its queue only from this callback - never drop it.
         if (!this._connectionId) {
             if (callback) {
                 callback({

--- a/js/connection/connectionTcp.js
+++ b/js/connection/connectionTcp.js
@@ -27,11 +27,9 @@ class ConnectionTcp extends Connection {
         }
 
         this._ipcDataHandler = window.electronAPI.onTcpData(buffer => {
-            this._onReceiveListeners.forEach(listener => {
-                listener({
-                    connectionId: this._connectionId,
-                    data: buffer
-                });
+            this.notifyReceiveListeners({
+                connectionId: this._connectionId,
+                data: buffer
             });
         });
 
@@ -44,9 +42,7 @@ class ConnectionTcp extends Connection {
             GUI.log(error);
             console.log(error);
             this.abort();
-            this._onReceiveErrorListeners.forEach(listener => {
-                listener(error);
-            });
+            this.notifyReceiveErrorListeners(error);
         });
     }
 

--- a/js/connection/connectionUdp.js
+++ b/js/connection/connectionUdp.js
@@ -82,71 +82,15 @@ class ConnectionUdp extends Connection {
                     callback(false);
                 }
             }
-        }).catch(error => {
-            console.log("UDP connection failed: " + error);
-            if (callback) {
-                callback(false);
-            }
-        });
+        }).catch(this.reportFailure("UDP connection failed", callback));
     }
 
     disconnectImplementation(callback) {
-        if (this._connectionId) {
-            window.electronAPI.udpClose().then(response => {
-                var ok = true;
-                if (response.error) {
-                    console.log("Unable to close UDP: " + response.msg);
-                    ok = false;
-                }
-                if (callback) {
-                    callback(ok);
-                }
-            }).catch(error => {
-                console.log("Unable to close UDP: " + error);
-                if (callback) {
-                    callback(false);
-                }
-            });
-        } else if (callback) {
-            callback(false);
-        }
+        this.completeClose('UDP', this._connectionId ? window.electronAPI.udpClose() : null, callback);
     }
 
-   sendImplementation(data, callback) {
-        // Connection.send() advances its queue only from this callback - never drop it.
-        if (!this._connectionId) {
-            if (callback) {
-                callback({
-                    bytesSent: 0,
-                    resultCode: 1
-                });
-            }
-            return;
-        }
-
-        window.electronAPI.udpSend(data).then(response => {
-            var result = 0;
-            var sent = response.bytesWritten;
-            if (response.error) {
-                console.log("UDP write error: " + response.msg);
-                result = 1;
-                sent = 0;
-            }
-            if (callback) {
-                callback({
-                    bytesSent: sent,
-                    resultCode: result
-                });
-            }
-        }).catch(error => {
-            console.log("UDP write failed: " + error);
-            if (callback) {
-                callback({
-                    bytesSent: 0,
-                    resultCode: 1
-                });
-            }
-        });
+    sendImplementation(data, callback) {
+        this.completeSend('UDP', this._connectionId ? window.electronAPI.udpSend(data) : null, callback);
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionUdp.js
+++ b/js/connection/connectionUdp.js
@@ -29,11 +29,9 @@ class ConnectionUdp extends Connection {
         }
 
         this._ipcMessageHandler = window.electronAPI.onUdpMessage(message => {
-            this._onReceiveListeners.forEach(listener => {
-                listener({
-                    connectionId: this._connectionId,
-                    data: message
-                });
+            this.notifyReceiveListeners({
+                connectionId: this._connectionId,
+                data: message
             });
         });
 
@@ -41,9 +39,7 @@ class ConnectionUdp extends Connection {
             GUI.log(error);
             console.log(error);
             this.abort();
-            this._onReceiveErrorListeners.forEach(listener => {
-                listener(error);
-            });
+            this.notifyReceiveErrorListeners(error);
         });
     }
 

--- a/js/connection/connectionUdp.js
+++ b/js/connection/connectionUdp.js
@@ -86,6 +86,11 @@ class ConnectionUdp extends Connection {
                     callback(false);
                 }
             }
+        }).catch(error => {
+            console.log("UDP connection failed: " + error);
+            if (callback) {
+                callback(false);
+            }
         });
     }
 
@@ -96,32 +101,57 @@ class ConnectionUdp extends Connection {
                 if (response.error) {
                     console.log("Unable to close UDP: " + response.msg);
                     ok = false;
-                }            
+                }
                 if (callback) {
                     callback(ok);
                 }
-            });  
-        }  
-    }
-
-   sendImplementation(data, callback) {    
-        if (this._connectionId) {
-            window.electronAPI.udpSend(data).then(response => {
-                var result = 0;
-                var sent = response.bytesWritten;
-                if (response.error) {
-                    console.log("Serial write error: " + response.msg);
-                    result = 1;
-                    sent = 0;
-                }
+            }).catch(error => {
+                console.log("Unable to close UDP: " + error);
                 if (callback) {
-                    callback({
-                        bytesSent: sent,
-                        resultCode: result
-                    });
+                    callback(false);
                 }
             });
+        } else if (callback) {
+            callback(false);
         }
+    }
+
+   sendImplementation(data, callback) {
+        // Connection.send() advances its output queue only from this callback, so
+        // every path has to fire it - a lost callback stalls the queue for good.
+        if (!this._connectionId) {
+            if (callback) {
+                callback({
+                    bytesSent: 0,
+                    resultCode: 1
+                });
+            }
+            return;
+        }
+
+        window.electronAPI.udpSend(data).then(response => {
+            var result = 0;
+            var sent = response.bytesWritten;
+            if (response.error) {
+                console.log("UDP write error: " + response.msg);
+                result = 1;
+                sent = 0;
+            }
+            if (callback) {
+                callback({
+                    bytesSent: sent,
+                    resultCode: result
+                });
+            }
+        }).catch(error => {
+            console.log("UDP write failed: " + error);
+            if (callback) {
+                callback({
+                    bytesSent: 0,
+                    resultCode: 1
+                });
+            }
+        });
     }
 
     addOnReceiveCallback(callback){

--- a/js/connection/connectionUdp.js
+++ b/js/connection/connectionUdp.js
@@ -113,8 +113,7 @@ class ConnectionUdp extends Connection {
     }
 
    sendImplementation(data, callback) {
-        // Connection.send() advances its output queue only from this callback, so
-        // every path has to fire it - a lost callback stalls the queue for good.
+        // Connection.send() advances its queue only from this callback - never drop it.
         if (!this._connectionId) {
             if (callback) {
                 callback({

--- a/js/msp.js
+++ b/js/msp.js
@@ -9,7 +9,7 @@ import CONFIGURATOR from './data_storage';
 // Every MSP code that changes something on the FC, recognised by name so a write
 // added later is covered without maintaining a list here.
 const WRITE_CODE_NAMES = Object.keys(MSPCodes)
-    .filter(name => /SET_|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
+    .filter(name => /(^|_)SET(_|$)|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
 
 // Writes carrying nothing read off the FC, so an unreadable response cannot poison
 // them. Refusing the live ones would be a hazard of its own.
@@ -42,7 +42,9 @@ for (const name of WRITE_CODE_NAMES) {
     if (ALWAYS_ALLOWED_WRITE_CODES.has(MSPCodes[name])) {
         continue;
     }
-    const sourceName = IRREGULAR_WRITE_SOURCES[name] || name.replace('SET_', '');
+    // MSP2_INAV_EZ_TUNE_SET names its write the other way round.
+    const sourceName = IRREGULAR_WRITE_SOURCES[name]
+        || (name.endsWith('_SET') ? name.slice(0, -4) : name.replace('SET_', ''));
     if (MSPCodes[sourceName] !== undefined && sourceName !== name) {
         WRITE_SOURCE_CODES.set(MSPCodes[name], MSPCodes[sourceName]);
     }
@@ -161,6 +163,24 @@ var MSP = {
         // Unpaired write: refuse rather than guess. Over-blocking costs a refused save,
         // under-blocking puts wrong values into the aircraft.
         return WRITE_CODES.has(code) ? this.parseFailures.values().next().value : false;
+    },
+
+    // Reports and refuses a write built from an unreadable response.
+    refuseBlockedWrite(code) {
+        const blockedBy = this.blockedWriteSource(code);
+        if (blockedBy === false) {
+            return false;
+        }
+
+        console.error('Refusing MSP write ' + this.getCodeName(code) + ': its source ' +
+            this.getCodeName(blockedBy) + ' could not be parsed this session');
+
+        // A silent refusal would be worse - the user would believe it was saved.
+        if (this.onConfigWriteBlocked) {
+            this.onConfigWriteBlocked(code, blockedBy);
+        }
+
+        return true;
     },
 
     init() {
@@ -381,21 +401,9 @@ var MSP = {
     },
 
     send_message(code, data, callback_sent, callback_msp, protocolVersion) {
-        const blockedBy = this.blockedWriteSource(code);
-        if (blockedBy !== false) {
-            console.error('Refusing MSP write ' + this.getCodeName(code) + ': its source ' +
-                this.getCodeName(blockedBy) + ' could not be parsed this session');
-
-            // A silent refusal would be worse - the user would believe it was saved.
-            if (this.onConfigWriteBlocked) {
-                this.onConfigWriteBlocked(code, blockedBy);
-            }
-
-            // Report failure rather than going quiet, or the caller's save chain hangs.
-            if (callback_msp) {
-                callback_msp(false);
-            }
-
+        // No callback on a refusal: save chains ignore its argument, so calling it
+        // would run the EEPROM write and reboot as if the settings had been stored.
+        if (this.refuseBlockedWrite(code)) {
             return false;
         }
 

--- a/js/msp.js
+++ b/js/msp.js
@@ -6,6 +6,50 @@ import eventFrequencyAnalyzer from './eventFrequencyAnalyzer';
 import timeout from './timeouts';
 import CONFIGURATOR from './data_storage';
 
+// Every MSP code that changes something on the FC, recognised by name so a write
+// added later is covered without maintaining a list here.
+const WRITE_CODE_NAMES = Object.keys(MSPCodes)
+    .filter(name => /SET_|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
+
+// Writes carrying nothing read off the FC, so an unreadable response cannot poison
+// them. Refusing the live ones would be a hazard of its own.
+const ALWAYS_ALLOWED_WRITE_NAMES = [
+    'MSP_SET_REBOOT',            // stores nothing; the user's way out of a bad session
+    'MSP_SET_MOTOR',             // stopMotors() stops a running motor test with this
+    'MSP_SET_RAW_RC', 'MSP_SET_RAW_GPS', 'MSP_SET_HEAD', 'MSP_SET_RTC',
+    'MSP_EEPROM_WRITE',          // persists what is already on the FC
+    'MSP_RESET_CONF', 'MSP_SET_RESET_CURR_PID',
+    'MSP_SELECT_SETTING', 'MSP2_INAV_SELECT_BATTERY_PROFILE', 'MSP2_INAV_SELECT_MIXER_PROFILE',
+    'MSP_WP_MISSION_SAVE', 'MSP_DATAFLASH_ERASE', 'MSP_OSD_CHAR_WRITE',
+    'MSP_SET_BOX',               // legacy, never sent by this Configurator
+];
+
+// Writes that do not pair with their read by name alone.
+const IRREGULAR_WRITE_SOURCES = {
+    MSP_SET_MODE_RANGE:            'MSP_MODE_RANGES',
+    MSP_SET_ADJUSTMENT_RANGE:      'MSP_ADJUSTMENT_RANGES',
+    MSP2_INAV_OSD_SET_LAYOUT_ITEM: 'MSP2_INAV_OSD_LAYOUTS',
+    MSP2_INAV_SET_GEOZONE_VERTICE: 'MSP2_INAV_GEOZONE_VERTEX',
+};
+
+const WRITE_CODES = new Set(WRITE_CODE_NAMES.map(name => MSPCodes[name]));
+const ALWAYS_ALLOWED_WRITE_CODES = new Set(ALWAYS_ALLOWED_WRITE_NAMES.map(name => MSPCodes[name]));
+
+// write -> the read whose parsed state it hands back, so an unreadable response
+// disables only the saves carrying its values instead of every save.
+const WRITE_SOURCE_CODES = new Map();
+for (const name of WRITE_CODE_NAMES) {
+    if (ALWAYS_ALLOWED_WRITE_CODES.has(MSPCodes[name])) {
+        continue;
+    }
+    const sourceName = IRREGULAR_WRITE_SOURCES[name] || name.replace('SET_', '');
+    if (MSPCodes[sourceName] !== undefined && sourceName !== name) {
+        WRITE_SOURCE_CODES.set(MSPCodes[name], MSPCodes[sourceName]);
+    }
+}
+
+const CODE_NAMES = new Map(Object.keys(MSPCodes).map(name => [MSPCodes[name], name]));
+
 /**
  *
  * @constructor
@@ -91,6 +135,33 @@ var MSP = {
     lastFrameReceivedMs: 0,
 
     processData: null,
+
+    // Reads whose response failed to parse this session. The FC state they fill is
+    // then part fresh and part stale, so the writes handing it back are refused.
+    parseFailures: new Set(),
+
+    // Set by MSPHelper; injected because gui.js already imports this module.
+    onConfigWriteBlocked: null,
+
+    getCodeName(code) {
+        return CODE_NAMES.get(code) || ('0x' + code.toString(16));
+    },
+
+    // Which unreadable response makes this write unsafe, or false if it is safe.
+    blockedWriteSource(code) {
+        if (this.parseFailures.size === 0 || ALWAYS_ALLOWED_WRITE_CODES.has(code)) {
+            return false;
+        }
+
+        const source = WRITE_SOURCE_CODES.get(code);
+        if (source !== undefined) {
+            return this.parseFailures.has(source) ? source : false;
+        }
+
+        // Unpaired write: refuse rather than guess. Over-blocking costs a refused save,
+        // under-blocking puts wrong values into the aircraft.
+        return WRITE_CODES.has(code) ? this.parseFailures.values().next().value : false;
+    },
 
     init() {
         mspQueue.setPutCallback(this.putCallback);
@@ -276,8 +347,7 @@ var MSP = {
             }
         } finally {
             /*
-             * Free port - processData is a pluggable callback, so releasing the lock
-             * cannot depend on it returning normally.
+             * Free port - processData is pluggable, so this cannot depend on it returning.
              */
             timeout.add('delayedFreeHardLock', function() {
                 mspQueue.freeHardLock();
@@ -311,6 +381,24 @@ var MSP = {
     },
 
     send_message(code, data, callback_sent, callback_msp, protocolVersion) {
+        const blockedBy = this.blockedWriteSource(code);
+        if (blockedBy !== false) {
+            console.error('Refusing MSP write ' + this.getCodeName(code) + ': its source ' +
+                this.getCodeName(blockedBy) + ' could not be parsed this session');
+
+            // A silent refusal would be worse - the user would believe it was saved.
+            if (this.onConfigWriteBlocked) {
+                this.onConfigWriteBlocked(code, blockedBy);
+            }
+
+            // Report failure rather than going quiet, or the caller's save chain hangs.
+            if (callback_msp) {
+                callback_msp(false);
+            }
+
+            return false;
+        }
+
         var payloadLength = data && data.length ? data.length : 0;
         var length;
         var buffer;
@@ -444,6 +532,7 @@ var MSP = {
     disconnect_cleanup() {
         this.state = 0; // reset packet state for "clean" initial entry (this is only required if user hot-disconnects)
         this.packet_error = 0; // reset CRC packet error counter for next session
+        this.parseFailures.clear(); // the next session re-reads everything from scratch
 
         this.callbacks_cleanup();
     },

--- a/js/msp.js
+++ b/js/msp.js
@@ -274,14 +274,15 @@ var MSP = {
                 this.packet_error++;
                 $('span.packet-error').html(this.packet_error);
             }
-
+        } finally {
             /*
-             * Free port
+             * Free port - processData is a pluggable callback, so releasing the lock
+             * cannot depend on it returning normally.
              */
             timeout.add('delayedFreeHardLock', function() {
                 mspQueue.freeHardLock();
             }, 10);
-        } finally {
+
             // Reset variables - MUST happen even if an exception occurred
             this.message_length_received = 0;
             this.state = this.decoder_states.IDLE;

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -4,6 +4,7 @@ import semver from 'semver';
 
 import './../injected_methods';
 import GUI from './../gui';
+import i18n from './../localization';
 import MSP from './../msp';
 import MSPCodes from './MSPCodes';
 import FC from './../fc';
@@ -54,8 +55,20 @@ var mspHelper = (function () {
     // always finish with a '\0'.
     var debugMsgBuffer = '';
 
+    var lastWriteBlockedNotice = 0;
+
     self.init = function() {
         MSP.setProcessData(this.processData);
+
+        MSP.onConfigWriteBlocked = function (code, sourceCode) {
+            // One notice per save burst - a save fans out into many writes.
+            const now = Date.now();
+            if (now - lastWriteBlockedNotice < 3000) {
+                return;
+            }
+            lastWriteBlockedNotice = now;
+            GUI.log(i18n.getMessage('mspWriteBlockedAfterParseFailure', [MSP.getCodeName(sourceCode)]));
+        };
     }
 
     /**
@@ -68,12 +81,15 @@ var mspHelper = (function () {
         try {
             parseMessage(dataHandler, data);
         } catch (error) {
-            // Completing the request below has to happen regardless. A payload this
-            // Configurator cannot parse (FC built from a different branch, fields
-            // added or removed) would otherwise leave the request pending forever:
-            // whatever tab is waiting on it never finishes loading and the GUI stays
-            // stuck mid tab-switch until the user disconnects.
+            // Completing the request below must happen anyway, or the tab waiting on it
+            // never finishes loading and the GUI stays stuck mid tab-switch.
             console.error('Failed to parse MSP code 0x' + dataHandler.code.toString(16) + ':', error);
+
+            // Half this message landed in FC state - refuse the writes handing it back.
+            if (!MSP.parseFailures.has(dataHandler.code)) {
+                MSP.parseFailures.add(dataHandler.code);
+                GUI.log(i18n.getMessage('mspResponseUnreadable', [MSP.getCodeName(dataHandler.code)]));
+            }
         }
 
         completeRequest(dataHandler, data);
@@ -335,10 +351,8 @@ var mspHelper = (function () {
             case MSPCodes.MSP2_PID:
                 // PID data arrived, we need to scale it and save to appropriate bank / array
                 for (let i = 0, needle = 0; i < (dataHandler.message_length_expected / 4); i++, needle += 4) {
-                    // A newer FC reports more banks than this Configurator knows about.
-                    // Keep them instead of writing past the array: MSP2_SET_PID is only
-                    // accepted at the FC's exact bank count, so dropping them would make
-                    // every PID save fail silently.
+                    // A newer FC reports more banks than we know. Keep them rather than
+                    // write past the array - MSP2_SET_PID needs the FC's exact count.
                     if (!FC.PIDs[i]) {
                         FC.PIDs[i] = new Array(4);
                     }

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -63,8 +63,24 @@ var mspHelper = (function () {
      * @param {MSP} dataHandler
      */
     self.processData = function (dataHandler) {
-        var data = new DataView(dataHandler.message_buffer, 0), // DataView (allowing us to view arrayBuffer as struct/union)
-            offset = 0,
+        var data = new DataView(dataHandler.message_buffer, 0); // DataView (allowing us to view arrayBuffer as struct/union)
+
+        try {
+            parseMessage(dataHandler, data);
+        } catch (error) {
+            // Completing the request below has to happen regardless. A payload this
+            // Configurator cannot parse (FC built from a different branch, fields
+            // added or removed) would otherwise leave the request pending forever:
+            // whatever tab is waiting on it never finishes loading and the GUI stays
+            // stuck mid tab-switch until the user disconnects.
+            console.error('Failed to parse MSP code 0x' + dataHandler.code.toString(16) + ':', error);
+        }
+
+        completeRequest(dataHandler, data);
+    };
+
+    var parseMessage = function (dataHandler, data) {
+        var offset = 0,
             needle = 0,
             i = 0,
             buff = [],
@@ -319,6 +335,13 @@ var mspHelper = (function () {
             case MSPCodes.MSP2_PID:
                 // PID data arrived, we need to scale it and save to appropriate bank / array
                 for (let i = 0, needle = 0; i < (dataHandler.message_length_expected / 4); i++, needle += 4) {
+                    // A newer FC reports more banks than this Configurator knows about.
+                    // Keep them instead of writing past the array: MSP2_SET_PID is only
+                    // accepted at the FC's exact bank count, so dropping them would make
+                    // every PID save fail silently.
+                    if (!FC.PIDs[i]) {
+                        FC.PIDs[i] = new Array(4);
+                    }
                     FC.PIDs[i][0] = data.getUint8(needle);
                     FC.PIDs[i][1] = data.getUint8(needle + 1);
                     FC.PIDs[i][2] = data.getUint8(needle + 2);
@@ -1711,7 +1734,9 @@ var mspHelper = (function () {
         } else {
             console.log('FC reports unsupported message error: 0x' + dataHandler.code.toString(16));
         }
+    };
 
+    var completeRequest = function (dataHandler, data) {
         // trigger callbacks, cleanup/remove callback after trigger
         for (let i = dataHandler.callbacks.length - 1; i >= 0; i--) { // iterating in reverse because we use .splice which modifies array length
             if (i < dataHandler.callbacks.length) {

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -58,7 +58,7 @@ var mspHelper = (function () {
     var lastWriteBlockedNotice = 0;
 
     self.init = function() {
-        MSP.setProcessData(this.processData);
+        MSP.setProcessData(this.handleResponse);
 
         MSP.onConfigWriteBlocked = function (code, sourceCode) {
             // One notice per save burst - a save fans out into many writes.
@@ -72,17 +72,14 @@ var mspHelper = (function () {
     }
 
     /**
-     *
+     * MSP response entry point. Completing the request must happen even when a
+     * parser case throws, or the tab waiting on it never finishes loading.
      * @param {MSP} dataHandler
      */
-    self.processData = function (dataHandler) {
-        var data = new DataView(dataHandler.message_buffer, 0); // DataView (allowing us to view arrayBuffer as struct/union)
-
+    self.handleResponse = function (dataHandler) {
         try {
-            parseMessage(dataHandler, data);
+            self.processData(dataHandler);
         } catch (error) {
-            // Completing the request below must happen anyway, or the tab waiting on it
-            // never finishes loading and the GUI stays stuck mid tab-switch.
             console.error('Failed to parse MSP code 0x' + dataHandler.code.toString(16) + ':', error);
 
             // Half this message landed in FC state - refuse the writes handing it back.
@@ -92,11 +89,16 @@ var mspHelper = (function () {
             }
         }
 
-        completeRequest(dataHandler, data);
+        completeRequest(dataHandler, new DataView(dataHandler.message_buffer, 0));
     };
 
-    var parseMessage = function (dataHandler, data) {
-        var offset = 0,
+    /**
+     *
+     * @param {MSP} dataHandler
+     */
+    self.processData = function (dataHandler) {
+        var data = new DataView(dataHandler.message_buffer, 0), // DataView (allowing us to view arrayBuffer as struct/union)
+            offset = 0,
             needle = 0,
             i = 0,
             buff = [],

--- a/locale/bg/messages.json
+++ b/locale/bg/messages.json
@@ -5735,6 +5735,24 @@
   "ledStripWiringMessage": {
     "message": "LED диодите без номер на реда на окабеляване няма да бъдат записани."
   },
+  "ledStripQuickPresets": {
+    "message": "Бързи предварителни настройки:"
+  },
+  "ledStripStep1Header": {
+    "message": "Ред на окабеляване"
+  },
+  "ledStripStep2Header": {
+    "message": "Позиция и посока"
+  },
+  "ledStripStep3Header": {
+    "message": "Функция"
+  },
+  "ledStripStep4Header": {
+    "message": "Цвят"
+  },
+  "ledStripEditPalette": {
+    "message": "Редактиране на цветовете на палитрата"
+  },
 
 
   "mainLogoText": {

--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -6074,6 +6074,24 @@
     "ledStripWiringMessage": {
         "message": "LEDs ohne Verdrahtungsnummer werden nicht gespeichert."
     },
+    "ledStripQuickPresets": {
+        "message": "Schnell-Presets:"
+    },
+    "ledStripStep1Header": {
+        "message": "Verdrahtungsreihenfolge"
+    },
+    "ledStripStep2Header": {
+        "message": "Position & Richtung"
+    },
+    "ledStripStep3Header": {
+        "message": "Funktion"
+    },
+    "ledStripStep4Header": {
+        "message": "Farbe"
+    },
+    "ledStripEditPalette": {
+        "message": "Palettenfarben bearbeiten"
+    },
     "mainLogoText": {
         "message": "CONFIGURATOR"
     },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5769,6 +5769,12 @@
     "illegalStateRestartRequired": {
         "message": "Illegal state. Restart required."
     },
+    "mspResponseUnreadable": {
+        "message": "The flight controller's $1 response could not be read. The values it carries may be incomplete, so <span style=\"color: red\">saving them has been disabled</span> to prevent writing wrong settings to the aircraft. Settings that do not use this data are unaffected. Reconnect to try again."
+    },
+    "mspWriteBlockedAfterParseFailure": {
+        "message": "<span style=\"color: red\">Not saved.</span> These settings come from the flight controller's $1 response, which could not be read this session, so writing them back is refused. Reconnect to try again."
+    },
     "motor_direction_inverted": {
         "message": "Normal motor direction / Props-in configuration"
     },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6081,6 +6081,48 @@
     "ledStripWiringMessage": {
         "message": "LEDs without wire ordering number will not be saved."
     },
+    "ledStripQuickPresets": {
+        "message": "Quick Presets:"
+    },
+    "ledStripQuickPresetXFrame": {
+        "message": "X-Frame Quad"
+    },
+    "ledStripQuickPresetCrossFrame": {
+        "message": "Cross-Frame Quad"
+    },
+    "ledStripQuickPresetWing": {
+        "message": "Wing"
+    },
+    "ledStripStep1Header": {
+        "message": "Wire Ordering"
+    },
+    "ledStripStep1Instruction": {
+        "message": "Click Wire Ordering, then drag grid cells in the order LEDs are wired"
+    },
+    "ledStripStep2Header": {
+        "message": "Position & Direction"
+    },
+    "ledStripStep2Instruction": {
+        "message": "Optionally, select LEDs & set their orientation"
+    },
+    "ledStripStep3Header": {
+        "message": "Function"
+    },
+    "ledStripStep3Instruction": {
+        "message": "Select LEDs and assign their function (Flight Mode, Armed state, etc.) and overlays."
+    },
+    "ledStripStep4Header": {
+        "message": "Color"
+    },
+    "ledStripStep4Instruction": {
+        "message": "Select LEDs and click a color to assign it"
+    },
+    "ledStripPlacedText": {
+        "message": "/ 128 placed"
+    },
+    "ledStripEditPalette": {
+        "message": "Edit palette colors"
+    },
     "mainLogoText": {
         "message": "CONFIGURATOR"
     },

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -5745,6 +5745,24 @@
     "ledStripWiringMessage": {
         "message": "ワイヤーオーダー番号のないLEDは保存されません"
     },
+    "ledStripQuickPresets": {
+        "message": "クイックプリセット:"
+    },
+    "ledStripStep1Header": {
+        "message": "配線順序"
+    },
+    "ledStripStep2Header": {
+        "message": "位置と方向"
+    },
+    "ledStripStep3Header": {
+        "message": "機能"
+    },
+    "ledStripStep4Header": {
+        "message": "色"
+    },
+    "ledStripEditPalette": {
+        "message": "パレットの色を編集"
+    },
     "mainLogoText": {
         "message": "CONFIGURATOR"
     },

--- a/locale/ru/messages.json
+++ b/locale/ru/messages.json
@@ -3013,6 +3013,24 @@
     "ledStripWiringMessage": {
         "message": "Светодиоды без порядкового номера подключения не будут сохранены."
     },
+    "ledStripQuickPresets": {
+        "message": "Быстрые пресеты:"
+    },
+    "ledStripStep1Header": {
+        "message": "Порядок подключения"
+    },
+    "ledStripStep2Header": {
+        "message": "Положение и направление"
+    },
+    "ledStripStep3Header": {
+        "message": "Функция"
+    },
+    "ledStripStep4Header": {
+        "message": "Цвет"
+    },
+    "ledStripEditPalette": {
+        "message": "Редактировать цвета палитры"
+    },
     "missionGeozoneMaxVerticesReached": {
         "message": "Достигнуто максимальное количество вершин геозоны."
     },

--- a/locale/uk/messages.json
+++ b/locale/uk/messages.json
@@ -5757,6 +5757,24 @@
     "ledStripWiringMessage": {
         "message": "Світлодіоди без порядкового номера підключення не будуть збережені."
     },
+    "ledStripQuickPresets": {
+        "message": "Швидкі пресети:"
+    },
+    "ledStripStep1Header": {
+        "message": "Порядок підключення"
+    },
+    "ledStripStep2Header": {
+        "message": "Положення та напрямок"
+    },
+    "ledStripStep3Header": {
+        "message": "Функція"
+    },
+    "ledStripStep4Header": {
+        "message": "Колір"
+    },
+    "ledStripEditPalette": {
+        "message": "Редагувати кольори палітри"
+    },
     "mainLogoText": {
         "message": "Конфігуратор"
     },

--- a/locale/zh_CN/messages.json
+++ b/locale/zh_CN/messages.json
@@ -5766,6 +5766,24 @@
     "ledStripWiringMessage": {
         "message": "没有布线序号的 LED 不会被保存。"
     },
+    "ledStripQuickPresets": {
+        "message": "快速预设:"
+    },
+    "ledStripStep1Header": {
+        "message": "接线顺序"
+    },
+    "ledStripStep2Header": {
+        "message": "位置和方向"
+    },
+    "ledStripStep3Header": {
+        "message": "功能"
+    },
+    "ledStripStep4Header": {
+        "message": "颜色"
+    },
+    "ledStripEditPalette": {
+        "message": "编辑调色板颜色"
+    },
 
 
     "mainLogoText": {

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -807,6 +807,14 @@ firmwareFlasherTab.initialize = function (callback) {
                 var mspListener = function(info) { MSP.read(info); };
                 CONFIGURATOR.connection.addOnReceiveCallback(mspListener);
 
+                // FC.CONFIG is null until the first normal connect calls resetState(),
+                // and going straight to the flasher after startup skips that - the
+                // MSP_FC_VERSION handler would throw on write. Only seed it when it is
+                // missing, so an already cached version survives for the timeout path.
+                if (!FC.CONFIG) {
+                    FC.resetState();
+                }
+
                 var versionQueryDone = false;
                 var versionQueryTimeout = setTimeout(function() {
                     if (!versionQueryDone) {

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -807,10 +807,8 @@ firmwareFlasherTab.initialize = function (callback) {
                 var mspListener = function(info) { MSP.read(info); };
                 CONFIGURATOR.connection.addOnReceiveCallback(mspListener);
 
-                // FC.CONFIG is null until the first normal connect calls resetState(),
-                // and going straight to the flasher after startup skips that - the
-                // MSP_FC_VERSION handler would throw on write. Only seed it when it is
-                // missing, so an already cached version survives for the timeout path.
+                // FC.CONFIG is null until the first connect calls resetState(). Guarded on
+                // !FC.CONFIG so a cached version survives for the query's timeout path.
                 if (!FC.CONFIG) {
                     FC.resetState();
                 }

--- a/tabs/led_strip.html
+++ b/tabs/led_strip.html
@@ -9,10 +9,10 @@
 
 
         <div class="quick-layouts">
-            <div class="section step-header">Quick Presets:</div>
-            <button class="quickLayout" data-layout="xframe">X-Frame Quad</button>
-            <button class="quickLayout" data-layout="crossframe">Cross-Frame Quad</button>
-            <button class="quickLayout" data-layout="wing">Wing</button>
+            <div class="section step-header" i18n="ledStripQuickPresets">Quick Presets:</div>
+            <button class="quickLayout" data-layout="xframe" i18n="ledStripQuickPresetXFrame">X-Frame Quad</button>
+            <button class="quickLayout" data-layout="crossframe" i18n="ledStripQuickPresetCrossFrame">Cross-Frame Quad</button>
+            <button class="quickLayout" data-layout="wing" i18n="ledStripQuickPresetWing">Wing</button>
         </div>
 
         <div class="gridColumn">
@@ -61,18 +61,18 @@
         <div class="controls">
 
             <div class="step-section" data-step-section="1">
-                <div class="section step-header"><span class="circle-number">① </span>Wire Ordering
-                    <span class="step-instruction">Click Wire Ordering, then drag grid cells in the order LEDs are wired</span>
+                <div class="section step-header"><span class="circle-number">① </span><span i18n="ledStripStep1Header">Wire Ordering</span>
+                    <span class="step-instruction" i18n="ledStripStep1Instruction">Click Wire Ordering, then drag grid cells in the order LEDs are wired</span>
                 </div>
                 <button class="funcWire" i18n="ledStripWiringMode"></button>
                 <span class="wires-placed">
-                    <span class="placed-count">0</span> / 128 placed
+                    <span class="placed-count">0</span> <span i18n="ledStripPlacedText">/ 128 placed</span>
                 </span>
             </div>
 
             <div class="step-section" data-step-section="2">
-                <div class="section step-header"><span class="circle-number">② </span>Position &amp; Direction
-                    <span class="step-instruction">Optionally, select LEDs & set their orientation</span>
+                <div class="section step-header"><span class="circle-number">② </span><span i18n="ledStripStep2Header">Position &amp; Direction</span>
+                    <span class="step-instruction" i18n="ledStripStep2Instruction">Optionally, select LEDs & set their orientation</span>
                 </div>
                 <div class="directions">
                     <button class="dir-n" i18n="ledStripDirN"></button>
@@ -85,8 +85,8 @@
             </div>
 
             <div class="step-section" data-step-section="3">
-                <div class="section step-header"><span class="circle-number">③ </span>Function
-                    <span class="step-instruction">Select LEDs and assign their function (Flight Mode, Armed state, etc.) and overlays.</span>
+                <div class="section step-header"><span class="circle-number">③ </span><span i18n="ledStripStep3Header">Function</span>
+                    <span class="step-instruction" i18n="ledStripStep3Instruction">Select LEDs and assign their function (Flight Mode, Armed state, etc.) and overlays.</span>
                 </div>
                 <div class="select">
                     <span class="color_section" i18n="ledStripFunctionTitle"></span>
@@ -175,8 +175,8 @@
             </div>
 
             <div class="step-section" data-step-section="4">
-                <div class="section step-header"><span class="circle-number">④ </span>Color
-                    <span class="step-instruction">Select LEDs and click a color to assign it</span>
+                <div class="section step-header"><span class="circle-number">④ </span><span i18n="ledStripStep4Header">Color</span>
+                    <span class="step-instruction" i18n="ledStripStep4Instruction">Select LEDs and click a color to assign it</span>
                 </div>
                 <div class="colors">
                     <button class="color-0" i18n_title="colorBlack">0</button>
@@ -196,7 +196,7 @@
                     <button class="color-14" i18n_title="colorBlack">14</button>
                     <button class="color-15" i18n_title="colorBlack">15</button>
                 </div>
-                <button class="editPalette w100">Edit palette colors</button>
+                <button class="editPalette w100" i18n="ledStripEditPalette">Edit palette colors</button>
             </div>
         </div>
 

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -164,7 +164,7 @@
                             </div>
                             <hr>
                             <div style="display: inline-block">
-                                <label for="multimissionOptionList" data-i18n="missionMultiMissionNo."></label>
+                                <label for="multimissionOptionList" data-i18n="missionMultiMissionNo"></label>
                                 <select name="Number" id="multimissionOptionList" style="width: 50px">
                                     <option value="0">ALL</option>
                                 </select>

--- a/tests/connection-receive-listener-isolation.test.mjs
+++ b/tests/connection-receive-listener-isolation.test.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * Regression test for the receive chain being killed by one throwing listener.
+ *
+ * Bug: every transport dispatched incoming data with a bare
+ * `this._onReceiveListeners.forEach(listener => listener(info))`. A listener
+ * that throws aborts the whole forEach, so every listener registered after it
+ * never sees that chunk - or any later one - and the exception escapes uncaught
+ * into the IPC handler.
+ *
+ * Observed as: opening the firmware flasher right after startup and running a
+ * pre-flash backup died on `Cannot set properties of null (setting
+ * 'flightControllerVersion')` (FC.CONFIG is null until the first normal connect
+ * calls FC.resetState()). That throw happened inside the dispatch loop, so
+ * MSP.read() never processed the response, the flasher waited forever for an
+ * answer and GUI.connect_lock stayed true - the app soft-locked.
+ *
+ * Fix under test: Connection.notifyReceiveListeners() /
+ * notifyReceiveErrorListeners() wrap each listener call in try/catch, and all
+ * four transports dispatch through them. (The FC.CONFIG null itself is fixed
+ * separately in tabs/firmware_flasher.js - see tests/firmware-flasher.test.mjs.)
+ *
+ * The test executes the REAL production files. This codebase uses Vite-style
+ * extensionless relative imports which plain Node's ESM resolver refuses to
+ * load, so - like tests/cli-tab-msp-polling.test.mjs - the sources are read
+ * fresh off disk and only their *import specifiers* are rewritten (GUI and i18n
+ * to inert stubs, './connection' to the rewritten base class). No statement,
+ * expression or ordering inside the code under test is touched.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'connection-receive-listener-'));
+process.on('exit', () => rmSync(tmpDir, { recursive: true, force: true }));
+
+function dataModule(code) {
+    // encodeURIComponent leaves ' ( ) ! * unescaped; the generated specifiers are
+    // embedded in single-quoted string literals, so escape those too.
+    const encoded = encodeURIComponent(code).replace(/['()!*]/g, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+    return 'data:text/javascript,' + encoded;
+}
+
+const mockGuiUrl = dataModule(`
+    const GUI = { connected_to: false, connecting_to: false, log() {} };
+    export default GUI;
+`);
+
+const mockI18nUrl = dataModule(`
+    const i18n = { getMessage(key) { return key; } };
+    export default i18n;
+`);
+
+/**
+ * Rewrite the listed import specifiers in a real source file and write the
+ * result to a temp module. Throws loudly if a pattern stops matching, so a
+ * future reshuffle of those imports fails the test instead of passing
+ * vacuously.
+ */
+function rewriteAndWrite(relSrcPath, rules, outNamePrefix) {
+    let source = readFileSync(join(repoRoot, relSrcPath), 'utf8');
+    for (const [regex, replacement, label] of rules) {
+        if (!regex.test(source)) {
+            throw new Error(
+                `connection-receive-listener-isolation.test.mjs: expected to find and replace "${label}" in ` +
+                `${relSrcPath} but the pattern ${regex} did not match. Update the test's substitution rules.`
+            );
+        }
+        source = source.replace(regex, replacement);
+    }
+    const outPath = join(tmpDir, `${outNamePrefix}.mjs`);
+    writeFileSync(outPath, source, 'utf8');
+    return pathToFileURL(outPath).href;
+}
+
+const realConnectionUrl = rewriteAndWrite('js/connection/connection.js', [
+    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${mockGuiUrl}';`, "import GUI"],
+], 'connection-generated');
+
+const realConnectionSerialUrl = rewriteAndWrite('js/connection/connectionSerial.js', [
+    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${mockGuiUrl}';`, "import GUI"],
+    [/^import \{ ConnectionType, Connection \} from '\.\/connection';$/m, `import { ConnectionType, Connection } from '${realConnectionUrl}';`, "import Connection"],
+    [/^import i18n from '\.\/\.\.\/localization';$/m, `import i18n from '${mockI18nUrl}';`, "import i18n"],
+], 'connectionSerial-generated');
+
+const { default: ConnectionSerial } = await import(realConnectionSerialUrl);
+
+/**
+ * Minimal window.electronAPI stand-in. The on* hooks hand the registered
+ * handler straight back, so registerIpcListeners() parks the real dispatch
+ * closure in _ipcDataHandler / _ipcErrorHandler and the tests can fire it the
+ * way the IPC bridge would.
+ */
+function installElectronApiStub() {
+    global.window = {
+        electronAPI: {
+            onSerialData: (handler) => handler,
+            onSerialClose: (handler) => handler,
+            onSerialError: (handler) => handler,
+            offSerialData: () => {},
+            offSerialClose: () => {},
+            offSerialError: () => {},
+        }
+    };
+}
+
+/** console.error is noise here - the fix logs every swallowed listener error. */
+function silenceConsoleError(t) {
+    const original = console.error;
+    console.error = () => {};
+    t.after(() => { console.error = original; });
+}
+
+test('a throwing receive listener must not cut off the listeners behind it', (t) => {
+    installElectronApiStub();
+    silenceConsoleError(t);
+
+    const connection = new ConnectionSerial();
+    connection.registerIpcListeners();
+
+    const seen = { before: 0, after: 0 };
+    connection.addOnReceiveListener(() => { seen.before++; });
+    connection.addOnReceiveListener(() => {
+        // Exactly what the flasher hit: FC.CONFIG was null.
+        throw new TypeError("Cannot set properties of null (setting 'flightControllerVersion')");
+    });
+    connection.addOnReceiveListener(() => { seen.after++; });
+
+    assert.doesNotThrow(
+        () => connection._ipcDataHandler(new Uint8Array([1, 2, 3]).buffer),
+        'the exception must not escape into the IPC handler'
+    );
+
+    assert.equal(seen.before, 1);
+    assert.equal(seen.after, 1, 'listeners registered after the throwing one must still receive the chunk');
+
+    // The chain has to survive for every following chunk too, not just this one.
+    connection._ipcDataHandler(new Uint8Array([4, 5, 6]).buffer);
+    assert.equal(seen.before, 2);
+    assert.equal(seen.after, 2, 'the chain must stay intact for later chunks');
+});
+
+test('a throwing receive-error listener must not cut off the listeners behind it', (t) => {
+    installElectronApiStub();
+    silenceConsoleError(t);
+
+    const connection = new ConnectionSerial();
+    connection.registerIpcListeners();
+
+    const seen = { before: 0, after: 0 };
+    connection.addOnReceiveErrorListener(() => { seen.before++; });
+    connection.addOnReceiveErrorListener(() => { throw new Error('bad error handler'); });
+    connection.addOnReceiveErrorListener(() => { seen.after++; });
+
+    assert.doesNotThrow(
+        () => connection._ipcErrorHandler('port disappeared'),
+        'the exception must not escape into the IPC error handler'
+    );
+
+    assert.equal(seen.before, 1);
+    assert.equal(seen.after, 1, 'error listeners registered after the throwing one must still be notified');
+});
+
+test('positive control: data reaches every listener in registration order', () => {
+    installElectronApiStub();
+
+    const connection = new ConnectionSerial();
+    connection._connectionId = 7;
+    connection.registerIpcListeners();
+
+    const order = [];
+    connection.addOnReceiveListener((info) => order.push(['first', info]));
+    connection.addOnReceiveListener((info) => order.push(['second', info]));
+
+    const buffer = new Uint8Array([9]).buffer;
+    connection._ipcDataHandler(buffer);
+
+    assert.deepEqual(order.map(([name]) => name), ['first', 'second']);
+    assert.equal(order[0][1].data, buffer, 'the received buffer must be passed through unchanged');
+    assert.equal(order[0][1].connectionId, 7, 'the connection id must still be reported');
+});

--- a/tests/connection-send-queue.test.mjs
+++ b/tests/connection-send-queue.test.mjs
@@ -135,8 +135,8 @@ test('send() completes instead of wedging the queue when there is no port', asyn
     installElectronApiStub({ send: () => Promise.resolve({ error: false, bytesWritten: 3 }) });
 
     const connection = new ConnectionSerial();
-    // _connectionId is 0 out of the constructor: the port vanished (or was never
-    // opened) while the app still holds this singleton.
+    // _connectionId is null out of the constructor: the port vanished (or was
+    // never opened) while the app still holds this singleton.
     let sendInfo = null;
     connection.send(payload, (info) => { sendInfo = info; });
     await settle();
@@ -179,7 +179,9 @@ test('the queue keeps draining after the port disappears mid-session', async () 
     await settle();
     assert.equal(firstInfo.resultCode, 0, 'sanity: the first write goes out normally');
 
-    connection._connectionId = 0;
+    // false, not 0 - 0 is a legitimate connection id (e.g. ConnectionExt's SITL WASM
+    // port), so hasConnectionId() only treats null/false as "no port".
+    connection._connectionId = false;
 
     const results = [];
     connection.send(payload, (info) => results.push(info));

--- a/tests/connection-send-queue.test.mjs
+++ b/tests/connection-send-queue.test.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for the permanently stalled output queue.
+ *
+ * Bug: js/connection/connection.js's send() drives its output buffer purely
+ * from the callback handed to sendImplementation() - that callback is what
+ * shifts the sent entry off the buffer and resets _transmitting. In
+ * js/connection/connectionSerial.js the callback was only reachable inside
+ * `if (this._connectionId)`, and none of the three electronAPI promises
+ * (serialConnect / serialSend / serialClose) had a .catch(). When the port
+ * disappears (FC rebooting into DFU, cable pulled, port busy during USB
+ * re-enumeration) the callback is lost, _transmitting stays true forever and
+ * every later send() only pushes into the buffer and returns.
+ *
+ * Because CONFIGURATOR.connection is a session-wide singleton
+ * (connectionFactory hands back the same instance per type), the object stays
+ * wedged for the rest of the app's lifetime. disconnect() could not heal it
+ * either: emptyOutputBuffer() - the only place resetting _transmitting - sat
+ * inside the very `if (this._connectionId)` branch that is false in exactly
+ * this situation.
+ *
+ * Fix under test:
+ *   - sendImplementation()/disconnectImplementation() fire their callback on
+ *     every path, including when there is no port
+ *   - .catch() on all three electronAPI promises
+ *   - Connection.disconnect()'s else branch performs the same cleanup
+ *
+ * The tests below execute the REAL production files. Both use this codebase's
+ * Vite-style extensionless relative imports, which plain Node's ESM resolver
+ * refuses to load, so - like tests/cli-tab-msp-polling.test.mjs - the sources
+ * are read fresh off disk and only their *import specifiers* are rewritten
+ * (GUI and i18n to inert stubs, './connection' to the rewritten base class).
+ * No statement, expression or ordering inside the code under test is touched.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'connection-send-queue-'));
+process.on('exit', () => rmSync(tmpDir, { recursive: true, force: true }));
+
+function dataModule(code) {
+    // encodeURIComponent leaves ' ( ) ! * unescaped; the generated specifiers are
+    // embedded in single-quoted string literals, so escape those too.
+    const encoded = encodeURIComponent(code).replace(/['()!*]/g, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+    return 'data:text/javascript,' + encoded;
+}
+
+const mockGuiUrl = dataModule(`
+    const GUI = { connected_to: false, connecting_to: false, log() {} };
+    export default GUI;
+`);
+
+const mockI18nUrl = dataModule(`
+    const i18n = { getMessage(key) { return key; } };
+    export default i18n;
+`);
+
+/**
+ * Rewrite the listed import specifiers in a real source file and write the
+ * result to a temp module. Throws loudly if a pattern stops matching, so a
+ * future reshuffle of those imports fails the test instead of passing
+ * vacuously.
+ */
+function rewriteAndWrite(relSrcPath, rules, outNamePrefix) {
+    let source = readFileSync(join(repoRoot, relSrcPath), 'utf8');
+    for (const [regex, replacement, label] of rules) {
+        if (!regex.test(source)) {
+            throw new Error(
+                `connection-send-queue.test.mjs: expected to find and replace "${label}" in ${relSrcPath} ` +
+                `but the pattern ${regex} did not match. Update the test's substitution rules.`
+            );
+        }
+        source = source.replace(regex, replacement);
+    }
+    const outPath = join(tmpDir, `${outNamePrefix}.mjs`);
+    writeFileSync(outPath, source, 'utf8');
+    return pathToFileURL(outPath).href;
+}
+
+const realConnectionUrl = rewriteAndWrite('js/connection/connection.js', [
+    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${mockGuiUrl}';`, "import GUI"],
+], 'connection-generated');
+
+const realConnectionSerialUrl = rewriteAndWrite('js/connection/connectionSerial.js', [
+    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${mockGuiUrl}';`, "import GUI"],
+    [/^import \{ ConnectionType, Connection \} from '\.\/connection';$/m, `import { ConnectionType, Connection } from '${realConnectionUrl}';`, "import Connection"],
+    [/^import i18n from '\.\/\.\.\/localization';$/m, `import i18n from '${mockI18nUrl}';`, "import i18n"],
+], 'connectionSerial-generated');
+
+const { default: ConnectionSerial } = await import(realConnectionSerialUrl);
+
+/**
+ * Minimal window.electronAPI stand-in. `behavior` decides what serialSend does,
+ * so each test can model a healthy port, a rejected IPC promise or a port that
+ * vanished mid-session.
+ */
+function installElectronApiStub(behavior) {
+    const calls = { send: 0, close: 0 };
+    global.window = {
+        electronAPI: {
+            serialConnect: () => Promise.resolve({ error: false, id: 1 }),
+            serialSend: (data) => {
+                calls.send++;
+                return behavior.send(data);
+            },
+            serialClose: () => {
+                calls.close++;
+                return behavior.close ? behavior.close() : Promise.resolve({ error: false });
+            },
+            onSerialData: (handler) => handler,
+            onSerialClose: (handler) => handler,
+            onSerialError: (handler) => handler,
+            offSerialData: () => {},
+            offSerialClose: () => {},
+            offSerialError: () => {},
+        }
+    };
+    return calls;
+}
+
+const payload = new Uint8Array([1, 2, 3]).buffer;
+
+/** Let the promise chains inside sendImplementation settle. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+test('send() completes instead of wedging the queue when there is no port', async () => {
+    installElectronApiStub({ send: () => Promise.resolve({ error: false, bytesWritten: 3 }) });
+
+    const connection = new ConnectionSerial();
+    // _connectionId is 0 out of the constructor: the port vanished (or was never
+    // opened) while the app still holds this singleton.
+    let sendInfo = null;
+    connection.send(payload, (info) => { sendInfo = info; });
+    await settle();
+
+    assert.notEqual(sendInfo, null, 'send() callback must fire even without a port');
+    assert.equal(sendInfo.resultCode, 1, 'a portless send must report failure');
+    assert.equal(sendInfo.bytesSent, 0);
+    assert.equal(connection._transmitting, false, '_transmitting must not stay stuck after a portless send');
+    assert.equal(connection._outputBuffer.length, 0, 'the failed entry must be shifted off the buffer');
+});
+
+test('a rejected serialSend promise must not stall the queue', async () => {
+    installElectronApiStub({ send: () => Promise.reject(new Error('port closed')) });
+
+    const connection = new ConnectionSerial();
+    connection._connectionId = 1;
+
+    let sendInfo = null;
+    connection.send(payload, (info) => { sendInfo = info; });
+    await settle();
+
+    assert.notEqual(sendInfo, null, 'send() callback must fire when the IPC promise rejects');
+    assert.equal(sendInfo.resultCode, 1);
+    assert.equal(connection._transmitting, false, '_transmitting must not stay stuck after a rejected send');
+    assert.equal(connection._outputBuffer.length, 0);
+});
+
+test('the queue keeps draining after the port disappears mid-session', async () => {
+    // First write succeeds, then the port is gone - the exact flash sequence that
+    // used to leave the singleton unusable until the app was restarted.
+    const calls = installElectronApiStub({
+        send: () => Promise.resolve({ error: false, bytesWritten: 3 })
+    });
+
+    const connection = new ConnectionSerial();
+    connection._connectionId = 1;
+
+    let firstInfo = null;
+    connection.send(payload, (info) => { firstInfo = info; });
+    await settle();
+    assert.equal(firstInfo.resultCode, 0, 'sanity: the first write goes out normally');
+
+    connection._connectionId = 0;
+
+    const results = [];
+    connection.send(payload, (info) => results.push(info));
+    connection.send(payload, (info) => results.push(info));
+    await settle();
+
+    assert.equal(results.length, 2, 'every queued write must resolve, not pile up behind a stuck flag');
+    assert.equal(connection._transmitting, false);
+    assert.equal(connection._outputBuffer.length, 0);
+    assert.equal(calls.send, 1, 'no write should be attempted once the port is gone');
+});
+
+test('disconnect() without a port clears the stuck state and fires its callback', async () => {
+    installElectronApiStub({ send: () => Promise.resolve({ error: false, bytesWritten: 3 }) });
+
+    const connection = new ConnectionSerial();
+    connection.registerIpcListeners();
+
+    // Reproduce the wedged singleton the old code left behind.
+    connection._connectionId = false;
+    connection._transmitting = true;
+    connection._outputBuffer = [{ data: payload, callback: null }];
+    connection.addOnReceiveListener(() => {});
+
+    let result = 'not called';
+    connection.disconnect((res) => { result = res; });
+
+    assert.notEqual(result, 'not called', 'disconnect() must fire its callback when there is no port');
+    assert.equal(connection._transmitting, false, 'disconnect() must reset _transmitting');
+    assert.equal(connection._outputBuffer.length, 0, 'disconnect() must drop queued output');
+    // The transports call abort() - which lands here - before notifying their error
+    // listeners, so this path must not tear the listener lists down.
+    assert.equal(connection._onReceiveListeners.length, 1, 'a portless disconnect must leave listener registration alone');
+
+    // ... and the healed object is usable again.
+    connection._connectionId = 1;
+    let sendInfo = null;
+    connection.send(payload, (info) => { sendInfo = info; });
+    await settle();
+    assert.equal(sendInfo.resultCode, 0, 'the connection must be reusable after a portless disconnect');
+});
+
+test('positive control: a healthy port still reports its written bytes', async () => {
+    const calls = installElectronApiStub({ send: () => Promise.resolve({ error: false, bytesWritten: 3 }) });
+
+    const connection = new ConnectionSerial();
+    connection._connectionId = 1;
+
+    let sendInfo = null;
+    connection.send(payload, (info) => { sendInfo = info; });
+    await settle();
+
+    assert.equal(calls.send, 1);
+    assert.equal(sendInfo.resultCode, 0);
+    assert.equal(sendInfo.bytesSent, 3);
+    assert.equal(connection._bytesSent, 3, 'byte statistics must still be tracked');
+    assert.equal(connection._transmitting, false);
+});
+
+test('disconnect() with a live port still reports the close result', async () => {
+    installElectronApiStub({
+        send: () => Promise.resolve({ error: false, bytesWritten: 3 }),
+        close: () => Promise.resolve({ error: false }),
+    });
+
+    const connection = new ConnectionSerial();
+    connection._connectionId = 1;
+
+    const result = await new Promise((r) => connection.disconnect(r));
+    assert.equal(result, true, 'a successful close must still report true');
+    assert.equal(connection._connectionId, false);
+});
+
+test('a rejected serialClose promise must still fire the disconnect callback', async () => {
+    installElectronApiStub({
+        send: () => Promise.resolve({ error: false, bytesWritten: 3 }),
+        close: () => Promise.reject(new Error('port already gone')),
+    });
+
+    const connection = new ConnectionSerial();
+    connection._connectionId = 1;
+
+    const result = await new Promise((r) => connection.disconnect(r));
+    assert.equal(result, false, 'a failed close must report false rather than hang');
+    assert.equal(connection._connectionId, false);
+});

--- a/tests/firmware-flasher.test.mjs
+++ b/tests/firmware-flasher.test.mjs
@@ -5,6 +5,8 @@
  *   Bug 1 — buildMigrationChain used range comparison instead of chain-walk
  *   Bug 2 — lastAutoBackup not cleared at the start of proceedWithFlash
  *   Bug 3 — _enterCli left its receive callback registered after resolving
+ * plus:
+ *   Bug 4 — restore's MSP version query ran against a null FC.CONFIG
  */
 
 import { test, describe } from 'node:test';
@@ -113,5 +115,42 @@ describe('_enterCli removes and nulls callback before resolving', () => {
         assert.notEqual(resolveIdx, -1, '_enterCli must call resolve()');
         assert.ok(removeIdx  < resolveIdx, 'removeOnReceiveCallback must come before resolve()');
         assert.ok(nullIdx    < resolveIdx, 'this._receiveCallback = null must come before resolve()');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 4 — restore seeds FC.CONFIG before querying the FC version
+//
+// FC.CONFIG is null in js/fc.js until the first normal connect calls
+// FC.resetState(). Going straight to the flasher after startup skips that, so
+// MSPHelper's MSP_FC_VERSION handler ("FC.CONFIG.flightControllerVersion = ...")
+// threw, the pre-flash backup hung waiting for a response that never got
+// processed, and GUI.connect_lock stayed true.
+//
+// The seeding must be guarded by !FC.CONFIG: an unconditional resetState()
+// would wipe the cached version that the query's 3s timeout path falls back on.
+// ---------------------------------------------------------------------------
+
+describe('restore seeds FC.CONFIG before the MSP version query', () => {
+    const src = readFileSync(resolve(root, 'tabs/firmware_flasher.js'), 'utf8');
+    // The restore flow's version query, not the target-prefetch one further down.
+    const listenerIdx = src.indexOf('CONFIGURATOR.connection.addOnReceiveCallback(mspListener)');
+    const queryIdx = src.indexOf('var versionQueryDone = false');
+
+    test('the guard sits between the MSP listener and the version query', () => {
+        assert.notEqual(listenerIdx, -1, 'the restore flow must still register mspListener');
+        assert.notEqual(queryIdx, -1, 'the restore flow must still have its version query');
+
+        const between = src.slice(listenerIdx, queryIdx);
+        assert.match(between, /if\s*\(\s*!FC\.CONFIG\s*\)\s*\{\s*FC\.resetState\(\);/,
+            'FC.CONFIG must be seeded via FC.resetState() before MSP_FC_VERSION is sent');
+    });
+
+    test('the seeding stays conditional so a cached version is not wiped', () => {
+        const between = src.slice(listenerIdx, queryIdx);
+        const resetIdx = between.indexOf('FC.resetState()');
+        const guardIdx = between.indexOf('!FC.CONFIG');
+        assert.notEqual(guardIdx, -1, 'resetState() must be guarded by !FC.CONFIG');
+        assert.ok(guardIdx < resetIdx, 'the !FC.CONFIG guard must come before resetState()');
     });
 });

--- a/tests/msp-parse-failure-recovery.test.mjs
+++ b/tests/msp-parse-failure-recovery.test.mjs
@@ -138,6 +138,7 @@ const i18nStubUrl = dataModule(`
     export default i18n;
 `);
 const inertFwApproachUrl = dataModule('export const FwApproach = class {};');
+const inertDronecanAsyncRequestParseUrl = dataModule('export const parseDronecanAsyncRequestResponse = () => null;');
 const inertGeozoneUrl = dataModule(`
     export const Geozone = class {};
     export const GeozoneVertex = class {};
@@ -162,6 +163,7 @@ const realMspHelperUrl = rewriteAndWrite('js/msp/MSPHelper.js', [
     [/^import ProgrammingPid from '\.\/\.\.\/programmingPid';$/m, `import ProgrammingPid from '${inertDefaultUrl}';`, "import ProgrammingPid"],
     [/^import Safehome from '\.\/\.\.\/safehome';$/m, `import Safehome from '${inertDefaultUrl}';`, "import Safehome"],
     [/^import \{ FwApproach \} from '\.\/\.\.\/fwApproach';$/m, `import { FwApproach } from '${inertFwApproachUrl}';`, "import FwApproach"],
+    [/^import \{ parseDronecanAsyncRequestResponse \} from '\.\/\.\.\/dronecanAsyncRequestParse';$/m, `import { parseDronecanAsyncRequestResponse } from '${inertDronecanAsyncRequestParseUrl}';`, "import parseDronecanAsyncRequestResponse"],
     [/^import Waypoint from '\.\/\.\.\/waypoint';$/m, `import Waypoint from '${inertDefaultUrl}';`, "import Waypoint"],
     [/^import mspDeduplicationQueue from '\.\/mspDeduplicationQueue';$/m, `import mspDeduplicationQueue from '${realDedupUrl}';`, "import mspDeduplicationQueue"],
     [/^import mspStatistics from '\.\/mspStatistics';$/m, `import mspStatistics from '${realStatisticsUrl}';`, "import mspStatistics"],

--- a/tests/msp-parse-failure-recovery.test.mjs
+++ b/tests/msp-parse-failure-recovery.test.mjs
@@ -336,7 +336,7 @@ test('every write code is classified - none falls through unnoticed', () => {
     // else fails to parse. That is the safe direction, but it is not the intended
     // behaviour, so adding an MSP write command must fail here until it is either
     // paired with its read or listed as carrying no FC-read data.
-    const writeNames = Object.keys(MSPCodes).filter(name => /SET_|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
+    const writeNames = Object.keys(MSPCodes).filter(name => /(^|_)SET(_|$)|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
     assert.ok(writeNames.length > 60, 'sanity: the write codes must still be recognisable by name');
 
     clearParseFailures();
@@ -428,7 +428,7 @@ test('reads, reboot and live commands are never blocked', () => {
     // does carry FC-read data must be refused. Together with the "none falls
     // through unnoticed" test above this pins both directions - an empty pairing
     // map would pass one of them but never both.
-    const writeNames = Object.keys(MSPCodes).filter(name => /SET_|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
+    const writeNames = Object.keys(MSPCodes).filter(name => /(^|_)SET(_|$)|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
     const blocked = writeNames.filter(name => MSP.blockedWriteSource(MSPCodes[name]) !== false);
     assert.ok(blocked.length > 50, `expected the bulk of writes to be refused, got ${blocked.length}`);
     assert.ok(blocked.includes('MSP2_SET_PID'));
@@ -436,6 +436,34 @@ test('reads, reboot and live commands are never blocked', () => {
     assert.ok(!blocked.includes('MSP_EEPROM_WRITE'));
 
     clearParseFailures();
+});
+
+test('a write is recognised however its name spells SET', () => {
+    // The classifier is a name regex, so a test built on that same regex cannot
+    // notice a write it fails to match - MSP2_INAV_EZ_TUNE_SET was missed that way.
+    // Codes named after SET that are reads, or writes carrying no FC-read data:
+    const notGuarded = [
+        'MSPV2_SETTING', 'MSP2_COMMON_SETTING_INFO',
+        'MSP_SET_REBOOT', 'MSP_SET_MOTOR', 'MSP_SET_RAW_RC', 'MSP_SET_RAW_GPS',
+        'MSP_SET_HEAD', 'MSP_SET_RTC', 'MSP_RESET_CONF', 'MSP_SET_RESET_CURR_PID',
+        'MSP_SELECT_SETTING', 'MSP_SET_BOX',
+    ];
+
+    clearParseFailures();
+    for (const name of Object.keys(MSPCodes)) {
+        MSP.parseFailures.add(MSPCodes[name]);
+    }
+
+    const unguarded = Object.keys(MSPCodes)
+        .filter(name => name.includes('SET') && !notGuarded.includes(name))
+        .filter(name => MSP.blockedWriteSource(MSPCodes[name]) === false);
+
+    assert.equal(MSP.blockedWriteSource(MSPCodes.MSP2_INAV_EZ_TUNE_SET), MSPCodes.MSP2_INAV_EZ_TUNE,
+        'the suffix-form write must pair with the response it hands back');
+
+    clearParseFailures();
+    assert.deepEqual(unguarded, [],
+        `these SET codes are neither guarded nor listed as carrying no FC data: ${unguarded.join(', ')}`);
 });
 
 test('positive control: writes go out normally while parsing is healthy', () => {
@@ -448,7 +476,7 @@ test('positive control: writes go out normally while parsing is healthy', () => 
     assert.equal(mspQueue.getLength(), 1, 'a healthy session must still queue its writes');
 });
 
-test('a blocked write reaches neither the wire nor a silent dead end', () => {
+test('a blocked write reaches neither the wire nor the save chain behind it', () => {
     resetQueue();
     clearParseFailures();
     MSP.parseFailures.add(MSPCodes.MSP2_PID);
@@ -459,7 +487,9 @@ test('a blocked write reaches neither the wire nor a silent dead end', () => {
 
     assert.equal(sent, false, 'send_message must report the refusal');
     assert.equal(mspQueue.getLength(), 0, 'nothing may be queued for the FC');
-    assert.equal(result, false, 'the caller must be told, or its save chain hangs like the original bug');
+    // Save chains read being called as success - failsafe's savePhaseTwo ignores the
+    // argument and would go on to write EEPROM, log "saved" and reboot the FC.
+    assert.equal(result, 'not called', 'a write that never went out must not complete');
     assert.ok(
         GUI.logged.includes('mspWriteBlockedAfterParseFailure'),
         'a silent refusal is worse than none - the user would believe the settings were saved'

--- a/tests/msp-parse-failure-recovery.test.mjs
+++ b/tests/msp-parse-failure-recovery.test.mjs
@@ -22,7 +22,7 @@
  *
  * Fix under test:
  *   - MSP2_PID grows FC.PIDs to the bank count the FC actually reports
- *   - processData() wraps the parse and completes the request regardless
+ *   - handleResponse() runs the parse and completes the request regardless
  *   - msp.js releases the hard lock in a finally
  *
  * The tests execute the REAL production files. This codebase uses Vite-style
@@ -227,7 +227,7 @@ test('MSP2_PID: an FC reporting more banks than we know must not throw', () => {
     // serial_backend.js still pre-sizes FC.PIDs to 11.
     const handler = makeDataHandler(MSPCodes.MSP2_PID, pidPayload(12), (resp) => { response = resp; });
 
-    assert.doesNotThrow(() => mspHelper.processData(handler));
+    assert.doesNotThrow(() => mspHelper.handleResponse(handler));
 
     assert.equal(FC.PIDs.length, 12, 'FC.PIDs must grow to the bank count the FC reported');
     assert.deepEqual(FC.PIDs[0], [1, 2, 3, 4], 'the first bank must still be parsed');
@@ -240,7 +240,7 @@ test('MSP2_PID positive control: a matching bank count parses unchanged', () => 
 
     let response = null;
     const handler = makeDataHandler(MSPCodes.MSP2_PID, pidPayload(11), (resp) => { response = resp; });
-    mspHelper.processData(handler);
+    mspHelper.handleResponse(handler);
 
     assert.equal(FC.PIDs.length, 11, 'a matching FC must not change the bank count');
     assert.deepEqual(FC.PIDs[10], [41, 42, 43, 44]);
@@ -258,8 +258,8 @@ test('a parser that throws must still complete the request', async () => {
     mspDeduplicationQueue.put(MSPCodes.MSP_LOOP_TIME);
 
     assert.doesNotThrow(
-        () => mspHelper.processData(handler),
-        'a failed parse must not propagate out of processData()'
+        () => mspHelper.handleResponse(handler),
+        'a failed parse must not propagate out of handleResponse()'
     );
 
     assert.notEqual(response, null, 'the waiting tab must still get its callback, or it hangs forever');

--- a/tests/msp-parse-failure-recovery.test.mjs
+++ b/tests/msp-parse-failure-recovery.test.mjs
@@ -127,6 +127,16 @@ const fcStubUrl = dataModule(`
     export default FC;
 `);
 const inertDefaultUrl = dataModule('export default {};');
+// GUI.log and i18n.getMessage are called on the parse-failure path, so these two
+// have to behave like the real thing rather than being inert.
+const guiStubUrl = dataModule(`
+    const GUI = { logged: [], log(message) { GUI.logged.push(message); } };
+    export default GUI;
+`);
+const i18nStubUrl = dataModule(`
+    const i18n = { getMessage(key) { return key; } };
+    export default i18n;
+`);
 const inertFwApproachUrl = dataModule('export const FwApproach = class {};');
 const inertGeozoneUrl = dataModule(`
     export const Geozone = class {};
@@ -137,7 +147,8 @@ const inertGeozoneUrl = dataModule(`
 const realMspHelperUrl = rewriteAndWrite('js/msp/MSPHelper.js', [
     [/^import semver from 'semver';$/m, `import semver from '${inertDefaultUrl}';`, "import semver"],
     [/^import '\.\/\.\.\/injected_methods';$/m, `import '${realInjectedMethodsUrl}';`, "import injected_methods"],
-    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${inertDefaultUrl}';`, "import GUI"],
+    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${guiStubUrl}';`, "import GUI"],
+    [/^import i18n from '\.\/\.\.\/localization';$/m, `import i18n from '${i18nStubUrl}';`, "import i18n"],
     [/^import MSP from '\.\/\.\.\/msp';$/m, `import MSP from '${realMspUrl}';`, "import MSP"],
     [/^import MSPCodes from '\.\/MSPCodes';$/m, `import MSPCodes from '${realMspCodesUrl}';`, "import MSPCodes"],
     [/^import FC from '\.\/\.\.\/fc';$/m, `import FC from '${fcStubUrl}';`, "import FC"],
@@ -163,8 +174,13 @@ const { default: MSPCodes } = await import(realMspCodesUrl);
 const { default: MSP } = await import(realMspUrl);
 const { default: mspQueue } = await import(realMspQueueUrl);
 const { default: mspDeduplicationQueue } = await import(realDedupUrl);
+const { default: CONFIGURATOR } = await import(realConfiguratorUrl);
+const { default: GUI } = await import(guiStubUrl);
 
 const FC = globalThis[FC_STATE_ID];
+
+// Wires MSP.onConfigWriteBlocked, the same call configurator_main.js makes at startup.
+mspHelper.init();
 
 /** Stand-in for the MSP decoder object processData() reads its message off. */
 function makeDataHandler(code, payloadBytes, onFinish) {
@@ -248,6 +264,12 @@ test('a parser that throws must still complete the request', async () => {
 
     assert.notEqual(response, null, 'the waiting tab must still get its callback, or it hangs forever');
     assert.equal(response.command, MSPCodes.MSP_LOOP_TIME);
+    assert.ok(
+        MSP.parseFailures.has(MSPCodes.MSP_LOOP_TIME),
+        'the failure must be recorded, or half-parsed state could still be written back'
+    );
+    MSP.parseFailures.clear();
+    assert.ok(GUI.logged.includes('mspResponseUnreadable'), 'the user must be told the values are suspect');
     assert.equal(handler.callbacks.length, 0, 'the request must be removed from the pending list');
     assert.equal(
         mspDeduplicationQueue.check(MSPCodes.MSP_LOOP_TIME),
@@ -285,4 +307,193 @@ test('a throwing processData must not leave the MSP queue hard-locked', async ()
         mspQueue.freeHardLock();
         mspQueue.setLockMethod('soft');
     }
+});
+
+// ---------------------------------------------------------------------------
+// Once a response could not be parsed, FC state is part fresh and part stale
+// with no way to tell which. Writing any of it back would push wrong values
+// into the aircraft, so every config write is refused until the next session.
+// ---------------------------------------------------------------------------
+
+/** A queue that can accept a message, with no leftover locks from earlier tests. */
+function resetQueue() {
+    CONFIGURATOR.connection = false; // keeps the real executor interval from dequeuing
+    CONFIGURATOR.cliActive = false;
+    mspQueue.flush();
+    mspDeduplicationQueue.flush();
+    mspQueue.freeHardLock();
+    mspQueue.freeSoftLock();
+    mspQueue.unlock();
+}
+
+/** Puts the session back into "everything parsed fine" state. */
+function clearParseFailures() {
+    MSP.parseFailures.clear();
+}
+
+test('every write code is classified - none falls through unnoticed', () => {
+    // A write nobody classified would be refused wholesale the moment anything
+    // else fails to parse. That is the safe direction, but it is not the intended
+    // behaviour, so adding an MSP write command must fail here until it is either
+    // paired with its read or listed as carrying no FC-read data.
+    const writeNames = Object.keys(MSPCodes).filter(name => /SET_|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
+    assert.ok(writeNames.length > 60, 'sanity: the write codes must still be recognisable by name');
+
+    clearParseFailures();
+    // With nothing broken, blockedWriteSource() reports false for everything, so
+    // probe the classification with one arbitrary failure in place instead.
+    MSP.parseFailures.add(MSPCodes.MSP_BOARD_INFO); // a read no write hands back
+
+    const unclassified = writeNames.filter(name => MSP.blockedWriteSource(MSPCodes[name]) !== false);
+
+    clearParseFailures();
+    assert.deepEqual(
+        unclassified,
+        [],
+        `these write codes are neither paired with a read nor listed as carrying no FC data: ${unclassified.join(', ')}`
+    );
+});
+
+test('a write is blocked only by the read it hands back', () => {
+    clearParseFailures();
+    MSP.parseFailures.add(MSPCodes.MSP2_PID);
+
+    assert.equal(MSP.blockedWriteSource(MSPCodes.MSP2_SET_PID), MSPCodes.MSP2_PID,
+        'the write that sends FC.PIDs back must be refused');
+
+    // Everything else on the same page, and every other page, keeps saving.
+    const stillAllowed = [
+        'MSP_SET_RC_TUNING',
+        'MSPV2_INAV_SET_RATE_PROFILE',
+        'MSPV2_SET_SETTING',
+        'MSP_SET_FEATURE',
+        'MSP2_INAV_SET_MIXER',
+        'MSP2_INAV_SET_SAFEHOME',
+        'MSP_SET_WP',
+    ];
+    for (const name of stillAllowed) {
+        assert.equal(MSP.blockedWriteSource(MSPCodes[name]), false, `${name} must keep working`);
+    }
+
+    clearParseFailures();
+});
+
+test('the pairing holds for the irregularly named writes', () => {
+    // These do not pair up by name alone (plural reads, VERTEX vs VERTICE), so a
+    // rename upstream would silently unpair them without this.
+    const pairs = [
+        ['MSP_SET_MODE_RANGE', 'MSP_MODE_RANGES'],
+        ['MSP_SET_ADJUSTMENT_RANGE', 'MSP_ADJUSTMENT_RANGES'],
+        ['MSP2_INAV_OSD_SET_LAYOUT_ITEM', 'MSP2_INAV_OSD_LAYOUTS'],
+        ['MSP2_INAV_SET_GEOZONE_VERTICE', 'MSP2_INAV_GEOZONE_VERTEX'],
+    ];
+
+    for (const [write, read] of pairs) {
+        clearParseFailures();
+        assert.notEqual(MSPCodes[read], undefined, `${read} must still exist in MSPCodes`);
+        MSP.parseFailures.add(MSPCodes[read]);
+        assert.equal(MSP.blockedWriteSource(MSPCodes[write]), MSPCodes[read], `${write} must pair with ${read}`);
+    }
+
+    clearParseFailures();
+});
+
+test('reads, reboot and live commands are never blocked', () => {
+    clearParseFailures();
+    // Every read this Configurator makes, at once - the worst case.
+    for (const name of Object.keys(MSPCodes)) {
+        MSP.parseFailures.add(MSPCodes[name]);
+    }
+
+    const neverBlocked = [
+        'MSP_STATUS',
+        'MSP2_PID',
+        'MSP_RC_TUNING',
+        'MSP_FC_VERSION',
+        // Stores nothing, and is how the user gets the FC back to a known-good state.
+        'MSP_SET_REBOOT',
+        // stopMotors() stops a running motor test with this - refusing it would
+        // strand the motors spinning.
+        'MSP_SET_MOTOR',
+        'MSP_SET_RAW_RC',
+        // Persists what is already on the FC; a refused write never got there.
+        'MSP_EEPROM_WRITE',
+    ];
+    for (const name of neverBlocked) {
+        assert.notEqual(MSPCodes[name], undefined, `${name} must still exist in MSPCodes`);
+        assert.equal(MSP.blockedWriteSource(MSPCodes[name]), false, `${name} must never be blocked`);
+    }
+
+    // The other half of the guarantee: with every read broken, every write that
+    // does carry FC-read data must be refused. Together with the "none falls
+    // through unnoticed" test above this pins both directions - an empty pairing
+    // map would pass one of them but never both.
+    const writeNames = Object.keys(MSPCodes).filter(name => /SET_|WRITE|SAVE|ERASE|RESET_|SELECT_/.test(name));
+    const blocked = writeNames.filter(name => MSP.blockedWriteSource(MSPCodes[name]) !== false);
+    assert.ok(blocked.length > 50, `expected the bulk of writes to be refused, got ${blocked.length}`);
+    assert.ok(blocked.includes('MSP2_SET_PID'));
+    assert.ok(blocked.includes('MSPV2_SET_SETTING'));
+    assert.ok(!blocked.includes('MSP_EEPROM_WRITE'));
+
+    clearParseFailures();
+});
+
+test('positive control: writes go out normally while parsing is healthy', () => {
+    resetQueue();
+    clearParseFailures();
+
+    const sent = MSP.send_message(MSPCodes.MSP2_SET_PID, [1, 2, 3, 4], false, () => {});
+
+    assert.equal(sent, true);
+    assert.equal(mspQueue.getLength(), 1, 'a healthy session must still queue its writes');
+});
+
+test('a blocked write reaches neither the wire nor a silent dead end', () => {
+    resetQueue();
+    clearParseFailures();
+    MSP.parseFailures.add(MSPCodes.MSP2_PID);
+    GUI.logged.length = 0;
+
+    let result = 'not called';
+    const sent = MSP.send_message(MSPCodes.MSP2_SET_PID, [1, 2, 3, 4], false, (r) => { result = r; });
+
+    assert.equal(sent, false, 'send_message must report the refusal');
+    assert.equal(mspQueue.getLength(), 0, 'nothing may be queued for the FC');
+    assert.equal(result, false, 'the caller must be told, or its save chain hangs like the original bug');
+    assert.ok(
+        GUI.logged.includes('mspWriteBlockedAfterParseFailure'),
+        'a silent refusal is worse than none - the user would believe the settings were saved'
+    );
+
+    clearParseFailures();
+});
+
+test('an unrelated page keeps saving after another page failed to load', () => {
+    resetQueue();
+    clearParseFailures();
+    MSP.parseFailures.add(MSPCodes.MSP2_PID);
+
+    assert.equal(MSP.send_message(MSPCodes.MSP_STATUS, false, false, () => {}), true, 'reads must keep working');
+    assert.equal(MSP.send_message(MSPCodes.MSP_SET_FEATURE, [1], false, () => {}), true, 'other settings must keep saving');
+    assert.equal(MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, () => {}), true, 'the save must still be committable');
+    assert.equal(mspQueue.getLength(), 3);
+
+    clearParseFailures();
+});
+
+test('reconnecting clears the block', () => {
+    resetQueue();
+    clearParseFailures();
+    MSP.parseFailures.add(MSPCodes.MSP2_PID);
+
+    // What serial_backend.js does at the start of every session, right after
+    // FC.resetState() - everything gets re-read from the FC from scratch.
+    MSP.disconnect_cleanup();
+    assert.equal(MSP.parseFailures.size, 0);
+
+    resetQueue();
+    assert.equal(MSP.send_message(MSPCodes.MSP2_SET_PID, [1, 2, 3, 4], false, () => {}), true);
+    assert.equal(mspQueue.getLength(), 1, 'writes must work again after a reconnect');
+
+    resetQueue();
 });

--- a/tests/msp-parse-failure-recovery.test.mjs
+++ b/tests/msp-parse-failure-recovery.test.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for a single unparseable MSP response locking up the GUI.
+ *
+ * Bug: MSPHelper's processData() is one big switch over the MSP code, and the
+ * code that *completes* the request - clearing the response timeout, removing
+ * the code from the deduplication queue, recording the round-trip and firing
+ * the registered onFinish callback - sat after that switch in the same
+ * function. Any parser case that threw skipped all of it, so:
+ *   - the tab waiting on that response never got its callback and never
+ *     finished loading, leaving the GUI stuck mid tab-switch (no tab changes,
+ *     only a disconnect gets you out),
+ *   - the request timed out and kept retrying,
+ *   - the MSP code stayed flagged in-flight, so retries were rejected as
+ *     duplicates,
+ *   - and back in msp.js the queue's hard lock was never released either,
+ *     because that also sat after the processData() call.
+ *
+ * Hit in practice with an FC built from a branch whose PID_ITEM_COUNT had
+ * grown by one: MSP2_PID walked one bank past FC.PIDs (fixed at 11 entries in
+ * serial_backend.js) and threw "Cannot set properties of undefined".
+ *
+ * Fix under test:
+ *   - MSP2_PID grows FC.PIDs to the bank count the FC actually reports
+ *   - processData() wraps the parse and completes the request regardless
+ *   - msp.js releases the hard lock in a finally
+ *
+ * The tests execute the REAL production files. This codebase uses Vite-style
+ * extensionless relative imports which plain Node's ESM resolver refuses to
+ * load, so - like tests/cli-tab-msp-polling.test.mjs - the sources are read
+ * fresh off disk and only their *import specifiers* are rewritten. Everything
+ * the code under test actually touches (MSPCodes, the MSP queue, the
+ * deduplication queue, statistics) stays wired to the real modules; the
+ * remaining imports, which no executed path reaches, become inert stubs. No
+ * statement, expression or ordering in the code under test is touched.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'msp-parse-failure-'));
+process.on('exit', () => rmSync(tmpDir, { recursive: true, force: true }));
+
+function dataModule(code) {
+    // encodeURIComponent leaves ' ( ) ! * unescaped; the generated specifiers are
+    // embedded in single-quoted string literals, so escape those too.
+    const encoded = encodeURIComponent(code).replace(/['()!*]/g, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+    return 'data:text/javascript,' + encoded;
+}
+
+function realModuleUrl(relPath) {
+    return pathToFileURL(join(repoRoot, relPath)).href;
+}
+
+/**
+ * Rewrite the listed import specifiers in a real source file and write the
+ * result to a temp module. Throws loudly if a pattern stops matching, so a
+ * future reshuffle of those imports fails the test instead of passing
+ * vacuously.
+ */
+function rewriteAndWrite(relSrcPath, rules, outName) {
+    let source = readFileSync(join(repoRoot, relSrcPath), 'utf8');
+    for (const [regex, replacement, label] of rules) {
+        if (!regex.test(source)) {
+            throw new Error(
+                `msp-parse-failure-recovery.test.mjs: expected to find and replace "${label}" in ${relSrcPath} ` +
+                `but the pattern ${regex} did not match. Update the test's substitution rules.`
+            );
+        }
+        source = source.replace(regex, replacement);
+    }
+    const outPath = join(tmpDir, outName);
+    writeFileSync(outPath, source, 'utf8');
+    return pathToFileURL(outPath).href;
+}
+
+// --- real, import-free leaf modules, loadable straight by absolute URL -------
+const realMspCodesUrl = realModuleUrl('js/msp/MSPCodes.js');
+const realTimeoutsUrl = realModuleUrl('js/timeouts.js');
+const realConfiguratorUrl = realModuleUrl('js/data_storage.js');
+const realDedupUrl = realModuleUrl('js/msp/mspDeduplicationQueue.js');
+const realStatisticsUrl = realModuleUrl('js/msp/mspStatistics.js');
+const realSmoothFilterUrl = realModuleUrl('js/simple_smooth_filter.js');
+const realInjectedMethodsUrl = realModuleUrl('js/injected_methods.js');
+
+// eventFrequencyAnalyzer and serial_queue start un-refed intervals in their
+// IIFEs. `.unref()` changes nothing about whether or how they run - it only
+// stops Node from waiting on them to decide when the process may exit, which
+// would otherwise hang `node --test` forever.
+const realEventFrequencyAnalyzerUrl = rewriteAndWrite('js/eventFrequencyAnalyzer.js', [
+    [/privateScope\.intervalHandler = setInterval\(publicScope\.analyze, bufferPeriod\);/g, 'privateScope.intervalHandler = setInterval(publicScope.analyze, bufferPeriod).unref();', "analyze setInterval"],
+], 'eventFrequencyAnalyzer-generated.mjs');
+
+const realMspQueueUrl = rewriteAndWrite('js/serial_queue.js', [
+    [/^import CONFIGURATOR from '\.\/data_storage';$/m, `import CONFIGURATOR from '${realConfiguratorUrl}';`, "import CONFIGURATOR"],
+    [/^import MSPCodes from '\.\/msp\/MSPCodes';$/m, `import MSPCodes from '${realMspCodesUrl}';`, "import MSPCodes"],
+    [/^import SimpleSmoothFilter from '\.\/simple_smooth_filter';$/m, `import SimpleSmoothFilter from '${realSmoothFilterUrl}';`, "import SimpleSmoothFilter"],
+    [/^import eventFrequencyAnalyzer from '\.\/eventFrequencyAnalyzer';$/m, `import eventFrequencyAnalyzer from '${realEventFrequencyAnalyzerUrl}';`, "import eventFrequencyAnalyzer"],
+    [/^import mspDeduplicationQueue from '\.\/msp\/mspDeduplicationQueue';$/m, `import mspDeduplicationQueue from '${realDedupUrl}';`, "import mspDeduplicationQueue"],
+    [/setInterval\(publicScope\.executor, Math\.round\(1000 \/ privateScope\.handlerFrequency\)\);/, 'setInterval(publicScope.executor, Math.round(1000 / privateScope.handlerFrequency)).unref();', "executor setInterval"],
+    [/setInterval\(publicScope\.balancer, Math\.round\(1000 \/ privateScope\.balancerFrequency\)\);/, 'setInterval(publicScope.balancer, Math.round(1000 / privateScope.balancerFrequency)).unref();', "balancer setInterval"],
+], 'serial_queue-generated.mjs');
+
+const realMspUrl = rewriteAndWrite('js/msp.js', [
+    [/^import MSPCodes from '\.\/msp\/MSPCodes';$/m, `import MSPCodes from '${realMspCodesUrl}';`, "import MSPCodes"],
+    [/^import mspQueue from '\.\/serial_queue';$/m, `import mspQueue from '${realMspQueueUrl}';`, "import mspQueue"],
+    [/^import eventFrequencyAnalyzer from '\.\/eventFrequencyAnalyzer';$/m, `import eventFrequencyAnalyzer from '${realEventFrequencyAnalyzerUrl}';`, "import eventFrequencyAnalyzer"],
+    [/^import timeout from '\.\/timeouts';$/m, `import timeout from '${realTimeoutsUrl}';`, "import timeout"],
+    [/^import CONFIGURATOR from '\.\/data_storage';$/m, `import CONFIGURATOR from '${realConfiguratorUrl}';`, "import CONFIGURATOR"],
+], 'msp-generated.mjs');
+
+// FC has to be controllable (the tests set up PID banks); everything below it
+// is only referenced from switch cases these tests never reach, so those
+// imports just have to resolve.
+const FC_STATE_ID = '__mspParseFailureFcState';
+globalThis[FC_STATE_ID] = { PIDs: [], FC_CONFIG: undefined };
+
+const fcStubUrl = dataModule(`
+    const FC = globalThis['${FC_STATE_ID}'];
+    export default FC;
+`);
+const inertDefaultUrl = dataModule('export default {};');
+const inertFwApproachUrl = dataModule('export const FwApproach = class {};');
+const inertGeozoneUrl = dataModule(`
+    export const Geozone = class {};
+    export const GeozoneVertex = class {};
+    export const GeozoneShapes = {};
+`);
+
+const realMspHelperUrl = rewriteAndWrite('js/msp/MSPHelper.js', [
+    [/^import semver from 'semver';$/m, `import semver from '${inertDefaultUrl}';`, "import semver"],
+    [/^import '\.\/\.\.\/injected_methods';$/m, `import '${realInjectedMethodsUrl}';`, "import injected_methods"],
+    [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${inertDefaultUrl}';`, "import GUI"],
+    [/^import MSP from '\.\/\.\.\/msp';$/m, `import MSP from '${realMspUrl}';`, "import MSP"],
+    [/^import MSPCodes from '\.\/MSPCodes';$/m, `import MSPCodes from '${realMspCodesUrl}';`, "import MSPCodes"],
+    [/^import FC from '\.\/\.\.\/fc';$/m, `import FC from '${fcStubUrl}';`, "import FC"],
+    [/^import VTX from '\.\/\.\.\/vtx';$/m, `import VTX from '${inertDefaultUrl}';`, "import VTX"],
+    [/^import mspQueue from '\.\/\.\.\/serial_queue';$/m, `import mspQueue from '${realMspQueueUrl}';`, "import mspQueue"],
+    [/^import ServoMixRule from '\.\/\.\.\/servoMixRule';$/m, `import ServoMixRule from '${inertDefaultUrl}';`, "import ServoMixRule"],
+    [/^import MotorMixRule from '\.\/\.\.\/motorMixRule';$/m, `import MotorMixRule from '${inertDefaultUrl}';`, "import MotorMixRule"],
+    [/^import LogicCondition from '\.\/\.\.\/logicCondition';$/m, `import LogicCondition from '${inertDefaultUrl}';`, "import LogicCondition"],
+    [/^import BitHelper from '\.\.\/bitHelper';$/m, `import BitHelper from '${inertDefaultUrl}';`, "import BitHelper"],
+    [/^import serialPortHelper from '\.\/\.\.\/serialPortHelper';$/m, `import serialPortHelper from '${inertDefaultUrl}';`, "import serialPortHelper"],
+    [/^import ProgrammingPid from '\.\/\.\.\/programmingPid';$/m, `import ProgrammingPid from '${inertDefaultUrl}';`, "import ProgrammingPid"],
+    [/^import Safehome from '\.\/\.\.\/safehome';$/m, `import Safehome from '${inertDefaultUrl}';`, "import Safehome"],
+    [/^import \{ FwApproach \} from '\.\/\.\.\/fwApproach';$/m, `import { FwApproach } from '${inertFwApproachUrl}';`, "import FwApproach"],
+    [/^import Waypoint from '\.\/\.\.\/waypoint';$/m, `import Waypoint from '${inertDefaultUrl}';`, "import Waypoint"],
+    [/^import mspDeduplicationQueue from '\.\/mspDeduplicationQueue';$/m, `import mspDeduplicationQueue from '${realDedupUrl}';`, "import mspDeduplicationQueue"],
+    [/^import mspStatistics from '\.\/mspStatistics';$/m, `import mspStatistics from '${realStatisticsUrl}';`, "import mspStatistics"],
+    [/^import settingsCache from '\.\/\.\.\/settingsCache';$/m, `import settingsCache from '${inertDefaultUrl}';`, "import settingsCache"],
+    [/^import \{Geozone, GeozoneVertex, GeozoneShapes \} from '\.\/\.\.\/geozone';$/m, `import { Geozone, GeozoneVertex, GeozoneShapes } from '${inertGeozoneUrl}';`, "import Geozone"],
+], 'MSPHelper-generated.mjs');
+
+const { default: mspHelper } = await import(realMspHelperUrl);
+const { default: MSPCodes } = await import(realMspCodesUrl);
+const { default: MSP } = await import(realMspUrl);
+const { default: mspQueue } = await import(realMspQueueUrl);
+const { default: mspDeduplicationQueue } = await import(realDedupUrl);
+
+const FC = globalThis[FC_STATE_ID];
+
+/** Stand-in for the MSP decoder object processData() reads its message off. */
+function makeDataHandler(code, payloadBytes, onFinish) {
+    const buffer = new Uint8Array(payloadBytes).buffer;
+    const entry = {
+        code,
+        onFinish,
+        createdOn: Date.now(),
+        sentOn: Date.now(),
+        timerFired: false,
+    };
+    entry.timer = setTimeout(() => { entry.timerFired = true; }, 25);
+
+    return {
+        code,
+        unsupported: false,
+        message_buffer: buffer,
+        message_length_expected: payloadBytes.length,
+        callbacks: [entry],
+        entry,
+    };
+}
+
+function elevenEmptyBanks() {
+    return Array.from({ length: 11 }, () => new Array(4));
+}
+
+/** message_length_expected / 4 banks of ascending, distinguishable bytes. */
+function pidPayload(bankCount) {
+    const bytes = [];
+    for (let bank = 0; bank < bankCount; bank++) {
+        bytes.push(bank * 4 + 1, bank * 4 + 2, bank * 4 + 3, bank * 4 + 4);
+    }
+    return bytes;
+}
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+test('MSP2_PID: an FC reporting more banks than we know must not throw', () => {
+    FC.PIDs = elevenEmptyBanks();
+
+    let response = null;
+    // 12 banks: PID_ITEM_COUNT grew by one (PID_AUTO_SPEED) while
+    // serial_backend.js still pre-sizes FC.PIDs to 11.
+    const handler = makeDataHandler(MSPCodes.MSP2_PID, pidPayload(12), (resp) => { response = resp; });
+
+    assert.doesNotThrow(() => mspHelper.processData(handler));
+
+    assert.equal(FC.PIDs.length, 12, 'FC.PIDs must grow to the bank count the FC reported');
+    assert.deepEqual(FC.PIDs[0], [1, 2, 3, 4], 'the first bank must still be parsed');
+    assert.deepEqual(FC.PIDs[11], [45, 46, 47, 48], 'the extra bank must be kept, not dropped');
+    assert.notEqual(response, null, 'the request must complete');
+});
+
+test('MSP2_PID positive control: a matching bank count parses unchanged', () => {
+    FC.PIDs = elevenEmptyBanks();
+
+    let response = null;
+    const handler = makeDataHandler(MSPCodes.MSP2_PID, pidPayload(11), (resp) => { response = resp; });
+    mspHelper.processData(handler);
+
+    assert.equal(FC.PIDs.length, 11, 'a matching FC must not change the bank count');
+    assert.deepEqual(FC.PIDs[10], [41, 42, 43, 44]);
+    assert.notEqual(response, null);
+});
+
+test('a parser that throws must still complete the request', async () => {
+    // MSP_LOOP_TIME's case does data.getInt16(0) and writes into FC.FC_CONFIG.
+    // With an empty payload from a mismatched FC that throws mid-parse - which
+    // is the shape of every "FC and Configurator disagree about a payload" bug.
+    FC.FC_CONFIG = undefined;
+
+    let response = null;
+    const handler = makeDataHandler(MSPCodes.MSP_LOOP_TIME, [], (resp) => { response = resp; });
+    mspDeduplicationQueue.put(MSPCodes.MSP_LOOP_TIME);
+
+    assert.doesNotThrow(
+        () => mspHelper.processData(handler),
+        'a failed parse must not propagate out of processData()'
+    );
+
+    assert.notEqual(response, null, 'the waiting tab must still get its callback, or it hangs forever');
+    assert.equal(response.command, MSPCodes.MSP_LOOP_TIME);
+    assert.equal(handler.callbacks.length, 0, 'the request must be removed from the pending list');
+    assert.equal(
+        mspDeduplicationQueue.check(MSPCodes.MSP_LOOP_TIME),
+        false,
+        'the code must be released, or every retry is rejected as a duplicate'
+    );
+
+    await wait(60);
+    assert.equal(handler.entry.timerFired, false, 'the response timeout must have been cleared');
+});
+
+test('a throwing processData must not leave the MSP queue hard-locked', async () => {
+    const originalProcessData = MSP.processData;
+    mspQueue.setLockMethod('hard');
+    mspQueue.setHardLock();
+    assert.equal(mspQueue.isLocked(), true, 'sanity: the queue starts locked');
+
+    MSP.setProcessData(() => { throw new Error('parser blew up'); });
+    MSP.message_checksum = 7;
+    MSP.message_length_received = 12;
+    MSP.state = MSP.decoder_states.PAYLOAD_V2;
+
+    try {
+        // The exception itself is expected to propagate - the connection's receive
+        // dispatch catches it. What must not happen is the cleanup being skipped.
+        assert.throws(() => MSP._dispatch_message(7), /parser blew up/);
+
+        assert.equal(MSP.state, MSP.decoder_states.IDLE, 'the decoder state must be reset');
+        assert.equal(MSP.message_length_received, 0);
+
+        await wait(60); // the hard lock is released on a 10ms timeout
+        assert.equal(mspQueue.isLocked(), false, 'the hard lock must be released even when the parser throws');
+    } finally {
+        MSP.setProcessData(originalProcessData);
+        mspQueue.freeHardLock();
+        mspQueue.setLockMethod('soft');
+    }
+});


### PR DESCRIPTION
## Summary

Carries `maintenance-9.x` forward into `maintenance-10.x`, following the merge-release-into-next-version procedure (branched off `maintenance-10.x`, merged `maintenance-9.x` in, resolved here - `maintenance-9.x` itself is untouched). This picks up PR #2716 (flasher/MSP-parse-failure lockup fixes) and closes PR #2731.

## Conflicts resolved

One conflict, in `js/msp.js`'s `disconnect_cleanup()`: both branches had independently added their own reset lines to the same method (9.x: `parseFailures.clear()`; 10.x: `last_received_timestamp`/`analog_last_received_timestamp`/`lastFrameReceivedMs`). Combined both - not an either/or, both belong.

All other conflicts auto-merged cleanly. Verified no dropped lines by diffing the resolved files against each parent branch individually (`git diff <parent> -- <file> | grep "^-[^-]"`).

### Re-sync (2026-09-04)

`maintenance-10.x` picked up 9 more commits after this PR was opened, including #2733 (`hasConnectionId()` - treats `0` as a legitimate connection id, only `null`/`false` mean "no connection"). Re-merged `upstream/maintenance-10.x` into this branch to pick those up.

Conflicts in `js/connection/connectionSerial.js`, `connectionTcp.js`, `connectionUdp.js`: this branch's `completeClose()`/`completeSend()` helper refactor and #2733's `if (this._connectionId)` -> `if (this.hasConnectionId())` fix both touched the same guard lines. Resolved by keeping the helper refactor and swapping in `hasConnectionId()`, e.g. `this.completeClose('serial', this.hasConnectionId() ? window.electronAPI.serialClose() : null, callback)`. Verified against both parents - no dropped lines either direction.

Also fixed `tests/connection-send-queue.test.mjs`: one test simulated "port disappeared mid-session" via `_connectionId = 0`, which the new `hasConnectionId()` semantics now treat as a valid connected id. Changed to `false`, matching the actual "disconnected" sentinel used elsewhere in `connection.js` (and every other test in that file).

## Testing

- Syntax-checked every modified JS file.
- Validated merged locale JSON files parse.
- `yarn test`: 109/111 pass. The 2 failures (`periodicStatusUpdater.run()` and `MSP._enqueue retry` positive controls in `tests/cli-tab-msp-polling.test.mjs`) are pre-existing on `maintenance-10.x` alone (confirmed via an isolated worktree run before merging) - unrelated to this merge.
- One test fix included as a separate commit on top of the original merge (not folded into it): `tests/msp-parse-failure-recovery.test.mjs` (added by #2716 against 9.x) didn't know about an import `maintenance-10.x` had since added to `MSPHelper.js` (`parseDronecanAsyncRequestResponse`), so it errored on `ERR_MODULE_NOT_FOUND` instead of running. Added an inert stub for it, matching the test's existing pattern for other out-of-scope dependencies - it isn't on the MSP2_PID path this test exercises.

## Code Review

`inav-code-review` run against the re-sync's diff (connection-guard conflict resolution + test fix): APPROVE, no issues found. The original merge's own resolution (the `disconnect_cleanup()` combination) has not separately been through this agent - it's a straightforward line-level combination, no new logic beyond it.

## Known open items (not addressed in this PR - flagging, not fixing, to keep this PR's scope to conflict resolution)

- **SonarCloud quality gate: 8.5% duplication on new code** (threshold 3%). This is from the 4 test files `tests/connection-receive-listener-isolation.test.mjs`, `tests/connection-send-queue.test.mjs`, `tests/msp-parse-failure-recovery.test.mjs`, `tests/firmware-flasher.test.mjs` becoming "new code" to `maintenance-10.x` for the first time via this merge (they already exist on `maintenance-9.x`). Not introduced by this PR's own conflict resolution.
- **Qodo bot flagged a real bug in `js/msp.js`**: `MSP.promise()` (line 525) calls `send_message()` and ignores its boolean return value; `send_message()` returns `false` without invoking its callback when `refuseBlockedWrite()` refuses a write (line 406-407), so the promise never resolves. Confirmed this is pre-existing on `maintenance-9.x` itself (from #2716's `cea5852c8c`), not something this merge introduced - out of scope for a conflict-resolution PR to fix.
