### PR TITLE
Add openAIP airspace and airport overlays to Mission Control

### DIFF
--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -647,6 +647,7 @@ $(function() {
                         $(this).val(apiKey);
                         store.set('openaip_api_key', apiKey);
                         globalSettings.openaipApiKey = apiKey;
+                        GUI.active_tab?.onOpenAipKeyChanged?.();
                     });
                     $('#google-api-key-test').on('click', testGoogleApiKey);
                     $('#google-api-key-help').on('click', showGoogleApiHelp);

--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -224,6 +224,7 @@ $(function() {
         globalSettings.mapProviderType = store.get('map_provider_type', 'osm'); 
         globalSettings.assistnowApiKey = store.get('assistnow_api_key', '');
         globalSettings.googleApiKey = store.get('google_api_key', '');
+        globalSettings.openaipApiKey = store.get('openaip_api_key', '');
         globalSettings.proxyURL = store.get('proxyurl', 'http://192.168.1.222/mapproxy/service?');
         globalSettings.proxyLayer = store.get('proxylayer', 'your_proxy_layer_name');
         globalSettings.showProfileParameters = store.get('show_profile_parameters', 1);
@@ -589,6 +590,7 @@ $(function() {
                     $('#cliAutocomplete').prop('checked', globalSettings.cliAutocomplete);
                     $('#assistnow-api-key').val(globalSettings.assistnowApiKey);
                     $('#google-api-key').val(globalSettings.googleApiKey);
+                    $('#openaip-api-key').val(globalSettings.openaipApiKey);
                     
                     i18n.getLanguages().forEach(lng => {
                         $('#languageOption').append("<option value='{0}'>{1}</option>".format(lng, i18n.getMessage("language_" + lng)));
@@ -639,6 +641,12 @@ $(function() {
                         $(this).val(apiKey);
                         store.set('google_api_key', apiKey);
                         globalSettings.googleApiKey = apiKey;
+                    });
+                    $('#openaip-api-key').on('change', function () {
+                        const apiKey = String($(this).val() || '').trim();
+                        $(this).val(apiKey);
+                        store.set('openaip_api_key', apiKey);
+                        globalSettings.openaipApiKey = apiKey;
                     });
                     $('#google-api-key-test').on('click', testGoogleApiKey);
                     $('#google-api-key-help').on('click', showGoogleApiHelp);

--- a/js/globalSettings.js
+++ b/js/globalSettings.js
@@ -23,6 +23,7 @@ var globalSettings = {
     cliAutocomplete: true,
     assistnowApiKey: null,
     googleApiKey: null,
+    openaipApiKey: null,
     assistnowOfflineData: [],
     assistnowOfflineDate: 0,
     store: null,

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6938,6 +6938,15 @@
     "gpsOptionsAssistnowToken": {
         "message": "AssitNow Token"
     },
+    "openaipOptions": {
+        "message": "Airspace data (openAIP)"
+    },
+    "openaipApiKey": {
+        "message": "openAIP API key"
+    },
+    "openaipApiKeyHelp": {
+        "message": "Lets Mission Control show airspace and airport overlays on the map. Register for free at <a href=\"https://www.openaip.net\" target=\"_blank\">openaip.net</a> and create an API key in your account settings. The key is stored locally and only sent to the openAIP tile server."
+    },
     "googleLocationServices": {
         "message": "Google Location & Weather Services"
     },
@@ -7114,6 +7123,15 @@
     },
     "layerDragDropHint": {
         "message": "or drag & drop GEO files onto the map"
+    },
+    "layerOpenAipAirspaces": {
+        "message": "Airspaces (openAIP)"
+    },
+    "layerOpenAipAirports": {
+        "message": "Airports (openAIP)"
+    },
+    "layerOpenAipNoKey": {
+        "message": "Airspace and airport overlays need a free openAIP API key. Enter it in the Options."
     },
     "layerConfirmDelete": {
         "message": "Are you sure you want to delete this layer?"

--- a/src/css/tabs/mission_planer.css
+++ b/src/css/tabs/mission_planer.css
@@ -753,6 +753,13 @@
     background-color: rgba(255, 255, 255, 0.05);
 }
 
+.tab-mission-control .openaip-no-key {
+    padding: 6px 5px;
+    color: #888;
+    font-size: 0.9em;
+    font-style: italic;
+}
+
 .tab-mission-control #geo_info {
     transition: opacity 0.2s;
 }

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -150,6 +150,8 @@
                                title="Load GEO File (KML, GeoJSON, GPX)"></a>
                         </div>
                         <hr>
+                        <div id="openaipLayerList" style="padding: 0 5px;"></div>
+                        <hr>
                         <div id="layerListContainer" style="padding: 0 5px;"></div>
                         <hr>
                         <div style="text-align: center; color: #888; font-size: 0.9em; margin-top: 10px;">

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2981,15 +2981,36 @@ function iconKey(filename) {
         return String(globalSettings.openaipApiKey || '').trim();
     }
 
-    function createOpenAipLayer(overlay, visible) {
+    function createOpenAipSource(overlayId) {
         // openAIP tile server v2: raster tiles up to zoom 14, key as query parameter,
         // four subdomains for load balancing (see https://docs.openaip.net)
+        return new XYZ({
+            url: 'https://{0-3}.api.tiles.openaip.net/api/data/' + overlayId + '/{z}/{x}/{y}.png?apiKey=' + encodeURIComponent(openAipApiKey()),
+            attributions: '<a href="https://www.openaip.net" target="_blank">openAIP</a>',
+            maxZoom: 14
+        });
+    }
+
+    missionControlTab.onOpenAipKeyChanged = function () {
+        if (!map) {
+            return;
+        }
+        const visibility = store.get(OPENAIP_VISIBILITY_KEY, {});
+        const hasKey = openAipApiKey() !== '';
+        map.getLayers().forEach(layer => {
+            const overlayId = layer.get('openaip_overlay');
+            if (overlayId) {
+                layer.setVisible(false);
+                layer.setSource(hasKey ? createOpenAipSource(overlayId) : null);
+                layer.setVisible(hasKey && visibility[overlayId] === true);
+            }
+        });
+        updateOpenAipLayerListUI();
+    };
+
+    function createOpenAipLayer(overlay, visible) {
         const layer = new TileLayer({
-            source: new XYZ({
-                url: 'https://{0-3}.api.tiles.openaip.net/api/data/' + overlay.id + '/{z}/{x}/{y}.png?apiKey=' + encodeURIComponent(openAipApiKey()),
-                attributions: '<a href="https://www.openaip.net" target="_blank">openAIP</a>',
-                maxZoom: 14
-            }),
+            source: createOpenAipSource(overlay.id),
             opacity: 0.85,
             visible: visible
         });
@@ -7049,6 +7070,7 @@ missionControlTab.setBit = function(bits, bit, value) {
 // }
 
 missionControlTab.cleanup = function (callback) {
+    missionControlTab.onOpenAipKeyChanged = null;
     cleanupMissionControlLocationResources();
     if (elevationChartInstance) {
         elevationChartInstance.destroy();

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2967,6 +2967,88 @@ function iconKey(filename) {
 
     /////////////////////////////////////////////
     //
+    // openAIP airspace / airport tile overlays
+    //
+    /////////////////////////////////////////////
+
+    const OPENAIP_OVERLAYS = [
+        { id: 'airspaces', label: 'layerOpenAipAirspaces' },
+        { id: 'airports', label: 'layerOpenAipAirports' },
+    ];
+    const OPENAIP_VISIBILITY_KEY = 'openaip_overlay_visibility';
+
+    function openAipApiKey() {
+        return String(globalSettings.openaipApiKey || '').trim();
+    }
+
+    function createOpenAipLayer(overlay, visible) {
+        // openAIP tile server v2: raster tiles up to zoom 14, key as query parameter,
+        // four subdomains for load balancing (see https://docs.openaip.net)
+        const layer = new TileLayer({
+            source: new XYZ({
+                url: 'https://{0-3}.api.tiles.openaip.net/api/data/' + overlay.id + '/{z}/{x}/{y}.png?apiKey=' + encodeURIComponent(openAipApiKey()),
+                attributions: '<a href="https://www.openaip.net" target="_blank">openAIP</a>',
+                maxZoom: 14
+            }),
+            opacity: 0.85,
+            visible: visible
+        });
+        layer.set('name', i18n.getMessage(overlay.label));
+        layer.set('openaip_overlay', overlay.id);
+        layer.set('no_interaction', true);
+        map.addLayer(layer);
+        return layer;
+    }
+
+    function addOpenAipLayers() {
+        const visibility = store.get(OPENAIP_VISIBILITY_KEY, {});
+        const hasKey = openAipApiKey() !== '';
+
+        OPENAIP_OVERLAYS.forEach(overlay => {
+            createOpenAipLayer(overlay, hasKey && visibility[overlay.id] === true);
+        });
+        updateOpenAipLayerListUI();
+    }
+
+    function updateOpenAipLayerListUI() {
+        const $container = $('#openaipLayerList').empty();
+        const hasKey = openAipApiKey() !== '';
+
+        map.getLayers().forEach(layer => {
+            const overlayId = layer.get('openaip_overlay');
+            if (!overlayId) {
+                return;
+            }
+            const inputId = 'openaip_layer_' + overlayId;
+            $container.append(`
+                <div class="layer-item" style="display: flex; align-items: center; padding: 8px 5px; border-bottom: 1px solid #444;">
+                    <input id="${inputId}" type="checkbox" class="togglemedium openaip-layer-toggle" data-overlay-id="${overlayId}" ${layer.getVisible() ? 'checked' : ''} ${hasKey ? '' : 'disabled'} style="flex-shrink: 0;">
+                    <label for="${inputId}" style="margin-left: 8px; cursor: pointer; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${layer.get('name')}</label>
+                </div>
+            `);
+        });
+
+        if (!hasKey) {
+            $container.append($('<div class="openaip-no-key"></div>').text(i18n.getMessage('layerOpenAipNoKey')));
+        }
+
+        GUI.switchery();
+        $('.openaip-layer-toggle').on('change', function () {
+            const overlayId = $(this).attr('data-overlay-id');
+            const isChecked = $(this).is(':checked');
+            map.getLayers().forEach(layer => {
+                if (layer.get('openaip_overlay') === overlayId) {
+                    layer.setVisible(isChecked);
+                }
+            });
+            const visibility = store.get(OPENAIP_VISIBILITY_KEY, {});
+            visibility[overlayId] = isChecked;
+            store.set(OPENAIP_VISIBILITY_KEY, visibility);
+        });
+    }
+
+    /////////////////////////////////////////////
+    //
     // Layer Management Functions
     //
     /////////////////////////////////////////////
@@ -4269,6 +4351,8 @@ function iconKey(filename) {
         }
 
         initializeMapLocation();
+
+        addOpenAipLayers();
 
         //////////////////////////////////////////////////////////////////////////
         // Load previously saved GEO files from electron store

--- a/tabs/options.html
+++ b/tabs/options.html
@@ -125,6 +125,20 @@
                     <a id="google-api-key-help" href="#" data-i18n="googleLocationHelpButton">Help and setup instructions</a>
                 </div>
                 <output id="google-api-key-result" aria-live="polite"></output>
+                <div class="clear-both"></div>
+            </div>
+        </div>
+        <div class="options-section gui_box grey">
+            <div class="gui_box_titlebar">
+                <div class="spacer_box_title" data-i18n="openaipOptions"></div>
+            </div>
+
+            <div class="spacer_box settings">
+                <div class="number">
+                    <input type="password" id="openaip-api-key" autocomplete="off" />
+                    <label for="openaip-api-key" data-i18n="openaipApiKey"></label>
+                </div>
+                <div class="note" data-i18n="openaipApiKeyHelp"></div>
             </div>
         </div>
     </div>

--- a/tabs/options.html
+++ b/tabs/options.html
@@ -136,7 +136,7 @@
             <div class="spacer_box settings">
                 <div class="number">
                     <input type="password" id="openaip-api-key" autocomplete="off" />
-                    <label for="openaip-api-key" data-i18n="openaipApiKey"></label>
+                    <label for="openaip-api-key" data-i18n="openaipApiKey">openAIP API key</label>
                 </div>
                 <div class="note" data-i18n="openaipApiKeyHelp"></div>
             </div>


### PR DESCRIPTION
## Problem
Mission Control's Map Layers box only lists GEO files the user loads themselves (KML/GeoJSON/GPX). There is no built-in airspace or airport information, so controlled zones (CTR, TMA, restricted, prohibited) are not visible while a mission is planned. Issue #1181 (Mission Planner roadmap) still lists "connect to airspace area limitation: to display zones with ceilings depending on the national regulation" as an open item.

## Cause
`tabs/mission_control.js:4698` on `maintenance-10.x`: after `initializeMapLocation()` the map only restores the saved GEO layers from `custom_overlay_list` (lines 4701-4712), and `tabs/mission_control.html:193` (`#layerListContainer`) is the only list in the Map Layers box. No overlay data source exists.

## Change
Adds two `TileLayer`/`XYZ` overlays in `tabs/mission_control.js` (`https://{0-3}.api.tiles.openaip.net/api/data/<airspaces|airports>/{z}/{x}/{y}.png?apiKey=...`, max zoom 14, opacity 0.85, openAIP attribution, `no_interaction`), inserted after `initializeMapLocation()` and before the saved GEO layers are restored. Their toggles render into a new `#openaipLayerList` in `tabs/mission_control.html`; without a key they are disabled with a hint, and each overlay's visibility is stored in `openaip_overlay_visibility`. The Options window gets an "Airspace data (openAIP)" section (`tabs/options.html`); the key is stored as `openaip_api_key` via `js/configurator_main.js` and `js/globalSettings.js`, trimmed on change, and `missionControlTab.onOpenAipKeyChanged` rebuilds the tile sources when it changes (cleared in `cleanup`). Six English strings, a `.openaip-no-key` style and a `clear-both` div after the Google API key buttons complete the diff.

## Test
No test file is added and no test log is attached. Not verified with a real openAIP key: the tiles have not been seen rendering in the configurator. Built by CI on `cbafccd`, all seven platform jobs green: https://github.com/iNavFlight/inav-configurator/actions/runs/34617523721. SonarCloud quality gate passed, 0 new issues: https://sonarcloud.io/dashboard?id=iNavFlight_inav-configurator&pullRequest=2745. Qodo's single finding (a key change not reaching an already open Mission Control tab) is addressed by commit `cbafccd`.

## Flash / RAM
Not applicable (Configurator).

## Docs
`README.md`: a new "Airspace Overlays (openAIP)" section next to the existing map-provider and MapTiler-key documentation, covering both switches, how to get a free openAIP key, and a note that the data is advisory.
