### PR TITLE
fix(connection): guard against a legitimately-zero connectionId

### DIFF
--- a/js/connection/connection.js
+++ b/js/connection/connection.js
@@ -129,8 +129,14 @@ class Connection {
         throw new TypeError("Abstract method");
     }
 
+    // _connectionId can legitimately be 0 (e.g. ConnectionExt's SITL WASM port),
+    // so callers must not test it for truthiness - only null/false mean "not connected".
+    hasConnectionId() {
+        return this._connectionId !== null && this._connectionId !== false;
+    }
+
     disconnect(callback) {
-        if (this._connectionId !== null && this._connectionId !== false) {
+        if (this.hasConnectionId()) {
             this.emptyOutputBuffer();
             this.removeAllListeners();
 

--- a/js/connection/connectionSerial.js
+++ b/js/connection/connectionSerial.js
@@ -97,8 +97,8 @@ class ConnectionSerial extends Connection {
         });
     }
 
-    disconnectImplementation(callback) {   
-        if (this._connectionId) {
+    disconnectImplementation(callback) {
+        if (this.hasConnectionId()) {
             window.electronAPI.serialClose().then(response => {
                 var ok = true;
                 if (response.error) {
@@ -112,8 +112,8 @@ class ConnectionSerial extends Connection {
         }  
     }
 
-    sendImplementation(data, callback) {        
-        if (this._connectionId) {
+    sendImplementation(data, callback) {
+        if (this.hasConnectionId()) {
             window.electronAPI.serialSend(data).then(response => {
                 var result = 0;
                 var sent = response.bytesWritten;

--- a/js/connection/connectionTcp.js
+++ b/js/connection/connectionTcp.js
@@ -97,8 +97,8 @@ class ConnectionTcp extends Connection {
     }
 
     disconnectImplementation(callback) {
-        
-        if (this._connectionId) {
+
+        if (this.hasConnectionId()) {
             window.electronAPI.tcpClose();
         }
 
@@ -110,8 +110,8 @@ class ConnectionTcp extends Connection {
        }
     }
 
-   sendImplementation(data, callback) {     
-        if (this._connectionId) {
+   sendImplementation(data, callback) {
+        if (this.hasConnectionId()) {
             window.electronAPI.tcpSend(data).then(response => {
                 var result = 0;
                 var sent = response.bytesWritten;

--- a/js/connection/connectionUdp.js
+++ b/js/connection/connectionUdp.js
@@ -90,7 +90,7 @@ class ConnectionUdp extends Connection {
     }
 
     disconnectImplementation(callback) {
-        if (this._connectionId) {
+        if (this.hasConnectionId()) {
             window.electronAPI.udpClose().then(response => {
                 var ok = true;
                 if (response.error) {
@@ -104,8 +104,8 @@ class ConnectionUdp extends Connection {
         }  
     }
 
-   sendImplementation(data, callback) {    
-        if (this._connectionId) {
+   sendImplementation(data, callback) {
+        if (this.hasConnectionId()) {
             window.electronAPI.udpSend(data).then(response => {
                 var result = 0;
                 var sent = response.bytesWritten;


### PR DESCRIPTION
## Summary

`disconnect()` and every transport's `disconnectImplementation()`/`sendImplementation()` gate on `if (this._connectionId)`, silently no-oping for a legitimate id of `0`, not just "no connection." `connection.js`'s `disconnect()` already special-cases `null`/`0`/`false` for this reason - `connectionExt.js`'s WASM SITL port legitimately uses id `0`. The three transports never followed suit.

Adds a shared `hasConnectionId()` helper and uses it everywhere instead of a truthiness check. No behavior change where ids never reach 0.

## Testing

- Syntax-checked all six touched call sites.
- `yarn test`: 75/77 pass; the 2 failures are pre-existing on `maintenance-10.x` without this change (confirmed via isolated worktree).
- No hardware test with a live 0-valued id - serial/TCP/UDP can't currently produce one, so this is a defensive fix, not a repro.