### PR TITLE
fix(cli): stop syncing raw FC output into command box during autocomplete build

### DIFF
--- a/tabs/cli.js
+++ b/tabs/cli.js
@@ -518,12 +518,15 @@ cliTab.read = function (readInfo) {
         }
     }
 
-    // fallback to native autocomplete
+    // Mirror the FC's line buffer into the command textarea. This is only correct as a
+    // "fallback to native autocomplete" when nothing else is driving the textarea: while the
+    // autocomplete cache builder is running (silently sending `help`/`dump`/`get` right after
+    // CLI entry, see CliAutoComplete.builderStart), this would splash fragments of that hidden
+    // output into the command box instead of the user's own input, so it must stay gated behind
+    // the same isEnabled() check used above rather than always running unconditionally.
     if (!CliAutoComplete.isEnabled()) {
         setPrompt(removePromptHash(this.cliBuffer));
     }
-
-    setPrompt(removePromptHash(this.cliBuffer));
 
     if (cliTab.promptCallback && this.cliBuffer.endsWith('# ')) {
         const cb = cliTab.promptCallback;


### PR DESCRIPTION
### What
Entering the CLI tab with autocomplete enabled showed random/garbled characters in the command entry box for ~15-20 seconds after connecting, which then settled down once the tab became usable (v9.1.1).

### Why
`cliTab.read()` had a leftover unconditional `setPrompt(this.cliBuffer)` call that mirrors the FC's incoming line buffer into the command textarea on every serial read. When CliAutoComplete was added (21a41698), a second, gated `setPrompt()` call was introduced above it to only run this "native fallback" echo when autocomplete is *not* enabled - but the original unconditional call was left in place below it, so it kept firing regardless. That meant every chunk of the autocomplete builder's hidden `help`/`dump`/`get` traffic (used to enumerate every FC setting on CLI entry) was written straight into the user's command box for as long as the cache build took.

### Fix
Remove the redundant unconditional call; keep only the one already gated by `!CliAutoComplete.isEnabled()`, matching how `writeLineToOutput()` already suppresses builder traffic.

### Testing
Reproduced by opening the CLI tab against an FC with autocomplete enabled; confirmed the command box previously filled with garbage during "Building AutoComplete Cache..." and stays clean with this fix