### PR TITLE
Add a copy-profile dialog to the header profile dropdowns

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
             <div class="header-wrapper">
                 <div id="profiles_wrapper_global">
                     <div id="profile_change">
+                        <a class="profile-copy" data-profile-type="0" href="#" data-i18n_title="copyProfileTooltip"></a>
                         <div class="dropdown dropdown-dark">
                             <form name="profile-change" id="profile-change">
                                 <!--suppress HtmlFormInputWithoutLabel -->
@@ -96,6 +97,7 @@
                         </div>
                     </div>
                     <div id="mixer_profile_change">
+                        <a class="profile-copy" data-profile-type="2" href="#" data-i18n_title="copyProfileTooltip"></a>
                         <div class="dropdown  dropdown-dark">
                             <form name="mixer-profile-change" id="mixer-profile-change">
                                 <select class="dropdown-select" id="mixerprofilechange" data-i18n_title="mixerProfileTitle">
@@ -106,6 +108,7 @@
                         </div>
                     </div>
                     <div id="battery_profile_change">
+                        <a class="profile-copy" data-profile-type="1" href="#" data-i18n_title="copyProfileTooltip"></a>
                         <div class="dropdown dropdown-dark">
                             <form name="battery-profile-change" id="battery-profile-change">
                                 <!--suppress HtmlFormInputWithoutLabel -->
@@ -459,6 +462,25 @@
             <div class="data-loading">
                 <p i18n="waitingForData"></p>
             </div>
+        </div>
+    </div>
+    <div id="modal-copy-profile" class="is-hidden">
+        <div class="modal__content">
+            <h1 class="modal__title" data-i18n="copyProfileTitle"></h1>
+            <div class="modal__text">
+                <span data-i18n="copyProfileFrom"></span>
+                <strong id="copy-profile-kind"></strong>
+                <strong id="copy-profile-from"></strong>
+            </div>
+            <div class="modal__text">
+                <label for="copy-profile-to" data-i18n="copyProfileTo">to</label>
+                <select id="copy-profile-to"></select>
+            </div>
+            <div class="modal__text" data-i18n="copyProfileWarning"></div>
+        </div>
+        <div class="modal__buttons">
+            <a id="copy-profile-cancel" class="modal__button" data-i18n="copyProfileCancel"></a>
+            <a id="copy-profile-confirm" class="modal__button modal__button--main" data-i18n="copyProfileButton"></a>
         </div>
     </div>
     <div id="modal-reconnect" class="is-hidden">

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
             <div class="header-wrapper">
                 <div id="profiles_wrapper_global">
                     <div id="profile_change">
-                        <a class="profile-copy" data-profile-type="0" href="#" data-i18n_title="copyProfileTooltip"></a>
+                        <a class="profile-copy" data-profile-type="0" href="#" data-i18n_title="copyProfileTooltip" aria-label="Copy this profile to another slot"></a>
                         <div class="dropdown dropdown-dark">
                             <form name="profile-change" id="profile-change">
                                 <!--suppress HtmlFormInputWithoutLabel -->
@@ -97,7 +97,7 @@
                         </div>
                     </div>
                     <div id="mixer_profile_change">
-                        <a class="profile-copy" data-profile-type="2" href="#" data-i18n_title="copyProfileTooltip"></a>
+                        <a class="profile-copy" data-profile-type="2" href="#" data-i18n_title="copyProfileTooltip" aria-label="Copy this profile to another slot"></a>
                         <div class="dropdown  dropdown-dark">
                             <form name="mixer-profile-change" id="mixer-profile-change">
                                 <select class="dropdown-select" id="mixerprofilechange" data-i18n_title="mixerProfileTitle">
@@ -108,7 +108,7 @@
                         </div>
                     </div>
                     <div id="battery_profile_change">
-                        <a class="profile-copy" data-profile-type="1" href="#" data-i18n_title="copyProfileTooltip"></a>
+                        <a class="profile-copy" data-profile-type="1" href="#" data-i18n_title="copyProfileTooltip" aria-label="Copy this profile to another slot"></a>
                         <div class="dropdown dropdown-dark">
                             <form name="battery-profile-change" id="battery-profile-change">
                                 <!--suppress HtmlFormInputWithoutLabel -->
@@ -466,7 +466,7 @@
     </div>
     <div id="modal-copy-profile" class="is-hidden">
         <div class="modal__content">
-            <h1 class="modal__title" data-i18n="copyProfileTitle"></h1>
+            <h1 class="modal__title" data-i18n="copyProfileTitle">Copy profile</h1>
             <div class="modal__text">
                 <span data-i18n="copyProfileFrom"></span>
                 <strong id="copy-profile-kind"></strong>
@@ -479,8 +479,8 @@
             <div class="modal__text" data-i18n="copyProfileWarning"></div>
         </div>
         <div class="modal__buttons">
-            <a id="copy-profile-cancel" class="modal__button" data-i18n="copyProfileCancel"></a>
-            <a id="copy-profile-confirm" class="modal__button modal__button--main" data-i18n="copyProfileButton"></a>
+            <a id="copy-profile-cancel" class="modal__button" data-i18n="copyProfileCancel">Cancel</a>
+            <a id="copy-profile-confirm" class="modal__button modal__button--main" data-i18n="copyProfileButton">Copy</a>
         </div>
     </div>
     <div id="modal-reconnect" class="is-hidden">

--- a/index.html
+++ b/index.html
@@ -479,8 +479,8 @@
             <div class="modal__text" data-i18n="copyProfileWarning"></div>
         </div>
         <div class="modal__buttons">
-            <a id="copy-profile-cancel" class="modal__button" data-i18n="copyProfileCancel">Cancel</a>
-            <a id="copy-profile-confirm" class="modal__button modal__button--main" data-i18n="copyProfileButton">Copy</a>
+            <button type="button" id="copy-profile-cancel" class="modal__button" data-i18n="copyProfileCancel">Cancel</button>
+            <button type="button" id="copy-profile-confirm" class="modal__button modal__button--main" data-i18n="copyProfileButton">Copy</button>
         </div>
     </div>
     <div id="modal-reconnect" class="is-hidden">

--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -816,6 +816,66 @@ $(function() {
             });
         });
 
+        // Copy the active control / battery / mixer profile onto another slot (MSP2_INAV_COPY_PROFILE)
+        const profileCopyKinds = {
+            0: { label: 'copyProfileKindControl', current: () => parseInt(profile_e.val()), count: () => profile_e.find('option').length },
+            1: { label: 'copyProfileKindBattery', current: () => parseInt(batteryprofile_e.val()), count: () => batteryprofile_e.find('option').length },
+            2: { label: 'copyProfileKindMixer', current: () => parseInt(mixerprofile_e.val()), count: () => mixerprofile_e.find('option').length },
+        };
+        let profileCopyModal = null;
+        let profileCopyRequest = null;
+
+        $('#profiles_wrapper_global .profile-copy').on('click', function (event) {
+            event.preventDefault();
+
+            const type = parseInt($(this).attr('data-profile-type'));
+            const kind = profileCopyKinds[type];
+            const fromIndex = kind.current();
+            const $to = $('#copy-profile-to').empty();
+
+            for (let i = 0; i < kind.count(); i++) {
+                if (i !== fromIndex) {
+                    $to.append($('<option>').val(i).text(i18n.getMessage('copyProfileSlot', [i + 1])));
+                }
+            }
+            $('#copy-profile-kind').text(i18n.getMessage(kind.label));
+            $('#copy-profile-from').text(fromIndex + 1);
+            profileCopyRequest = { type: type, kind: kind, fromIndex: fromIndex };
+
+            // The template is moved into the jBox on first use, so keep a single instance
+            if (!profileCopyModal) {
+                profileCopyModal = new jBox('Modal', {
+                    width: 420,
+                    height: 240,
+                    animation: false,
+                    closeOnClick: false,
+                    closeOnEsc: true,
+                    content: $('#modal-copy-profile')
+                });
+            }
+            profileCopyModal.open();
+        });
+
+        $(document).on('click', '#copy-profile-cancel', function () {
+            profileCopyModal.close();
+        });
+
+        $(document).on('click', '#copy-profile-confirm', function () {
+            const toIndex = parseInt($('#copy-profile-to').val());
+            if (!profileCopyRequest || Number.isNaN(toIndex)) {
+                return;
+            }
+            const request = profileCopyRequest;
+            MSP.send_message(MSPCodes.MSP2_INAV_COPY_PROFILE, [request.type, request.fromIndex, toIndex], false, function () {
+                profileCopyModal.close();
+                if (MSP.unsupported) {
+                    GUI.log(i18n.getMessage('copyProfileFailed'));
+                    return;
+                }
+                GUI.log(i18n.getMessage('copyProfileDone', [i18n.getMessage(request.kind.label), request.fromIndex + 1, toIndex + 1]));
+            });
+        });
+
     });
 });
 

--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -824,10 +824,21 @@ $(function() {
         };
         let profileCopyModal = null;
         let profileCopyRequest = null;
+        let profileCopyInFlight = false;
+
+        GUI.resetProfileCopy = function () {
+            profileCopyRequest = null;
+            profileCopyInFlight = false;
+            $('#copy-profile-confirm').prop('disabled', false);
+            profileCopyModal?.close();
+        };
 
         $('#profiles_wrapper_global .profile-copy').on('click', function (event) {
             event.preventDefault();
 
+            if (!CONFIGURATOR.connectionValid || profileCopyInFlight) {
+                return;
+            }
             const type = Number.parseInt($(this).attr('data-profile-type'));
             const kind = profileCopyKinds[type];
             const fromIndex = kind.current();
@@ -853,7 +864,9 @@ $(function() {
                     content: $('#modal-copy-profile')
                 });
             }
+            $('#copy-profile-confirm').prop('disabled', false);
             profileCopyModal.open();
+            $('#copy-profile-to').trigger('focus');
         });
 
         $(document).on('click', '#copy-profile-cancel', function () {
@@ -862,18 +875,31 @@ $(function() {
 
         $(document).on('click', '#copy-profile-confirm', function () {
             const toIndex = Number.parseInt($('#copy-profile-to').val());
-            if (!profileCopyRequest || Number.isNaN(toIndex)) {
+            if (!CONFIGURATOR.connectionValid || profileCopyInFlight || !profileCopyRequest || Number.isNaN(toIndex)) {
                 return;
             }
             const request = profileCopyRequest;
-            MSP.send_message(MSPCodes.MSP2_INAV_COPY_PROFILE, [request.type, request.fromIndex, toIndex], false, function () {
-                profileCopyModal.close();
-                if (MSP.unsupported) {
+            profileCopyInFlight = true;
+            $('#copy-profile-confirm').prop('disabled', true);
+            const finishCopy = function (response) {
+                // A disconnect invalidates this request, including any late response.
+                if (profileCopyRequest !== request) {
+                    return;
+                }
+                GUI.resetProfileCopy();
+                if (!response) {
+                    GUI.log(i18n.getMessage('copyProfileTransportFailed'));
+                    return;
+                }
+                if (response.unsupported) {
                     GUI.log(i18n.getMessage('copyProfileFailed'));
                     return;
                 }
                 GUI.log(i18n.getMessage('copyProfileDone', [i18n.getMessage(request.kind.label), request.fromIndex + 1, toIndex + 1]));
-            });
+            };
+            if (MSP.send_message(MSPCodes.MSP2_INAV_COPY_PROFILE, [request.type, request.fromIndex, toIndex], false, finishCopy) === false) {
+                finishCopy(false);
+            }
         });
 
     });

--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -818,9 +818,9 @@ $(function() {
 
         // Copy the active control / battery / mixer profile onto another slot (MSP2_INAV_COPY_PROFILE)
         const profileCopyKinds = {
-            0: { label: 'copyProfileKindControl', current: () => parseInt(profile_e.val()), count: () => profile_e.find('option').length },
-            1: { label: 'copyProfileKindBattery', current: () => parseInt(batteryprofile_e.val()), count: () => batteryprofile_e.find('option').length },
-            2: { label: 'copyProfileKindMixer', current: () => parseInt(mixerprofile_e.val()), count: () => mixerprofile_e.find('option').length },
+            0: { label: 'copyProfileKindControl', current: () => Number.parseInt(profile_e.val()), count: () => profile_e.find('option').length },
+            1: { label: 'copyProfileKindBattery', current: () => Number.parseInt(batteryprofile_e.val()), count: () => batteryprofile_e.find('option').length },
+            2: { label: 'copyProfileKindMixer', current: () => Number.parseInt(mixerprofile_e.val()), count: () => mixerprofile_e.find('option').length },
         };
         let profileCopyModal = null;
         let profileCopyRequest = null;
@@ -828,7 +828,7 @@ $(function() {
         $('#profiles_wrapper_global .profile-copy').on('click', function (event) {
             event.preventDefault();
 
-            const type = parseInt($(this).attr('data-profile-type'));
+            const type = Number.parseInt($(this).attr('data-profile-type'));
             const kind = profileCopyKinds[type];
             const fromIndex = kind.current();
             const $to = $('#copy-profile-to').empty();
@@ -861,7 +861,7 @@ $(function() {
         });
 
         $(document).on('click', '#copy-profile-confirm', function () {
-            const toIndex = parseInt($('#copy-profile-to').val());
+            const toIndex = Number.parseInt($('#copy-profile-to').val());
             if (!profileCopyRequest || Number.isNaN(toIndex)) {
                 return;
             }

--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -241,6 +241,7 @@ var MSPCodes = {
     MSP2_INAV_EZ_TUNE_SET:              0x2071,
 
     MSP2_INAV_SELECT_MIXER_PROFILE:     0x2080,
+    MSP2_INAV_COPY_PROFILE:             0x2081,
     
     MSP2_ADSB_VEHICLE_LIST:             0x2090,
     MSP2_ADSB_LIMITS:                   0x2091,

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -268,6 +268,7 @@ var SerialBackend = (function () {
                             this.isDemoRunning = false;
                         }
 
+                        GUI.resetProfileCopy?.();
                         var wasConnected = CONFIGURATOR.connectionValid;
 
                         timeout.killAll();
@@ -551,6 +552,7 @@ var SerialBackend = (function () {
     }
 
     privateScope.onClosed = function (result) {
+        GUI.resetProfileCopy?.();
         if (result) { // All went as expected
             GUI.log(i18n.getMessage('serialPortClosedOk'));
         } else { // Something went wrong

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -2171,6 +2171,9 @@
     "copyProfileDone": {
         "message": "Copied $1 $2 to profile $3."
     },
+    "copyProfileTransportFailed": {
+        "message": "Profile copy could not be confirmed. Check the connection and destination profile before trying again."
+    },
     "copyProfileFailed": {
         "message": "The flight controller did not copy the profile: it needs a firmware with MSP2_INAV_COPY_PROFILE (INAV 10), must be disarmed, and the target slot must exist."
     },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -2135,6 +2135,45 @@
     "setMixerProfile": {
         "message": "Setting Mixer Profile: <strong style=\"color: #37a8db\">$1</strong>"
     },
+    "copyProfileTooltip": {
+        "message": "Copy this profile to another slot"
+    },
+    "copyProfileTitle": {
+        "message": "Copy profile"
+    },
+    "copyProfileFrom": {
+        "message": "Copy the active"
+    },
+    "copyProfileTo": {
+        "message": "to"
+    },
+    "copyProfileSlot": {
+        "message": "Profile $1"
+    },
+    "copyProfileKindControl": {
+        "message": "control profile"
+    },
+    "copyProfileKindBattery": {
+        "message": "battery profile"
+    },
+    "copyProfileKindMixer": {
+        "message": "mixer profile"
+    },
+    "copyProfileWarning": {
+        "message": "The destination profile is overwritten and saved to the flight controller right away."
+    },
+    "copyProfileButton": {
+        "message": "Copy"
+    },
+    "copyProfileCancel": {
+        "message": "Cancel"
+    },
+    "copyProfileDone": {
+        "message": "Copied $1 $2 to profile $3."
+    },
+    "copyProfileFailed": {
+        "message": "The flight controller did not copy the profile: it needs a firmware with MSP2_INAV_COPY_PROFILE (INAV 10), must be disarmed, and the target slot must exist."
+    },
     "setBatteryProfile": {
         "message": "Setting Battery Profile: <strong style=\"color: #37a8db\">$1</strong>"
     },

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1903,7 +1903,7 @@ dialog {
     color: white;
     font-size: 10px;
     margin-top: 20px;
-    width: 130px;
+    width: 150px;
     float: right;
     margin-right: 10px;
     line-height: 12px;
@@ -1916,7 +1916,7 @@ dialog {
 #profile_change {
     color: white;
     margin: 0px;
-    width: 130px;
+    width: 150px;
     float: left;
     line-height: 12px;
 }
@@ -1928,7 +1928,7 @@ dialog {
 #mixer_profile_change {
     color: white;
     margin: 0px;
-    width: 130px;
+    width: 150px;
     float: left;
     line-height: 12px;
 }
@@ -1940,13 +1940,37 @@ dialog {
 #battery_profile_change {
     color: white;
     margin: 0px;
-    width: 130px;
+    width: 150px;
     float: right;
     line-height: 12px;
 }
 
 #battery_profile_change > .dropdown {
     margin: 0px;
+}
+
+#profiles_wrapper_global .profile-copy {
+    float: right;
+    width: 14px;
+    height: 14px;
+    margin: 3px 0 0 4px;
+    opacity: 0.7;
+    background: no-repeat center / 12px 12px url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><rect x='1' y='1' width='9' height='9' rx='1.5' fill='none' stroke='white' stroke-width='1.6'/><rect x='6' y='6' width='9' height='9' rx='1.5' fill='%23222' stroke='white' stroke-width='1.6'/></svg>");
+}
+
+#profiles_wrapper_global .profile-copy:hover {
+    opacity: 1;
+}
+
+#profile_change > .dropdown,
+#mixer_profile_change > .dropdown,
+#battery_profile_change > .dropdown {
+    width: 130px;
+    float: left;
+}
+
+#modal-copy-profile select {
+    margin-left: 6px;
 }
 
 .dataflash-contents_global {


### PR DESCRIPTION
## Problem
The header offers three profile dropdowns (control, mixer, battery) that only switch the active slot. There is no way in the Configurator to duplicate a tuned profile onto another slot: a pilot who wants a second control, battery or mixer profile based on the current one has to retype every value. No issue is filed for this.

## Cause
`js/configurator_main.js:801-816` on `maintenance-10.x`: the dropdown handlers send only `MSP_SELECT_SETTING`, `MSP2_INAV_SELECT_BATTERY_PROFILE` and `MSP2_INAV_SELECT_MIXER_PROFILE`. `js/msp/MSPCodes.js:243` stops at `MSP2_INAV_SELECT_MIXER_PROFILE` (0x2080); a copy command exists only with iNavFlight/inav#11888.

## Change
`index.html` adds a copy icon (`.profile-copy`) beside each dropdown and a `#modal-copy-profile` template; `configurator_main.js` fills it with the active slot as source and the dropdown's other slots as targets, opens one jBox instance, and on Copy sends `MSP2_INAV_COPY_PROFILE` (0x2081, added to `MSPCodes.js`) with `[type, from, to]`. The callback distinguishes a queue failure (`copyProfileTransportFailed`), an unsupported reply (`copyProfileFailed`) and success (`copyProfileDone`); an in-flight flag disables the Copy button meanwhile, and `GUI.resetProfileCopy()` clears dialog and request on disconnect and port close (`serial_backend.js`). `locale/en/messages.json` gets the 14 strings; `main.css` widens the header profile columns from 130 to 150 px and adds the icon.

Depends on iNavFlight/inav#11888 (open).

## Test
SITL. Driven from this dialog against the CI-built SITL of iNavFlight/inav#11888 (fork run https://github.com/Raffi1202/inav/actions/runs/34391346661, `inav-9.1.0-ci-20260909-91fab5f_SITL-WIN`): battery profile 2 -> 3 logs "Copied battery profile 2 to profile 3"; after setting roll P of control profile 1 to 77 and copying 1 -> 2, profile 2 reads back `[77, 30, 23, 60]`. Against the bundled 9.1 SITL (no command) the dialog closes and the log shows the "did not copy" line. Details: https://github.com/iNavFlight/inav/pull/11888#issuecomment-5607125881.

That check predates commit 1ea84cd, which reworked the failure handling; the current head is built by upstream CI on all platforms (https://github.com/iNavFlight/inav-configurator/actions/runs/34616693396) and passes the SonarCloud quality gate with 0 new issues (https://sonarcloud.io/dashboard?id=iNavFlight_inav-configurator&pullRequest=2746). Not run on hardware.

## Flash / RAM
Not applicable (Configurator).

## Docs
No documentation change needed: `docs/` on `maintenance-10.x` holds only `docs/development/patterns/msp-async-data-access.md`, and no file in this repo describes the header profile selectors. The MSP command itself is documented in `msp_messages.json` of iNavFlight/inav#11888.
