### PR TITLE
MSP over MAVLink Tunnel support

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,10 @@
                 </div>
                 <div id="portsinput">
                     <div class="portsinput__row">
+                        <div id="mavlink-sysid-option" class="portsinput__top-element portsinput__top-element--port-override" style="display: none;">
+                            <label for="wireless-mavlink-sysid" i18n="wirelessMavlinkSysidLabel"></label>
+                            <input id="wireless-mavlink-sysid" type="number" min="0" max="255" value="0" />
+                        </div>
                         <div id="port-override-option" class="portsinput__top-element portsinput__top-element--port-override">
                             <label id="port-override-label" for="port-override" i18n="mainPortOverrideLabel"></label>
                             <input id="port-override" type="text" value="/dev/rfcomm0" />
@@ -77,6 +81,12 @@
                                 <span class="" data-i18n="wirelessModeSwitch"></span>
                             </label>
                             <input id="wireless-mode" class="togglesmall" type="checkbox" />
+                        </div>
+                        <div id="mavlink-tunnel-option" class="portsinput__top-element portsinput__top-element--inline" style="display: none;">
+                            <label for="wireless-mavlink-tunnel">
+                                <span data-i18n="wirelessMavlinkTunnelSwitch"></span>
+                            </label>
+                            <input id="wireless-mavlink-tunnel" class="togglesmall" type="checkbox" />
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -62,6 +62,9 @@
                         <div class="dropdown dropdown-dark portsinput__top-element">
                             <!--suppress HtmlFormInputWithoutLabel -->
                             <select class="dropdown-select" id="baud" title="Baud Rate">
+                                <option value="921600">921600</option>
+                                <option value="460800">460800</option>
+                                <option value="230400">230400</option>
                                 <option value="115200" selected="selected">115200</option>
                                 <option value="57600">57600</option>
                                 <option value="38400">38400</option>

--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -150,6 +150,10 @@ $(function() {
                 }
 
                 if (GUI.allowedTabs.indexOf(tab) < 0) {
+                    if (CONFIGURATOR.mavlinkTunnelActive && tab === 'cli') {
+                        GUI.log(i18n.getMessage('tabSwitchMavlinkTunnelUnavailable'));
+                        return;
+                    }
                     GUI.log(i18n.getMessage('tabSwitchUpgradeRequired', [tabName]));
                     return;
                 }

--- a/js/connection/connection.js
+++ b/js/connection/connection.js
@@ -24,6 +24,7 @@ class Connection {
         this._onReceiveListeners      = [];
         this._onReceiveErrorListeners = [];
         this._type = null;
+        this._timeoutOverride = null;
         
         if (this.constructor === Connection) {
             throw new TypeError("Abstract class, cannot be instanced.");
@@ -260,11 +261,19 @@ class Connection {
         this._transmitting = false;
     }
 
+    setTimeoutOverride(timeoutMs) {
+        this._timeoutOverride = timeoutMs;
+    }
+
     /**
      * Default timeout values
      * @returns {number} [ms]
      */
     getTimeout() {
+        if (this._timeoutOverride !== null) {
+            return this._timeoutOverride;
+        }
+
         if (this._bitrate >= 57600) {
             return 3000;
         } if (this._bitrate >= 19200) {

--- a/js/data_storage.js
+++ b/js/data_storage.js
@@ -8,6 +8,7 @@ var CONFIGURATOR = {
     'connectionValidCliOnly': false,
     'cliActive': false,
     'cliValid': false,
+    'mavlinkTunnelActive': false,
     'connection': false
 };
 

--- a/js/main/main.js
+++ b/js/main/main.js
@@ -376,8 +376,8 @@ app.whenReady().then(() => {
     return udp.send(data);
   });
 
-  ipcMain.on('udpClose', (_event) => {
-    udp.close();
+  ipcMain.handle('udpClose', (_event) => {
+    return udp.close();
   });
 
   ipcMain.handle('writeFile', (_event, filename, data) => {

--- a/js/main/udp.js
+++ b/js/main/udp.js
@@ -1,32 +1,38 @@
 // Runs in main thread
 
 import dgram from 'dgram';
-const socket = dgram.createSocket('udp4');
 
 const udp = {
+    _socket: null,
     _id: 1,
     _ip: null,
     _port: null,
     connect: function(ip, port, window = true) {
         return new Promise(resolve => {     
             try {
-                socket.bind(port, () => {
-                    this._ip = ip;
-                    this._port = port;
-                    resolve({ error: false, id: this._id++ });
-                });
+                if (this._socket) {
+                    this._socket.close();
+                }
 
-                socket.on('error', error => {
+                this._socket = dgram.createSocket('udp4');
+
+                this._socket.on('error', error => {
                     if (window && typeof window.isDestroyed === 'function' && !window.isDestroyed()) {
                         window.webContents.send('udpError', error); 
                     }
                 });
 
-                socket.on('message', (message, _rinfo) => {
+                this._socket.on('message', (message, _rinfo) => {
                     if (window && typeof window.isDestroyed === 'function' && !window.isDestroyed()) {
                         window.webContents.send('udpMessage', message);
                     }
-                });                   
+                });
+
+                this._socket.bind(port, () => {
+                    this._ip = ip;
+                    this._port = port;
+                    resolve({ error: false, id: this._id++ });
+                });
             } catch (err) {
                 resolve({error: true, errorMsg: err});
             }
@@ -35,8 +41,17 @@ const udp = {
     close: function() {
         return new Promise(resolve => {
             try {
-                socket.disconnect();
-                resolve({error: false});
+                if (this._socket) {
+                    const socket = this._socket;
+                    this._socket = null;
+                    this._ip = null;
+                    this._port = null;
+                    socket.close(() => {
+                        resolve({error: false});
+                    });
+                } else {
+                    resolve({error: false});
+                }
             } catch (err) {
                 resolve({error: true, msg: err});
             }
@@ -44,14 +59,16 @@ const udp = {
     },
     send: function(data) {
         return new Promise(resolve => {  
-            if (this._ip && this._port) {
-                socket.send(Buffer.from(data), this._port, this._ip, (error) => {
+            if (this._socket && this._ip && this._port) {
+                this._socket.send(Buffer.from(data), this._port, this._ip, (error) => {
                     if (!error) {
                         resolve({error: false, bytesWritten: data.byteLength});
                     } else {
                         resolve({error: true, msg: error});
                     }
                 });
+            } else {
+                resolve({error: true, msg: "UDP socket closed or invalid"});
             }
         });
     }

--- a/js/mavlink/mspTunnel.js
+++ b/js/mavlink/mspTunnel.js
@@ -1,0 +1,295 @@
+'use strict';
+
+const MAVLINK_V1_MAGIC = 0xFE;
+const MAVLINK_V2_MAGIC = 0xFD;
+const MAVLINK_V2_INCOMPAT_FLAG_SIGNED = 0x01;
+const MAVLINK_V2_HEADER_LENGTH = 10;
+const MAVLINK_V1_HEADER_LENGTH = 6;
+const MAVLINK_CHECKSUM_LENGTH = 2;
+const MAVLINK_SIGNATURE_LENGTH = 13;
+const MAVLINK_MSG_ID_HEARTBEAT = 0;
+const MAVLINK_MSG_ID_TUNNEL = 385;
+const MAVLINK_MSG_HEARTBEAT_CRC_EXTRA = 50;
+const MAVLINK_MSG_TUNNEL_CRC_EXTRA = 147;
+const MAVLINK_TUNNEL_PAYLOAD_TYPE_INAV_MSP = 0x8001;
+const MAVLINK_AUTOPILOT_INVALID = 8;
+const MAVLINK_CONFIGURATOR_SYSTEM_ID = 253;
+const MAVLINK_CONFIGURATOR_COMPONENT_ID = 25;
+const MAVLINK_TUNNEL_CHUNK_SIZE = 128;
+
+class MavlinkMspTunnel {
+    constructor() {
+        this.reset();
+    }
+
+    reset() {
+        this._buffer = new Uint8Array(0);
+        this._sequence = 0;
+        this._requestedSystemId = 0;
+        this._targetSystemId = 0;
+    }
+
+    configure(requestedSystemId) {
+        this.reset();
+        this._requestedSystemId = requestedSystemId;
+    }
+
+    isTargetReady() {
+        return this._targetSystemId !== 0;
+    }
+
+    getTargetSystemId() {
+        return this._targetSystemId;
+    }
+
+    wrapMspFrame(frameBuffer) {
+        if (!this._targetSystemId) {
+            throw new Error('MAVLink tunnel target is not ready');
+        }
+
+        const frameBytes = new Uint8Array(frameBuffer);
+        const packets = [];
+
+        for (let offset = 0; offset < frameBytes.length; offset += MAVLINK_TUNNEL_CHUNK_SIZE) {
+            const chunk = frameBytes.slice(offset, offset + MAVLINK_TUNNEL_CHUNK_SIZE);
+            packets.push(this._encodeTunnelFrame(chunk));
+        }
+
+        return this._concatArrays(packets).buffer;
+    }
+
+    ingest(rawBuffer) {
+        this._append(rawBuffer);
+
+        const mspFrames = [];
+        let targetDiscovered = false;
+
+        while (this._buffer.length > 0) {
+            const frameStart = this._findFrameStart();
+            if (frameStart < 0) {
+                this._buffer = new Uint8Array(0);
+                break;
+            }
+
+            if (frameStart > 0) {
+                this._buffer = this._buffer.slice(frameStart);
+            }
+
+            if (this._buffer.length < 2) {
+                break;
+            }
+
+            const magic = this._buffer[0];
+            const payloadLength = this._buffer[1];
+            let frameLength;
+            let msgId;
+            let systemId;
+            let componentId;
+            let payloadOffset;
+            let checksumOffset;
+            let crcExtra = null;
+
+            if (magic === MAVLINK_V2_MAGIC) {
+                if (this._buffer.length < MAVLINK_V2_HEADER_LENGTH) {
+                    break;
+                }
+
+                const signed = (this._buffer[2] & MAVLINK_V2_INCOMPAT_FLAG_SIGNED) !== 0;
+                frameLength = MAVLINK_V2_HEADER_LENGTH + payloadLength + MAVLINK_CHECKSUM_LENGTH + (signed ? MAVLINK_SIGNATURE_LENGTH : 0);
+                if (this._buffer.length < frameLength) {
+                    break;
+                }
+
+                msgId = this._buffer[7] | (this._buffer[8] << 8) | (this._buffer[9] << 16);
+                systemId = this._buffer[5];
+                componentId = this._buffer[6];
+                payloadOffset = MAVLINK_V2_HEADER_LENGTH;
+                checksumOffset = MAVLINK_V2_HEADER_LENGTH + payloadLength;
+            } else {
+                if (this._buffer.length < MAVLINK_V1_HEADER_LENGTH) {
+                    break;
+                }
+
+                frameLength = MAVLINK_V1_HEADER_LENGTH + payloadLength + MAVLINK_CHECKSUM_LENGTH;
+                if (this._buffer.length < frameLength) {
+                    break;
+                }
+
+                msgId = this._buffer[5];
+                systemId = this._buffer[3];
+                componentId = this._buffer[4];
+                payloadOffset = MAVLINK_V1_HEADER_LENGTH;
+                checksumOffset = MAVLINK_V1_HEADER_LENGTH + payloadLength;
+            }
+
+            if (msgId === MAVLINK_MSG_ID_HEARTBEAT) {
+                crcExtra = MAVLINK_MSG_HEARTBEAT_CRC_EXTRA;
+            } else if (msgId === MAVLINK_MSG_ID_TUNNEL) {
+                crcExtra = MAVLINK_MSG_TUNNEL_CRC_EXTRA;
+            }
+
+            const frame = this._buffer.slice(0, frameLength);
+            this._buffer = this._buffer.slice(frameLength);
+
+            if (crcExtra === null) {
+                continue;
+            }
+
+            if (!this._crcMatches(frame, magic, payloadLength, checksumOffset, crcExtra)) {
+                continue;
+            }
+
+            if (msgId === MAVLINK_MSG_ID_HEARTBEAT) {
+                if (this._acceptHeartbeat(systemId, frame.slice(payloadOffset, payloadOffset + payloadLength))) {
+                    targetDiscovered = true;
+                }
+                continue;
+            }
+
+            if (msgId === MAVLINK_MSG_ID_TUNNEL) {
+                const payload = frame.slice(payloadOffset, payloadOffset + payloadLength);
+                if (this._isConfiguratorTunnel(payload, systemId, componentId)) {
+                    const tunnelLength = payload[4];
+                    const expectedPayloadLength = 5 + tunnelLength;
+                    const paddedPayload = new Uint8Array(expectedPayloadLength);
+                    paddedPayload.set(payload.slice(0, Math.min(payload.length, expectedPayloadLength)));
+                    mspFrames.push(paddedPayload.slice(5).buffer);
+                }
+            }
+        }
+
+        return {
+            targetDiscovered: targetDiscovered,
+            mspFrames: mspFrames,
+        };
+    }
+
+    _acceptHeartbeat(systemId, payload) {
+        if (payload.length < 9) {
+            return false;
+        }
+
+        if (payload[5] === MAVLINK_AUTOPILOT_INVALID) {
+            return false;
+        }
+
+        if (this._requestedSystemId !== 0 && systemId !== this._requestedSystemId) {
+            return false;
+        }
+
+        if (!this._targetSystemId) {
+            this._targetSystemId = systemId;
+            return true;
+        }
+
+        return false;
+    }
+
+    _isConfiguratorTunnel(payload, systemId, componentId) {
+        if (payload.length < 5) {
+            return false;
+        }
+
+        const payloadType = payload[0] | (payload[1] << 8);
+        const targetSystem = payload[2];
+        const targetComponent = payload[3];
+
+        return payloadType === MAVLINK_TUNNEL_PAYLOAD_TYPE_INAV_MSP &&
+            systemId === this._targetSystemId &&
+            componentId !== 0 &&
+            targetSystem === MAVLINK_CONFIGURATOR_SYSTEM_ID &&
+            targetComponent === MAVLINK_CONFIGURATOR_COMPONENT_ID;
+    }
+
+    _encodeTunnelFrame(payload) {
+        const payloadLength = 5 + payload.length;
+        const frame = new Uint8Array(MAVLINK_V2_HEADER_LENGTH + payloadLength + MAVLINK_CHECKSUM_LENGTH);
+
+        frame[0] = MAVLINK_V2_MAGIC;
+        frame[1] = payloadLength;
+        frame[2] = 0;
+        frame[3] = 0;
+        frame[4] = this._sequence;
+        frame[5] = MAVLINK_CONFIGURATOR_SYSTEM_ID;
+        frame[6] = MAVLINK_CONFIGURATOR_COMPONENT_ID;
+        frame[7] = MAVLINK_MSG_ID_TUNNEL & 0xFF;
+        frame[8] = (MAVLINK_MSG_ID_TUNNEL >> 8) & 0xFF;
+        frame[9] = (MAVLINK_MSG_ID_TUNNEL >> 16) & 0xFF;
+        frame[10] = MAVLINK_TUNNEL_PAYLOAD_TYPE_INAV_MSP & 0xFF;
+        frame[11] = (MAVLINK_TUNNEL_PAYLOAD_TYPE_INAV_MSP >> 8) & 0xFF;
+        frame[12] = this._targetSystemId;
+        frame[13] = 0;
+        frame[14] = payload.length;
+        frame.set(payload, 15);
+
+        const crc = this._crcX25(frame.slice(1, MAVLINK_V2_HEADER_LENGTH + payloadLength), MAVLINK_MSG_TUNNEL_CRC_EXTRA);
+        frame[MAVLINK_V2_HEADER_LENGTH + payloadLength] = crc & 0xFF;
+        frame[MAVLINK_V2_HEADER_LENGTH + payloadLength + 1] = (crc >> 8) & 0xFF;
+
+        this._sequence = (this._sequence + 1) & 0xFF;
+
+        return frame;
+    }
+
+    _crcMatches(frame, magic, payloadLength, checksumOffset, crcExtra) {
+        const headerWithoutMagic = magic === MAVLINK_V2_MAGIC ?
+            frame.slice(1, MAVLINK_V2_HEADER_LENGTH + payloadLength) :
+            frame.slice(1, MAVLINK_V1_HEADER_LENGTH + payloadLength);
+        const crc = this._crcX25(headerWithoutMagic, crcExtra);
+        const frameCrc = frame[checksumOffset] | (frame[checksumOffset + 1] << 8);
+
+        return crc === frameCrc;
+    }
+
+    _crcX25(bytes, crcExtra) {
+        let crc = 0xFFFF;
+
+        for (let index = 0; index < bytes.length; index++) {
+            crc = this._crcAccumulate(bytes[index], crc);
+        }
+
+        return this._crcAccumulate(crcExtra, crc);
+    }
+
+    _crcAccumulate(byte, crc) {
+        let tmp = byte ^ (crc & 0xFF);
+        tmp ^= (tmp << 4) & 0xFF;
+        return ((crc >> 8) ^ (tmp << 8) ^ (tmp << 3) ^ (tmp >> 4)) & 0xFFFF;
+    }
+
+    _append(rawBuffer) {
+        const bytes = new Uint8Array(rawBuffer);
+        const combined = new Uint8Array(this._buffer.length + bytes.length);
+        combined.set(this._buffer, 0);
+        combined.set(bytes, this._buffer.length);
+        this._buffer = combined;
+    }
+
+    _findFrameStart() {
+        for (let index = 0; index < this._buffer.length; index++) {
+            if (this._buffer[index] === MAVLINK_V1_MAGIC || this._buffer[index] === MAVLINK_V2_MAGIC) {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    _concatArrays(arrays) {
+        let totalLength = 0;
+        for (let index = 0; index < arrays.length; index++) {
+            totalLength += arrays[index].length;
+        }
+
+        const combined = new Uint8Array(totalLength);
+        let offset = 0;
+        for (let index = 0; index < arrays.length; index++) {
+            combined.set(arrays[index], offset);
+            offset += arrays[index].length;
+        }
+
+        return combined;
+    }
+}
+
+export default MavlinkMspTunnel;

--- a/js/msp.js
+++ b/js/msp.js
@@ -91,6 +91,7 @@ var MSP = {
     lastFrameReceivedMs: 0,
 
     processData: null,
+    transportTransform: null,
 
     init() {
         mspQueue.setPutCallback(this.putCallback);
@@ -99,6 +100,10 @@ var MSP = {
 
     setProcessData(cb) {
         this.processData = cb;
+    },
+
+    setTransportTransform(cb) {
+        this.transportTransform = cb;
     },
 
     read: function (readInfo) {
@@ -370,7 +375,7 @@ var MSP = {
 
         var message = new MspMessageClass();
         message.code = code;
-        message.messageBody = buffer;
+        message.messageBody = this.transportTransform ? this.transportTransform(buffer) : buffer;
         message.onFinish = callback_msp;
         message.onSend = callback_sent;
 
@@ -446,6 +451,7 @@ var MSP = {
         this.last_received_timestamp = null;
         this.analog_last_received_timestamp = null;
         this.lastFrameReceivedMs = 0;
+        this.transportTransform = null;
 
         this.callbacks_cleanup();
     },

--- a/js/port_handler.js
+++ b/js/port_handler.js
@@ -105,6 +105,11 @@ PortHandler.check = function () {
                     $('#wireless-mode').prop('checked', true).trigger('change');
                 }
 
+                if (store.get('wireless_mavlink_tunnel_enabled', false)) {
+                    $('#wireless-mavlink-tunnel').prop('checked', true).trigger('change');
+                }
+
+                $('#wireless-mavlink-sysid').val(store.get('wireless_mavlink_sysid', '0'));
             }
 
             if (!self.initial_ports) {

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -30,6 +30,7 @@ import mspDeduplicationQueue from './msp/mspDeduplicationQueue';
 import store from './store';
 import cliTab from '../tabs/cli';
 import javascriptProgrammingTab from '../tabs/javascript_programming';
+import MavlinkMspTunnel from './mavlink/mspTunnel';
 
 var SerialBackend = (function () {
 
@@ -39,6 +40,71 @@ var SerialBackend = (function () {
     privateScope.isDemoRunning = false;
 
     privateScope.isWirelessMode = false;
+    privateScope.mavlinkTunnel = null;
+    privateScope.mavlinkHandshakeStarted = false;
+
+    privateScope.isMavlinkTunnelEnabled = function () {
+        return $('#wireless-mode').is(':checked') && $('#wireless-mavlink-tunnel').is(':checked');
+    };
+
+    privateScope.updateWirelessOptions = function () {
+        const wirelessEnabled = $('#wireless-mode').is(':checked');
+        $('#mavlink-tunnel-option').toggle(wirelessEnabled);
+        $('#mavlink-sysid-option').toggle(wirelessEnabled && $('#wireless-mavlink-tunnel').is(':checked'));
+
+        if (wirelessEnabled) {
+            mspQueue.setLockMethod('hard');
+        } else {
+            mspQueue.setLockMethod('soft');
+        }
+    };
+
+    privateScope.startHandshake = function () {
+        if (privateScope.mavlinkHandshakeStarted) {
+            return;
+        }
+
+        privateScope.mavlinkHandshakeStarted = true;
+
+        // request configuration data. Start with MSPv1 and
+        // upgrade to MSPv2 if possible.
+        MSP.protocolVersion = MSP.constants.PROTOCOL_V2;
+        MSP.send_message(MSPCodes.MSP_API_VERSION, false, false, function () {
+
+            if (FC.CONFIG.apiVersion === "0.0.0") {
+                GUI.log("<span style='color: red; font-weight: bolder'><strong>" + i18n.getMessage("illegalStateRestartRequired") + "</strong></span>");
+                FC.restartRequired = true;
+                return;
+            }
+
+            GUI.log(i18n.getMessage('apiVersionReceived', [FC.CONFIG.apiVersion]));
+
+            MSP.send_message(MSPCodes.MSP_FC_VARIANT, false, false, function () {
+                if (FC.CONFIG.flightControllerIdentifier == 'INAV') {
+                    MSP.send_message(MSPCodes.MSP_FC_VERSION, false, false, function () {
+
+                        GUI.log(i18n.getMessage('fcInfoReceived', [FC.CONFIG.flightControllerIdentifier, FC.CONFIG.flightControllerVersion]));
+                        if (semver.gte(FC.CONFIG.flightControllerVersion, CONFIGURATOR.minfirmwareVersionAccepted) && semver.lt(FC.CONFIG.flightControllerVersion, CONFIGURATOR.maxFirmwareVersionAccepted)) {
+                            if (CONFIGURATOR.connection.type == ConnectionType.BLE && semver.lt(FC.CONFIG.flightControllerVersion, "5.0.0")) {
+                                privateScope.onBleNotSupported();
+                            } else {
+                                mspHelper.getCraftName(function(name) {
+                                    if (name) {
+                                        FC.CONFIG.name = name;
+                                    }
+                                    privateScope.onValidFirmware();
+                                });
+                            }
+                        } else  {
+                            privateScope.onInvalidFirmwareVersion();
+                        }
+                    });
+                } else {
+                    privateScope.onInvalidFirmwareVariant();
+                }
+            });
+        });
+    };
 
     privateScope.reopenTab = null;
 
@@ -63,13 +129,16 @@ var SerialBackend = (function () {
         mspHelper.setSensorStatusEx(privateScope.sensor_status_ex);
 
         $('#wireless-mode').on('change', function () {
-            var $this = $(this);
+            privateScope.updateWirelessOptions();
+        });
 
-            if ($this.is(':checked')) {
-                mspQueue.setLockMethod('hard');
-            } else {
-                mspQueue.setLockMethod('soft');
-            }
+        $('#wireless-mavlink-tunnel').on('change', function () {
+            privateScope.updateWirelessOptions();
+        });
+
+        $('#wireless-mavlink-sysid').on('change', function () {
+            const value = Math.max(0, Math.min(255, parseInt($(this).val(), 10) || 0));
+            $(this).val(value);
         });
 
         GUI.handleReconnect = function (reopenLastTab = true) {
@@ -157,6 +226,7 @@ var SerialBackend = (function () {
         };
 
         GUI.updateManualPortVisibility();
+        privateScope.updateWirelessOptions();
 
         publicScope.$portOverride.on('change', function () {
             store.set('portOverride', publicScope.$portOverride.val());
@@ -299,6 +369,9 @@ var SerialBackend = (function () {
                             CONFIGURATOR.connection.disconnect(privateScope.onClosed);
                             MSP.disconnect_cleanup();
                             privateScope.ltmProtocolGate.reset();
+                            CONFIGURATOR.mavlinkTunnelActive = false;
+                            privateScope.mavlinkTunnel = null;
+                            privateScope.mavlinkHandshakeStarted = false;
 
                             // Reset various UI elements
                             $('span.i2c-error').text(0);
@@ -348,6 +421,9 @@ var SerialBackend = (function () {
                 // continue as usually
                 CONFIGURATOR.connectionValid = true;
                 GUI.allowedTabs = GUI.defaultAllowedTabsWhenConnected.slice();
+                if (privateScope.isMavlinkTunnelEnabled()) {
+                    GUI.allowedTabs = GUI.allowedTabs.filter(tabName => tabName !== 'cli');
+                }
                 privateScope.onConnect();
 
                 defaultsDialog.init().then( () => {
@@ -421,6 +497,8 @@ var SerialBackend = (function () {
 
             store.set('last_used_bps', CONFIGURATOR.connection.bitrate);
             store.set('wireless_mode_enabled', $('#wireless-mode').is(":checked"));
+            store.set('wireless_mavlink_tunnel_enabled', $('#wireless-mavlink-tunnel').is(":checked"));
+            store.set('wireless_mavlink_sysid', $('#wireless-mavlink-sysid').val());
 
             // Reset state BEFORE adding receive listeners to ensure any
             // garbage bytes or boot messages don't corrupt the MSP decoder
@@ -428,14 +506,33 @@ var SerialBackend = (function () {
             MSP.disconnect_cleanup();
             privateScope.ltmProtocolGate.reset();
 
+            privateScope.mavlinkHandshakeStarted = false;
+            privateScope.mavlinkTunnel = null;
+            CONFIGURATOR.mavlinkTunnelActive = privateScope.isMavlinkTunnelEnabled();
+
+            if (privateScope.isMavlinkTunnelEnabled()) {
+                privateScope.mavlinkTunnel = new MavlinkMspTunnel();
+                privateScope.mavlinkTunnel.configure(parseInt($('#wireless-mavlink-sysid').val(), 10) || 0);
+                MSP.setTransportTransform((buffer) => privateScope.mavlinkTunnel.wrapMspFrame(buffer));
+                CONFIGURATOR.connection.setTimeoutOverride(5000);
+            } else {
+                MSP.setTransportTransform(null);
+                CONFIGURATOR.connection.setTimeoutOverride(null);
+            }
+
             CONFIGURATOR.connection.addOnReceiveListener(publicScope.read_serial);
-            CONFIGURATOR.connection.addOnReceiveListener(publicScope.read_ltm);
+            if (!privateScope.isMavlinkTunnelEnabled()) {
+                CONFIGURATOR.connection.addOnReceiveListener(publicScope.read_ltm);
+            }
 
             // disconnect after 10 seconds with error if we don't get IDENT data
             timeout.add('connecting', function () {
 
                 //As we add LTM listener, we need to invalidate connection only when both protocols are not listening!
                 if (!CONFIGURATOR.connectionValid && !ltmDecoder.isReceiving()) {
+                    if (privateScope.isMavlinkTunnelEnabled() && privateScope.mavlinkTunnel && !privateScope.mavlinkTunnel.isTargetReady()) {
+                        GUI.log(i18n.getMessage('mavlinkTunnelHeartbeatTimeout'));
+                    }
                     GUI.log(i18n.getMessage('noConfigurationReceived'));
 
                         mspQueue.flush();
@@ -455,44 +552,12 @@ var SerialBackend = (function () {
                 privateScope.ltmProtocolGate.activateGroundstationIfLtmOnly();
             }, 1000);
 
-            // request configuration data. Start with MSPv1 and
-            // upgrade to MSPv2 if possible.
-            MSP.protocolVersion = MSP.constants.PROTOCOL_V2;
-            MSP.send_message(MSPCodes.MSP_API_VERSION, false, false, function () {
-
-                if (FC.CONFIG.apiVersion === "0.0.0") {
-                    GUI.log("<span style='color: red; font-weight: bolder'><strong>" + i18n.getMessage("illegalStateRestartRequired") + "</strong></span>");
-                    FC.restartRequired = true;
-                    return;
-                }
-
-                GUI.log(i18n.getMessage('apiVersionReceived', [FC.CONFIG.apiVersion]));
-
-                MSP.send_message(MSPCodes.MSP_FC_VARIANT, false, false, function () {
-                    if (FC.CONFIG.flightControllerIdentifier == 'INAV') {
-                        MSP.send_message(MSPCodes.MSP_FC_VERSION, false, false, function () {
-
-                            GUI.log(i18n.getMessage('fcInfoReceived', [FC.CONFIG.flightControllerIdentifier, FC.CONFIG.flightControllerVersion]));
-                            if (semver.gte(FC.CONFIG.flightControllerVersion, CONFIGURATOR.minfirmwareVersionAccepted) && semver.lt(FC.CONFIG.flightControllerVersion, CONFIGURATOR.maxFirmwareVersionAccepted)) {
-                                if (CONFIGURATOR.connection.type == ConnectionType.BLE && semver.lt(FC.CONFIG.flightControllerVersion, "5.0.0")) {
-                                    privateScope.onBleNotSupported();
-                                } else {
-                                    mspHelper.getCraftName(function(name) {
-                                        if (name) {
-                                            FC.CONFIG.name = name;
-                                        }
-                                        privateScope.onValidFirmware();
-                                    });
-                                }
-                            } else  {
-                                privateScope.onInvalidFirmwareVersion();
-                            }
-                        });
-                    } else {
-                        privateScope.onInvalidFirmwareVariant();
-                    }
-                });
-            });
+            if (privateScope.isMavlinkTunnelEnabled()) {
+                const configuredSysid = parseInt($('#wireless-mavlink-sysid').val(), 10) || 0;
+                GUI.log(i18n.getMessage('mavlinkTunnelWaitingHeartbeat', [configuredSysid]));
+            } else {
+                privateScope.startHandshake();
+            }
         } else {
             console.log('Failed to open serial port');
             GUI.log(i18n.getMessage('serialPortOpenFail'));
@@ -570,6 +635,24 @@ var SerialBackend = (function () {
     }
 
     publicScope.read_serial = function (info) {
+        if (privateScope.mavlinkTunnel) {
+            const tunnelInfo = privateScope.mavlinkTunnel.ingest(info.data);
+            if (tunnelInfo.targetDiscovered && !privateScope.mavlinkHandshakeStarted) {
+                GUI.log(i18n.getMessage('mavlinkTunnelHeartbeatDetected', [privateScope.mavlinkTunnel.getTargetSystemId()]));
+                privateScope.startHandshake();
+            }
+
+            if (!CONFIGURATOR.cliActive) {
+                for (let index = 0; index < tunnelInfo.mspFrames.length; index++) {
+                    MSP.read({
+                        connectionId: info.connectionId,
+                        data: tunnelInfo.mspFrames[index],
+                    });
+                }
+            }
+            return;
+        }
+
         if (!CONFIGURATOR.cliActive) {
             MSP.read(info);
         } else if (CONFIGURATOR.cliActive) {

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -688,6 +688,9 @@
     "tabSwitchUpgradeRequired": {
         "message": "You need to <strong>upgrade</strong> your firmware before you can use the $1 tab."
     },
+    "tabSwitchMavlinkTunnelUnavailable": {
+        "message": "CLI is not available over MAVLink tunnel mode."
+    },
     "firmwareVersion": {
         "message": "Firmware Version: <strong>$1</strong>"
     },
@@ -3537,6 +3540,21 @@
     },
     "wirelessModeSwitch": {
         "message": "Wireless mode"
+    },
+    "wirelessMavlinkTunnelSwitch": {
+        "message": "MAVLink Tunnel"
+    },
+    "wirelessMavlinkSysidLabel": {
+        "message": "SysID"
+    },
+    "mavlinkTunnelWaitingHeartbeat": {
+        "message": "Waiting for MAVLink heartbeat ($1)"
+    },
+    "mavlinkTunnelHeartbeatDetected": {
+        "message": "MAVLink heartbeat detected on SYSID $1"
+    },
+    "mavlinkTunnelHeartbeatTimeout": {
+        "message": "No MAVLink heartbeat received for tunnel mode"
     },
     "rthConfiguration": {
         "message": "RTH Settings"

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -181,7 +181,7 @@ input[type="number"]::-webkit-inner-spin-button {
     float: right;
     margin-top: 20px;
     margin-right: 20px;
-    width: 450px;
+    width: 540px;
 }
 
 #portsinput .dropdown {
@@ -232,6 +232,10 @@ input[type="number"]::-webkit-inner-spin-button {
     top: 2px;
 }
 
+#mavlink-sysid-option {
+    width: 85px !important;
+}
+
 .portsinput__row {
     text-align: right;
 }
@@ -254,8 +258,29 @@ input[type="number"]::-webkit-inner-spin-button {
     top: 1px;
 }
 
+#mavlink-sysid-option label {
+    color: #ddd;
+    position: relative;
+    top: 1px;
+    float: left;
+}
+
 #port-override input {
     width: 136px;
+}
+
+#wireless-mavlink-sysid {
+    background-color: rgba(0, 0, 0, 0.1);
+    color: #888888;
+    width: 44px;
+    margin-left: 2px;
+    margin-top: 0;
+    padding: 1px;
+    border-radius: 3px;
+    height: 15px;
+    font-size: 12px;
+    float: right;
+    text-align: right;
 }
 
 #header_dataflash {


### PR DESCRIPTION
Talk MSP to a flight controller over a MAVLink link, by wrapping MSP frames in MAVLink `TUNNEL` messages. This is the Configurator half of the firmware support merged in iNavFlight/inav#11718.

Without this, a vehicle on a MAVLink radio link has to be unplugged from its telemetry setup and connected over USB to change anything. With it, the Configurator connects through the same link the GCS uses. 

Note that it may be very slow due to the very nature of Mavlink and tunneling.

## Using it

A **MAVLink Tunnel** toggle appears next to Wireless mode, with an optional **SysID** to pin one vehicle when several share the link (0 = first heartbeat seen).

The Configurator waits for a `HEARTBEAT` before starting the MSP handshake, so it knows which system to address, then chunks outgoing MSP frames to the 128-byte `TUNNEL` payload and reassembles the replies addressed back to it.

## Requirements and limitations

- Needs firmware with `USE_MAVLINK_MSP_TUNNEL` (`maintenance-10.x` and later; enabled for any target with MAVLink telemetry that does not opt out via `DISABLE_MAVLINK_MSP_TUNNEL`).
- MAVLink 2 only — `TUNNEL` is message 385.
- The **CLI tab is unavailable** while tunnelling, and LTM decoding is disabled on the port. Neither survives the framing, so both are switched off rather than left to fail confusingly.
- Large configuration pages are noticeably slower over a radio link than over USB. The link's telemetry bandwidth, not the tunnel framing, is the limit.

## Three commits

**`Fix UDP connection lifecycle and udpClose IPC handler`** — two pre-existing bugs, unrelated to MAVLink, found while testing the tunnel over UDP:

- The dgram socket was created once at module import and `close()` called `socket.disconnect()`, which throws on a socket that was only bound, so a UDP connection could not be reopened after being closed. The socket is now created per connection and closed properly, and sends fail cleanly once it is gone instead of resolving nothing.
- `js/main/preload.js` already calls `udpClose()` through `ipcRenderer.invoke()`, but the main process registered it with `ipcMain.on()`, so the promise in `connectionUdp.js` never settled. Registered with `ipcMain.handle()` now.

Separated so they can be reviewed — or reverted — on their own.

**`Add MSP-over-MAVLink tunnel transport`** — the tunnel itself: `js/mavlink/mspTunnel.js` plus the connection plumbing, a transport hook in `js/msp.js`, and the UI.

**`Offer baud rates above 115200 when connecting`** — the connection baud dropdown stopped at 115200, so an ELRS MAVLink link at 460800 could not be opened at all, making the tunnel unreachable over the most common radio it would be used with. Adds 230400, 460800 and 921600.

## Testing

**On hardware:** an H743 over an ELRS MAVLink link at 460800 and MLRS link at 115200. The tunnel connects and the vehicle is configurable through it.

Against SITL built from `maintenance-10.x` (`8d0e6825`), with UART2 as a MAVLink telemetry port and no MSP on it:

| | Result |
|---|---|
| Plain MSP on the MSP port | Connects, handshake completes |
| **Control: MAVLink port, tunnel off** | `No configuration received within 10 seconds` — correctly fails |
| MAVLink port, tunnel on | Heartbeat detected on SYSID 1, full handshake, FC identified |
| Modes and Configuration tabs over the tunnel | Both load, 63 populated inputs — multi-chunk frames past the 128-byte payload work |
| CLI tab while tunnelling | Refused with an explanatory message |
| Disconnect, then reconnect without the tunnel | Clean; tunnel state resets |

The control row isolates the tunnel as the cause: same port, same firmware, tunnel off is dead and tunnel on is a working MSP session. Status bar read `MSP version: 2`, `MSP round trip: 44 ms`, **`Packet error: 0`** — no framing corruption.

Protocol details were cross-checked against `src/main/fc/fc_mavlink.c`: payload type `0x8001`, 128-byte chunking matching `MAVLINK_MSG_TUNNEL_FIELD_PAYLOAD_LEN`, the FC accepting `target_component == 0`, and the MAVLink 2 trailing-zero truncation of the FC's zero-padded reply.