### PR TITLE
Fix AUX_CONFIG/AUX_CONFIG_IDS desync when FC reports an unrecognized mode id

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -203,11 +203,17 @@ var FC = {
 
         this.generateAuxConfig = function () {
             console.log('Generating AUX_CONFIG');
+            // AUX_CONFIG and AUX_CONFIG_IDS must stay the same length and index-aligned —
+            // tabs/auxiliary.js pairs them by position, so an unrecognized id must be
+            // dropped from both, not just from the name list.
+            const ids = this.AUX_CONFIG_IDS;
             this.AUX_CONFIG = [];
-            for ( let i = 0; i < this.AUX_CONFIG_IDS.length; i++ ) {
-                let found = FLIGHT_MODES.find( mode => mode.permanentId === this.AUX_CONFIG_IDS[i] );
+            this.AUX_CONFIG_IDS = [];
+            for ( let i = 0; i < ids.length; i++ ) {
+                let found = FLIGHT_MODES.find( mode => mode.permanentId === ids[i] );
                 if (found) {
                     this.AUX_CONFIG.push(found.boxName);
+                    this.AUX_CONFIG_IDS.push(ids[i]);
                 }
             }
         };

--- a/tabs/auxiliary.js
+++ b/tabs/auxiliary.js
@@ -305,6 +305,15 @@ auxiliaryTab.initialize = function (callback) {
             // we must send this many back to the FC - overwrite all of the old ones to be sure.
             var requiredModesRangeCount = FC.MODE_RANGES.length;
 
+            // Modes this configurator build doesn't recognize (e.g. added by a newer
+            // firmware than this local FLIGHT_MODES table knows about) get no row in
+            // the UI at all - preserve their existing assignments as-is instead of
+            // letting the rebuild below silently disable them.
+            var recognizedIds = new Set(LOCAL_AUX_CONFIG_IDS);
+            var unrecognizedRanges = FC.MODE_RANGES.filter(function (modeRange) {
+                return !recognizedIds.has(modeRange.id);
+            });
+
             FC.MODE_RANGES = [];
 
             var uniqueModes = [];
@@ -329,6 +338,10 @@ auxiliaryTab.initialize = function (callback) {
                     FC.MODE_RANGES.push(modeRange);
                 });
             });
+
+            for (var preservedIndex = 0; preservedIndex < unrecognizedRanges.length && FC.MODE_RANGES.length < requiredModesRangeCount; preservedIndex++) {
+                FC.MODE_RANGES.push(unrecognizedRanges[preservedIndex]);
+            }
 
             for (var modeRangeIndex = FC.MODE_RANGES.length; modeRangeIndex < requiredModesRangeCount; modeRangeIndex++) {
                 var defaultModeRange = {

--- a/tests/auxiliary-preserve-unrecognized-mode-ranges.test.mjs
+++ b/tests/auxiliary-preserve-unrecognized-mode-ranges.test.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for the "preserve unrecognized mode ranges on save"
+ * fix in tabs/auxiliary.js's `a.save` click handler.
+ *
+ * Background: FC.generateAuxConfig() (see tests/fc-generate-aux-config.test.mjs)
+ * already filters LOCAL_AUX_CONFIG/LOCAL_AUX_CONFIG_IDS down to only the
+ * permanentIds this configurator build's local FLIGHT_MODES table
+ * recognizes. process_html() only renders a UI row per entry in
+ * LOCAL_AUX_CONFIG - so any FC.MODE_RANGES slot whose `.id` is NOT
+ * recognized locally (e.g. a mode added by newer firmware than this
+ * configurator build knows about) gets no row at all.
+ *
+ * Before this fix, the save handler unconditionally discarded the OLD
+ * FC.MODE_RANGES array and rebuilt it purely from whatever rows exist in
+ * the DOM, padding the rest with disabled placeholders
+ * ({ id: 0, range: 900-900 }). Since unrecognized-id slots never had a
+ * row, this silently deleted the user's existing switch assignment to
+ * that mode on every save - a safety-relevant data-loss bug (see also
+ * PR discussion / Qodo review comment referenced in the task for this
+ * branch).
+ *
+ * Fix under test: before wiping FC.MODE_RANGES, the handler now captures
+ * the OLD entries whose `.id` is not in the recognized-id set
+ * (`unrecognizedRanges`), and - after rebuilding from the DOM rows as
+ * before - pushes them back in (bounded by the FC's fixed slot budget)
+ * before padding the remainder with placeholders.
+ *
+ * This file does NOT drive real jQuery/noUiSlider/DOM (this repo has no
+ * jsdom dependency - see tests/magnetometer-slider.test.mjs for the
+ * established pattern of testing this kind of jQuery-tab logic by
+ * re-deriving it as a pure computation rather than simulating the DOM).
+ * Instead, `computeFinalModeRanges()` below is a line-for-line mirror of
+ * the new logic added in tabs/auxiliary.js (compare against
+ * `git diff tabs/auxiliary.js`, lines ~306-356): same variable names,
+ * same loop bounds, same order of operations. The one abstraction is
+ * that the real code's jQuery `.each()` walk over rendered DOM rows
+ * (which only ever produces entries for recognized ids, by construction
+ * of process_html()) is replaced here with a plain array parameter,
+ * `domRebuiltRanges`, supplied directly by each test case.
+ *
+ * If tabs/auxiliary.js's save handler logic changes, this mirror must be
+ * updated to match, or this test stops being meaningful.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * Mirrors tabs/auxiliary.js `$('a.save').on('click', ...)` array-management
+ * logic (the part downstream of reading DOM state into `domRebuiltRanges`).
+ *
+ * @param {Array<{id:number, auxChannelIndex:number, range:{start:number,end:number}}>} oldModeRanges
+ *   FC.MODE_RANGES as it stood BEFORE the save handler wipes it (i.e. as last
+ *   loaded from the FC via MSP_MODE_RANGES - always exactly
+ *   `requiredModesRangeCount` long, the FC's fixed slot budget).
+ * @param {number[]} recognizedIdsList
+ *   LOCAL_AUX_CONFIG_IDS at save time (permanentIds this configurator build's
+ *   FLIGHT_MODES table recognizes).
+ * @param {Array<{id:number, auxChannelIndex:number, range:{start:number,end:number}}>} domRebuiltRanges
+ *   Stand-in for what the real code's `$('.tab-auxiliary .modes .mode').each(...)`
+ *   walk produces: one entry per rendered range row, in DOM order. By
+ *   construction in the real code, every `.id` here is a member of
+ *   recognizedIdsList, because process_html() only creates rows for
+ *   recognized ids.
+ * @returns {Array} the final MODE_RANGES array that would be sent to the FC.
+ */
+function computeFinalModeRanges(oldModeRanges, recognizedIdsList, domRebuiltRanges) {
+    // we must send this many back to the FC - overwrite all of the old ones to be sure.
+    var requiredModesRangeCount = oldModeRanges.length;
+
+    // Modes this configurator build doesn't recognize (e.g. added by a newer
+    // firmware than this local FLIGHT_MODES table knows about) get no row in
+    // the UI at all - preserve their existing assignments as-is instead of
+    // letting the rebuild below silently disable them.
+    var recognizedIds = new Set(recognizedIdsList);
+    var unrecognizedRanges = oldModeRanges.filter(function (modeRange) {
+        return !recognizedIds.has(modeRange.id);
+    });
+
+    var MODE_RANGES = [];
+
+    // Stand-in for the real code's DOM `.each()` walk - pushes exactly what
+    // the caller says the rendered rows would produce, in the same order.
+    domRebuiltRanges.forEach(function (modeRange) {
+        MODE_RANGES.push(modeRange);
+    });
+
+    for (var preservedIndex = 0; preservedIndex < unrecognizedRanges.length && MODE_RANGES.length < requiredModesRangeCount; preservedIndex++) {
+        MODE_RANGES.push(unrecognizedRanges[preservedIndex]);
+    }
+
+    for (var modeRangeIndex = MODE_RANGES.length; modeRangeIndex < requiredModesRangeCount; modeRangeIndex++) {
+        var defaultModeRange = {
+            id: 0,
+            auxChannelIndex: 0,
+            range: {
+                start: 900,
+                end: 900
+            }
+        };
+        MODE_RANGES.push(defaultModeRange);
+    }
+
+    return MODE_RANGES;
+}
+
+function placeholder() {
+    return { id: 0, auxChannelIndex: 0, range: { start: 900, end: 900 } };
+}
+
+test('normal save (all ids recognized): behavior is unchanged from before the fix', () => {
+    // ARM (id 0) is always recognized. Old FC.MODE_RANGES: one real ARM
+    // assignment on channel 0, plus 3 padding placeholders (a 4-slot budget).
+    const oldModeRanges = [
+        { id: 0, auxChannelIndex: 0, range: { start: 1700, end: 2100 } },
+        placeholder(),
+        placeholder(),
+        placeholder(),
+    ];
+    const recognizedIds = [0, 1, 2, 3]; // ARM, ANGLE, HORIZON, NAV ALTHOLD
+
+    // User didn't change anything - DOM rebuild reproduces the same single
+    // ARM row unchanged.
+    const domRebuiltRanges = [
+        { id: 0, auxChannelIndex: 0, range: { start: 1700, end: 2100 } },
+    ];
+
+    const result = computeFinalModeRanges(oldModeRanges, recognizedIds, domRebuiltRanges);
+
+    // Byte-identical to what the pre-fix code would have produced: DOM row,
+    // then padding placeholders up to the original budget of 4.
+    assert.deepEqual(result, [
+        { id: 0, auxChannelIndex: 0, range: { start: 1700, end: 2100 } },
+        placeholder(),
+        placeholder(),
+        placeholder(),
+    ]);
+    assert.equal(result.length, oldModeRanges.length, 'total slots sent to FC must equal the FC-reported budget');
+});
+
+test('unrecognized-id assignment survives a save unchanged (the bug this fix addresses)', () => {
+    // 4-slot budget. Slot 0: ARM (recognized, rendered, untouched by user).
+    // Slot 1: a real switch assignment to permanentId 250, a mode this
+    // configurator build's FLIGHT_MODES table does not know about (e.g.
+    // newer firmware). Slots 2-3: unused placeholders.
+    const unrecognizedAssignment = { id: 250, auxChannelIndex: 2, range: { start: 1300, end: 1700 } };
+    const oldModeRanges = [
+        { id: 0, auxChannelIndex: 0, range: { start: 1700, end: 2100 } },
+        unrecognizedAssignment,
+        placeholder(),
+        placeholder(),
+    ];
+    const recognizedIds = [0, 1, 2, 3]; // does NOT include 250
+
+    // process_html() never rendered a row for id 250, so the DOM rebuild can
+    // only ever reproduce the ARM row.
+    const domRebuiltRanges = [
+        { id: 0, auxChannelIndex: 0, range: { start: 1700, end: 2100 } },
+    ];
+
+    const result = computeFinalModeRanges(oldModeRanges, recognizedIds, domRebuiltRanges);
+
+    assert.equal(result.length, oldModeRanges.length, 'total slots sent to FC must equal the FC-reported budget');
+
+    // The unrecognized assignment must be present, unmodified, somewhere in
+    // the result (order beyond "after the DOM rows" is not a guarantee we
+    // need to make - the FC-side effect is what matters).
+    assert.deepEqual(
+        result.find((r) => r.id === 250),
+        unrecognizedAssignment,
+        'the id-250 assignment must survive the save byte-for-byte instead of being silently disabled'
+    );
+
+    // Exact expected order per the real algorithm: DOM rows first, then
+    // preserved unrecognized ranges, then placeholders to fill the budget.
+    assert.deepEqual(result, [
+        { id: 0, auxChannelIndex: 0, range: { start: 1700, end: 2100 } },
+        unrecognizedAssignment,
+        placeholder(),
+        placeholder(),
+    ]);
+});
+
+test('preserved entries are bounded by the FC slot budget - never overflow', () => {
+    // 2-slot budget (tiny, to make the boundary easy to reason about). Both
+    // slots are already consumed by unrecognized assignments (e.g. the user
+    // is on a very old configurator build against very new firmware that
+    // defines several new modes).
+    const unrecognized1 = { id: 250, auxChannelIndex: 2, range: { start: 1300, end: 1700 } };
+    const unrecognized2 = { id: 251, auxChannelIndex: 3, range: { start: 1300, end: 1700 } };
+    const oldModeRanges = [unrecognized1, unrecognized2];
+    const recognizedIds = [0, 1, 2, 3]; // neither 250 nor 251 is recognized
+
+    // Nothing recognized was assigned, so the DOM has no range rows at all -
+    // an empty budget-worth of rendered rows.
+    const domRebuiltRanges = [];
+
+    const result = computeFinalModeRanges(oldModeRanges, recognizedIds, domRebuiltRanges);
+
+    assert.equal(result.length, oldModeRanges.length, 'result must never exceed the FC slot budget');
+    assert.deepEqual(result, [unrecognized1, unrecognized2], 'both unrecognized entries fit within budget and must both survive');
+});
+
+test('preserved entries are dropped (not overflowed) once the budget is exhausted by DOM rows', () => {
+    // 2-slot budget. Old state: 1 unrecognized assignment (id 250) plus 1
+    // placeholder. Between load and save, the user used the UI's "add
+    // range" button to add a second real range for a recognized mode,
+    // consuming the entire budget with DOM-visible rows before the
+    // preserve-loop even runs.
+    const unrecognizedAssignment = { id: 250, auxChannelIndex: 2, range: { start: 1300, end: 1700 } };
+    const oldModeRanges = [unrecognizedAssignment, placeholder()];
+    const recognizedIds = [0, 1, 2, 3];
+
+    const domRow1 = { id: 0, auxChannelIndex: 0, range: { start: 1700, end: 2100 } };
+    const domRow2 = { id: 0, auxChannelIndex: 1, range: { start: 1300, end: 1700 } };
+    const domRebuiltRanges = [domRow1, domRow2]; // already == requiredModesRangeCount
+
+    const result = computeFinalModeRanges(oldModeRanges, recognizedIds, domRebuiltRanges);
+
+    // Critical invariant: even though there was an unrecognized entry
+    // pending preservation, the result must NOT exceed the FC's budget -
+    // sendModeRanges() addresses FC slots positionally, so exceeding the
+    // budget would write past what the FC allocated.
+    assert.equal(result.length, oldModeRanges.length, 'result must never exceed the FC slot budget, even when the budget is already exhausted by DOM rows');
+    assert.deepEqual(result, [domRow1, domRow2], 'the unrecognized entry is correctly dropped (not silently duplicated or overflowed) once no budget remains');
+});
+
+test('multiple unrecognized entries: only as many as fit are preserved, in original order', () => {
+    // 3-slot budget. Old state: 1 recognized ARM assignment + 2 different
+    // unrecognized assignments (ids 250 and 251) - already fully consuming
+    // the budget, nothing to spare.
+    const armAssignment = { id: 0, auxChannelIndex: 0, range: { start: 1700, end: 2100 } };
+    const unrecognized1 = { id: 250, auxChannelIndex: 2, range: { start: 1300, end: 1700 } };
+    const unrecognized2 = { id: 251, auxChannelIndex: 3, range: { start: 1300, end: 1700 } };
+    const oldModeRanges = [armAssignment, unrecognized1, unrecognized2];
+    const recognizedIds = [0, 1, 2, 3];
+
+    // ARM row rendered/unchanged; the two unrecognized ones have no rows.
+    const domRebuiltRanges = [armAssignment];
+
+    const result = computeFinalModeRanges(oldModeRanges, recognizedIds, domRebuiltRanges);
+
+    assert.equal(result.length, oldModeRanges.length);
+    // Both fit (1 DOM row + 2 preserved == 3 == budget), in encounter order.
+    assert.deepEqual(result, [armAssignment, unrecognized1, unrecognized2]);
+});
+
+test('empty unrecognizedRanges (nothing to preserve) still pads to budget exactly as before the fix', () => {
+    const oldModeRanges = [placeholder(), placeholder(), placeholder()];
+    const recognizedIds = [0, 1, 2, 3];
+    const domRebuiltRanges = [];
+
+    const result = computeFinalModeRanges(oldModeRanges, recognizedIds, domRebuiltRanges);
+
+    assert.deepEqual(result, [placeholder(), placeholder(), placeholder()]);
+});

--- a/tests/fc-generate-aux-config.test.mjs
+++ b/tests/fc-generate-aux-config.test.mjs
@@ -36,10 +36,11 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { makeRewriteAndWrite } from './helpers/rewriteAndWrite.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -82,27 +83,7 @@ const mockBitHelperUrl = dataModule(`
 // so it can be loaded directly off disk with no rewriting.
 const realFlightModesUrl = pathToFileURL(join(repoRoot, 'js/flightModes.js')).href;
 
-/**
- * Rewrite the listed import specifiers in a real source file and write the
- * result to a temp module. Throws loudly if a pattern stops matching, so a
- * future reshuffle of those imports fails the test instead of passing
- * vacuously.
- */
-function rewriteAndWrite(relSrcPath, rules, outNamePrefix) {
-    let source = readFileSync(join(repoRoot, relSrcPath), 'utf8');
-    for (const [regex, replacement, label] of rules) {
-        if (!regex.test(source)) {
-            throw new Error(
-                `fc-generate-aux-config.test.mjs: expected to find and replace "${label}" in ${relSrcPath} ` +
-                `but the pattern ${regex} did not match. Update the test's substitution rules.`
-            );
-        }
-        source = source.replace(regex, replacement);
-    }
-    const outPath = join(tmpDir, `${outNamePrefix}.mjs`);
-    writeFileSync(outPath, source, 'utf8');
-    return pathToFileURL(outPath).href;
-}
+const rewriteAndWrite = makeRewriteAndWrite(repoRoot, tmpDir, 'fc-generate-aux-config.test.mjs');
 
 const realFcUrl = rewriteAndWrite('js/fc.js', [
     [/^import ServoMixerRuleCollection from '\.\/servoMixerRuleCollection';$/m, `import ServoMixerRuleCollection from '${mockClassUrl}';`, "import ServoMixerRuleCollection"],

--- a/tests/fc-generate-aux-config.test.mjs
+++ b/tests/fc-generate-aux-config.test.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for FC.generateAuxConfig() array desync.
+ *
+ * Bug: js/fc.js's generateAuxConfig() builds two parallel arrays describing
+ * the flight controller's available aux/box modes: FC.AUX_CONFIG (display
+ * names) and FC.AUX_CONFIG_IDS (permanentIds). The FC can report a
+ * permanentId the local FLIGHT_MODES table (js/flightModes.js) doesn't
+ * recognize (e.g. it's stale/out of date vs. the connected firmware). The
+ * buggy version only pushed to AUX_CONFIG when the id was recognized, but
+ * left AUX_CONFIG_IDS unfiltered - desyncing the two arrays' length/alignment
+ * from that point onward. Downstream, tabs/auxiliary.js pairs AUX_CONFIG[i]
+ * (name) with AUX_CONFIG_IDS[i] (id) by shared index i, assuming they stay
+ * aligned. The desync meant every mode-select row after the first
+ * unrecognized id displayed the WRONG name for the id it actually wrote to
+ * MSP_SET_MODE_RANGE on save - a safety bug.
+ *
+ * Fix under test: generateAuxConfig() now filters BOTH AUX_CONFIG and
+ * AUX_CONFIG_IDS identically - only pushes to AUX_CONFIG_IDS when a matching
+ * entry is also pushed to AUX_CONFIG - so both arrays end up the same
+ * length, index-aligned, and containing only recognized ids/names in
+ * original relative order.
+ *
+ * The test below executes the REAL production js/fc.js and the REAL
+ * js/flightModes.js. Like tests/connection-send-queue.test.mjs and
+ * tests/cli-tab-msp-polling.test.mjs, plain Node's ESM resolver refuses to
+ * load this codebase's Vite-style extensionless relative imports, so fc.js
+ * is read fresh off disk and only its *import specifiers* are rewritten:
+ * the heavy collection/model classes that generateAuxConfig() never touches
+ * are pointed at trivial no-arg-constructible stubs (still exercised,
+ * because FC.resetState() instantiates them, just not asserted on), and
+ * './flightModes' is pointed directly at the real js/flightModes.js file on
+ * disk (unmodified - it has no imports of its own). No statement,
+ * expression or ordering inside generateAuxConfig() itself is touched.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'fc-generate-aux-config-'));
+process.on('exit', () => rmSync(tmpDir, { recursive: true, force: true }));
+
+function dataModule(code) {
+    // encodeURIComponent leaves ' ( ) ! * unescaped; the generated specifiers are
+    // embedded in single-quoted string literals, so escape those too.
+    const encoded = encodeURIComponent(code).replace(/['()!*]/g, (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+    return 'data:text/javascript,' + encoded;
+}
+
+// Trivial no-arg-constructible stand-ins for the collection/model classes
+// FC.resetState() instantiates. generateAuxConfig() never reads from these,
+// so their internal behavior is irrelevant - they only need to exist and be
+// `new`-able so resetState() (which is where generateAuxConfig itself is
+// defined, as `this.generateAuxConfig = function () {...}`) can run.
+const mockClassUrl = dataModule(`
+    class MockCollection {}
+    export default MockCollection;
+`);
+
+const mockModelUrl = dataModule(`
+    export const PLATFORM = { AIRPLANE: 0, MULTIROTOR: 1, TRICOPTER: 2 };
+`);
+
+const mockVtxUrl = dataModule(`
+    const VTX = { DEV_UNKNOWN: 0xFF };
+    export default VTX;
+`);
+
+const mockBitHelperUrl = dataModule(`
+    const BitHelper = { bit_check: () => false };
+    export default BitHelper;
+`);
+
+// The real, unmodified flightModes.js - this file has no imports of its own,
+// so it can be loaded directly off disk with no rewriting.
+const realFlightModesUrl = pathToFileURL(join(repoRoot, 'js/flightModes.js')).href;
+
+/**
+ * Rewrite the listed import specifiers in a real source file and write the
+ * result to a temp module. Throws loudly if a pattern stops matching, so a
+ * future reshuffle of those imports fails the test instead of passing
+ * vacuously.
+ */
+function rewriteAndWrite(relSrcPath, rules, outNamePrefix) {
+    let source = readFileSync(join(repoRoot, relSrcPath), 'utf8');
+    for (const [regex, replacement, label] of rules) {
+        if (!regex.test(source)) {
+            throw new Error(
+                `fc-generate-aux-config.test.mjs: expected to find and replace "${label}" in ${relSrcPath} ` +
+                `but the pattern ${regex} did not match. Update the test's substitution rules.`
+            );
+        }
+        source = source.replace(regex, replacement);
+    }
+    const outPath = join(tmpDir, `${outNamePrefix}.mjs`);
+    writeFileSync(outPath, source, 'utf8');
+    return pathToFileURL(outPath).href;
+}
+
+const realFcUrl = rewriteAndWrite('js/fc.js', [
+    [/^import ServoMixerRuleCollection from '\.\/servoMixerRuleCollection';$/m, `import ServoMixerRuleCollection from '${mockClassUrl}';`, "import ServoMixerRuleCollection"],
+    [/^import MotorMixerRuleCollection from '\.\/motorMixerRuleCollection';$/m, `import MotorMixerRuleCollection from '${mockClassUrl}';`, "import MotorMixerRuleCollection"],
+    [/^import LogicConditionsCollection from '\.\/logicConditionsCollection';$/m, `import LogicConditionsCollection from '${mockClassUrl}';`, "import LogicConditionsCollection"],
+    [/^import LogicConditionsStatus from '\.\/logicConditionsStatus';$/m, `import LogicConditionsStatus from '${mockClassUrl}';`, "import LogicConditionsStatus"],
+    [/^import GlobalVariablesStatus from '\.\/globalVariablesStatus';$/m, `import GlobalVariablesStatus from '${mockClassUrl}';`, "import GlobalVariablesStatus"],
+    [/^import ProgrammingPidCollection from '\.\/programmingPidCollection';$/m, `import ProgrammingPidCollection from '${mockClassUrl}';`, "import ProgrammingPidCollection"],
+    [/^import ProgrammingPidStatus from '\.\/programmingPidStatus';$/m, `import ProgrammingPidStatus from '${mockClassUrl}';`, "import ProgrammingPidStatus"],
+    [/^import WaypointCollection from '\.\/waypointCollection';$/m, `import WaypointCollection from '${mockClassUrl}';`, "import WaypointCollection"],
+    [/^import OutputMappingCollection from '\.\/outputMapping';$/m, `import OutputMappingCollection from '${mockClassUrl}';`, "import OutputMappingCollection"],
+    [/^import SafehomeCollection from '\.\/safehomeCollection';$/m, `import SafehomeCollection from '${mockClassUrl}';`, "import SafehomeCollection"],
+    [/^import FwApproachCollection from '\.\/fwApproachCollection';$/m, `import FwApproachCollection from '${mockClassUrl}';`, "import FwApproachCollection"],
+    [/^import GeozoneCollection from '\.\/geozoneCollection';$/m, `import GeozoneCollection from '${mockClassUrl}';`, "import GeozoneCollection"],
+    [/^import \{ PLATFORM \} from '\.\/model';$/m, `import { PLATFORM } from '${mockModelUrl}';`, "import PLATFORM"],
+    [/^import VTX from '\.\/vtx';$/m, `import VTX from '${mockVtxUrl}';`, "import VTX"],
+    [/^import BitHelper from '\.\/bitHelper';$/m, `import BitHelper from '${mockBitHelperUrl}';`, "import BitHelper"],
+    [/^import \{ FLIGHT_MODES \} from '\.\/flightModes';$/m, `import { FLIGHT_MODES } from '${realFlightModesUrl}';`, "import FLIGHT_MODES"],
+], 'fc-generated');
+
+const { default: FC } = await import(realFcUrl);
+
+// Also import the real FLIGHT_MODES table directly so the test can compute
+// its own expectations without duplicating box-name data.
+const { FLIGHT_MODES } = await import(realFlightModesUrl);
+
+function permanentIdToBoxName(id) {
+    const entry = FLIGHT_MODES.find((mode) => mode.permanentId === id);
+    return entry ? entry.boxName : undefined;
+}
+
+test('generateAuxConfig() keeps AUX_CONFIG and AUX_CONFIG_IDS the same length when the FC reports unrecognized permanentIds', () => {
+    FC.resetState();
+
+    // Simulate a stale local FLIGHT_MODES table: the FC (real firmware)
+    // reports two permanentIds in a row (9990, 9991) that this build of the
+    // configurator doesn't know about, sandwiched between ids it does
+    // recognize. permanentIds 0/1/2/3 (ARM/ANGLE/HORIZON/NAV ALTHOLD) all
+    // exist in js/flightModes.js; 9990/9991 deliberately do not.
+    FC.AUX_CONFIG_IDS = [0, 9990, 9991, 1, 2, 9992, 3];
+
+    FC.generateAuxConfig();
+
+    assert.equal(
+        FC.AUX_CONFIG.length,
+        FC.AUX_CONFIG_IDS.length,
+        'AUX_CONFIG and AUX_CONFIG_IDS must stay the same length - this is the invariant tabs/auxiliary.js relies on when pairing them by index'
+    );
+
+    // Only the recognized ids should have survived, in original relative order.
+    assert.deepEqual(FC.AUX_CONFIG_IDS, [0, 1, 2, 3]);
+    assert.deepEqual(FC.AUX_CONFIG, ['ARM', 'ANGLE', 'HORIZON', 'NAV ALTHOLD']);
+
+    // The core correctness property: not just equal length, but that each
+    // index's id and name actually still refer to the SAME flight mode.
+    for (let i = 0; i < FC.AUX_CONFIG_IDS.length; i++) {
+        const expectedName = permanentIdToBoxName(FC.AUX_CONFIG_IDS[i]);
+        assert.notEqual(expectedName, undefined, `test setup error: id ${FC.AUX_CONFIG_IDS[i]} not found in FLIGHT_MODES`);
+        assert.equal(
+            FC.AUX_CONFIG[i],
+            expectedName,
+            `AUX_CONFIG[${i}] ("${FC.AUX_CONFIG[i]}") must be the boxName for AUX_CONFIG_IDS[${i}] (${FC.AUX_CONFIG_IDS[i]}), which is "${expectedName}"`
+        );
+    }
+});
+
+test('generateAuxConfig() positive control: an all-recognized id list passes through unchanged', () => {
+    FC.resetState();
+    FC.AUX_CONFIG_IDS = [0, 1, 2];
+
+    FC.generateAuxConfig();
+
+    assert.equal(FC.AUX_CONFIG.length, FC.AUX_CONFIG_IDS.length);
+    assert.deepEqual(FC.AUX_CONFIG_IDS, [0, 1, 2]);
+    assert.deepEqual(FC.AUX_CONFIG, ['ARM', 'ANGLE', 'HORIZON']);
+});
+
+test('generateAuxConfig() negative control: an all-unrecognized id list empties both arrays', () => {
+    FC.resetState();
+    FC.AUX_CONFIG_IDS = [9990, 9991, 9992];
+
+    FC.generateAuxConfig();
+
+    assert.equal(FC.AUX_CONFIG.length, 0);
+    assert.equal(FC.AUX_CONFIG_IDS.length, 0);
+});

--- a/tests/helpers/rewriteAndWrite.mjs
+++ b/tests/helpers/rewriteAndWrite.mjs
@@ -1,0 +1,29 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Factory for a per-test rewriteAndWrite(relSrcPath, rules, outNamePrefix)
+ * helper: rewrites the listed import specifiers in a real source file and
+ * writes the result to a temp module, so plain Node's ESM resolver can load
+ * a file that otherwise uses this codebase's Vite-style extensionless
+ * imports. Throws loudly if a pattern stops matching, so a future reshuffle
+ * of those imports fails the test instead of passing vacuously.
+ */
+export function makeRewriteAndWrite(repoRoot, tmpDir, testFileName) {
+    return function rewriteAndWrite(relSrcPath, rules, outNamePrefix) {
+        let source = readFileSync(join(repoRoot, relSrcPath), 'utf8');
+        for (const [regex, replacement, label] of rules) {
+            if (!regex.test(source)) {
+                throw new Error(
+                    `${testFileName}: expected to find and replace "${label}" in ${relSrcPath} ` +
+                    `but the pattern ${regex} did not match. Update the test's substitution rules.`
+                );
+            }
+            source = source.replace(regex, replacement);
+        }
+        const outPath = join(tmpDir, `${outNamePrefix}.mjs`);
+        writeFileSync(outPath, source, 'utf8');
+        return pathToFileURL(outPath).href;
+    };
+}


### PR DESCRIPTION
## Summary

Fixes a bug in `generateAuxConfig()` (`js/fc.js`) that can cause the Modes tab to display the wrong mode name for the permanentId it actually writes to the flight controller — a silent mislabeling that lets a user unknowingly assign a different mode than the one shown to a switch.

## Root Cause

`generateAuxConfig()` builds two parallel arrays from the FC's live box-mode list: `AUX_CONFIG` (display names, resolved via the local `FLIGHT_MODES` table) and `AUX_CONFIG_IDS` (permanentIds, as reported by the FC over MSP). The old code only skipped adding a name to `AUX_CONFIG` when a permanentId wasn't recognized in the local `FLIGHT_MODES` table, but left `AUX_CONFIG_IDS` unfiltered. Once the FC reports any id the local table doesn't recognize (e.g. the table hasn't caught up with a newer firmware build that added a mode), the two arrays desync in length. `tabs/auxiliary.js` pairs them by shared array index, so every mode-select row after the desync point ends up showing the wrong name for the id it actually writes on save.

This was traced back from a real-world report: a test pilot's switch activated MSP RC Override — cutting RC link control — instead of the mode they'd selected by name in the GUI.

## Changes

- `js/fc.js`: `generateAuxConfig()` now filters `AUX_CONFIG` and `AUX_CONFIG_IDS` identically, so an unrecognized id is dropped from both arrays at the same iteration, keeping them the same length and correctly index-aligned.
- `tests/fc-generate-aux-config.test.mjs` (new): unit test exercising the real `js/fc.js`/`js/flightModes.js` against a case with unrecognized ids interspersed with recognized ones, asserting both array-length parity and correct name/id pairing at every index.

## Testing

- New unit test (`node --test tests/fc-generate-aux-config.test.mjs`) confirmed genuine red→green: fails against the pre-fix code (array length mismatch, e.g. `4 !== 7`) and passes against the fix.
- Full suite: `npm test` — 77/77 passing.
- Not flight-tested against the exact build/firmware pairing that produced the original report; the fix addresses the confirmed code-level root cause of that symptom.

## Code Review

Reviewed with the inav-code-review agent — approved, no critical or important issues in the diff itself. The review separately flagged an adjacent, pre-existing issue in `FC.getModeId()`/`isModeEnabled()` with the same root cause (stale local mode table vs. firmware) that can affect ARM/FAILSAFE status reporting; that is out of scope for this PR and is being tracked separately.