### PR TITLE
Show profile names in the header dropdowns and add name fields

### DIFF
--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -598,7 +598,7 @@ $(function() {
                     $('#languageOption').val(i18n.getCurrentLanguage());
                     
                     $('#languageOption').on('change', () => {
-                        i18n.changeLanguage($('#languageOption').val()).then(() => GUI.updateProfileNames());
+                        i18n.changeLanguage($('#languageOption').val()).then(GUI.updateProfileNames);
                     });
 
                     // Set the value of the unit type

--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -598,7 +598,7 @@ $(function() {
                     $('#languageOption').val(i18n.getCurrentLanguage());
                     
                     $('#languageOption').on('change', () => {
-                        i18n.changeLanguage($('#languageOption').val());
+                        i18n.changeLanguage($('#languageOption').val()).then(() => GUI.updateProfileNames());
                     });
 
                     // Set the value of the unit type

--- a/js/fc.js
+++ b/js/fc.js
@@ -47,6 +47,7 @@ var FC = {
     SENSOR_DATA: null,
     MOTOR_DATA: null,
     SERVO_DATA: null,
+    PROFILE_NAMES: null,
     GPS_DATA: null,
     ADSB_VEHICLES: null,
     ADSB_LIMITS: null,
@@ -294,6 +295,7 @@ var FC = {
 
         this.MOTOR_DATA = new Array(8);
         this.SERVO_DATA = new Array(16);
+        this.PROFILE_NAMES = null;
 
         this.GPS_DATA = {
             fix: 0,

--- a/js/gui.js
+++ b/js/gui.js
@@ -5,6 +5,7 @@ import FC from './fc';
 import interval from './intervals';
 import { scaleRangeInt } from './helpers';
 import i18n from './localization';
+import { profileOptionLabel } from './profileNames';
 import mspDeduplicationQueue from "./msp/mspDeduplicationQueue";
 import mspQueue from './serial_queue';
 
@@ -240,6 +241,21 @@ GUI_control.prototype.updateProfileChange = function(refresh) {
         }
         GUI.updateActivatedTab();
     }
+};
+
+// Label the header profile dropdowns with the user-defined profile names (FC.PROFILE_NAMES),
+// falling back to the plain translated labels when the firmware has none.
+GUI_control.prototype.updateProfileNames = function () {
+    const names = FC.PROFILE_NAMES;
+    const relabel = function ($select, messageKey, list) {
+        $select.find('option').each(function (index) {
+            $(this).text(profileOptionLabel(i18n.getMessage(messageKey + (index + 1)), list ? list[index] : ''));
+        });
+    };
+
+    relabel($('#profilechange'), 'sensorProfile', names ? names.control : null);
+    relabel($('#batteryprofilechange'), 'sensorBatteryProfile', names ? names.battery : null);
+    relabel($('#mixerprofilechange'), 'mixerProfile', names ? names.mixer : null);
 };
 
 GUI_control.prototype.fillSelect = function ($element, values, currentValue, unit) {

--- a/js/localization.js
+++ b/js/localization.js
@@ -119,7 +119,7 @@ i18n.getLanguages = function() {
 
 i18n.changeLanguage = function(languageSelected) {
     store.set('userLanguage', languageSelected);
-    i18next.changeLanguage(i18n.getValidLocale(languageSelected));
+    return i18next.changeLanguage(i18n.getValidLocale(languageSelected));
 };
 
 i18n.localize = function (reTranslate = false) {

--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -241,6 +241,7 @@ var MSPCodes = {
     MSP2_INAV_EZ_TUNE_SET:              0x2071,
 
     MSP2_INAV_SELECT_MIXER_PROFILE:     0x2080,
+    MSP2_INAV_PROFILE_NAMES:            0x2082,
     
     MSP2_ADSB_VEHICLE_LIST:             0x2090,
     MSP2_ADSB_LIMITS:                   0x2091,

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -28,6 +28,7 @@ import Waypoint from './../waypoint';
 import mspDeduplicationQueue from './mspDeduplicationQueue';
 import mspStatistics from './mspStatistics';
 import settingsCache from './../settingsCache';
+import { parseProfileNames } from './../profileNames';
 import {Geozone, GeozoneVertex, GeozoneShapes } from './../geozone';
 import { parseDronecanAsyncRequestResponse } from './../dronecanAsyncRequestParse';
 
@@ -164,6 +165,10 @@ var mspHelper = (function () {
                 GUI.updateStatusBar();
                 if (profile_changed > 0 || wasUninitialized) {
                     GUI.updateProfileChange(profile_changed);
+                }
+                if (wasUninitialized) {
+                    // first status of this connection: fetch the profile names for the header dropdowns
+                    MSP.send_message(MSPCodes.MSP2_INAV_PROFILE_NAMES, false, false);
                 }
                 break;
 
@@ -721,6 +726,14 @@ var mspHelper = (function () {
                 break;
             case MSPCodes.MSP_EEPROM_WRITE:
                 console.log('Settings Saved in EEPROM');
+                // a save may have renamed the active profile
+                MSP.send_message(MSPCodes.MSP2_INAV_PROFILE_NAMES, false, false);
+                break;
+
+            case MSPCodes.MSP2_INAV_PROFILE_NAMES:
+                // null = firmware without the message (unsupported reply) or a malformed payload
+                FC.PROFILE_NAMES = dataHandler.unsupported ? null : parseProfileNames(data);
+                GUI.updateProfileNames();
                 break;
             case MSPCodes.MSP_DEBUGMSG:
                 for (var ii = 0; ii < data.byteLength; ii++) {
@@ -3864,6 +3877,10 @@ var mspHelper = (function () {
 
     self.loadMixerConfig = function (callback) {
         MSP.send_message(MSPCodes.MSP2_INAV_MIXER, false, false, callback);
+    };
+
+    self.loadProfileNames = function (callback) {
+        MSP.send_message(MSPCodes.MSP2_INAV_PROFILE_NAMES, false, false, callback);
     };
 
     self.saveMixerConfig = function (callback) {

--- a/js/profileNames.js
+++ b/js/profileNames.js
@@ -1,0 +1,68 @@
+'use strict';
+
+// Decoder for MSP2_INAV_PROFILE_NAMES: the user-defined names of every
+// control, battery and mixer profile slot in one reply.
+//
+//   uint8  maxNameLength          (MAX_PROFILE_NAME_LENGTH in the firmware)
+//   uint8  controlProfileCount, then per slot: uint8 length + that many bytes
+//   uint8  batteryProfileCount, then per slot as above
+//   uint8  mixerProfileCount,   then per slot as above
+//
+// An unnamed slot has length 0 and decodes to an empty string.
+
+function readNameList(data, cursor) {
+    if (cursor.offset >= data.byteLength) {
+        return null;
+    }
+
+    const count = data.getUint8(cursor.offset++);
+    const names = [];
+
+    for (let i = 0; i < count; i++) {
+        if (cursor.offset >= data.byteLength) {
+            return null;
+        }
+        const length = data.getUint8(cursor.offset++);
+        if (cursor.offset + length > data.byteLength) {
+            return null;
+        }
+        let name = '';
+        for (let c = 0; c < length; c++) {
+            name += String.fromCharCode(data.getUint8(cursor.offset++));
+        }
+        names.push(name);
+    }
+
+    return names;
+}
+
+/**
+ * @param {DataView} data payload of an MSP2_INAV_PROFILE_NAMES reply
+ * @returns {{maxLength: number, control: string[], battery: string[], mixer: string[]}|null}
+ *          null when the payload is truncated or malformed
+ */
+export function parseProfileNames(data) {
+    if (!data || data.byteLength < 4) {
+        return null;
+    }
+
+    const cursor = { offset: 0 };
+    const maxLength = data.getUint8(cursor.offset++);
+    const control = readNameList(data, cursor);
+    const battery = readNameList(data, cursor);
+    const mixer = readNameList(data, cursor);
+
+    if (control === null || battery === null || mixer === null || cursor.offset !== data.byteLength) {
+        return null;
+    }
+
+    return { maxLength: maxLength, control: control, battery: battery, mixer: mixer };
+}
+
+/**
+ * Label for a profile selector entry: the translated base label, plus the
+ * user's name when the slot has one.
+ */
+export function profileOptionLabel(baseLabel, name) {
+    return name ? baseLabel + ': ' + name : baseLabel;
+}

--- a/js/profileNames.js
+++ b/js/profileNames.js
@@ -28,7 +28,7 @@ function readNameList(data, cursor) {
         }
         let name = '';
         for (let c = 0; c < length; c++) {
-            name += String.fromCharCode(data.getUint8(cursor.offset++));
+            name += String.fromCodePoint(data.getUint8(cursor.offset++));
         }
         names.push(name);
     }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -2135,6 +2135,18 @@
     "setMixerProfile": {
         "message": "Setting Mixer Profile: <strong style=\"color: #37a8db\">$1</strong>"
     },
+    "controlProfileName": {
+        "message": "Control profile name"
+    },
+    "batteryProfileName": {
+        "message": "Battery profile name"
+    },
+    "mixerProfileName": {
+        "message": "Mixer profile name"
+    },
+    "profileNameHelp": {
+        "message": "Optional name for this profile slot, shown next to its number in the profile dropdowns at the top. Up to 12 characters. Needs INAV 10 firmware."
+    },
     "setBatteryProfile": {
         "message": "Setting Battery Profile: <strong style=\"color: #37a8db\">$1</strong>"
     },

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -77,6 +77,13 @@
                     <div class="spacer_box_title" data-i18n="configurationVoltageCurrentSensor"></div>
                 </div>
                 <div class="spacer_box">
+                    <div class="number">
+                        <input type="text" id="battery_profile_name" data-setting="battery_profile_name" />
+                        <label for="battery_profile_name">
+                            <span data-i18n="batteryProfileName"></span>
+                        </label>
+                        <div for="battery_profile_name" class="helpicon cf_tip" data-i18n_title="profileNameHelp"></div>
+                    </div>
                     <div class="features batteryVoltage"></div>
                     <div class="select">
                         <select id="vbat_meter_type" data-setting="vbat_meter_type"></select>

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -80,7 +80,7 @@
                     <div class="number">
                         <input type="text" id="battery_profile_name" data-setting="battery_profile_name" />
                         <label for="battery_profile_name">
-                            <span data-i18n="batteryProfileName"></span>
+                            <span data-i18n="batteryProfileName">Battery profile name</span>
                         </label>
                         <div for="battery_profile_name" class="helpicon cf_tip" data-i18n_title="profileNameHelp"></div>
                     </div>

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -12,7 +12,7 @@
                         <div class="number">
                             <input type="text" id="mixer_profile_name" data-setting="mixer_profile_name" />
                             <label for="mixer_profile_name">
-                                <span data-i18n="mixerProfileName"></span>
+                                <span data-i18n="mixerProfileName">Mixer profile name</span>
                             </label>
                             <div for="mixer_profile_name" class="helpicon cf_tip" data-i18n_title="profileNameHelp"></div>
                         </div>

--- a/tabs/mixer.html
+++ b/tabs/mixer.html
@@ -9,6 +9,13 @@
                         <div class="spacer_box_title" data-i18n="platformConfiguration"></div>
                     </div>
                     <div class="spacer_box">
+                        <div class="number">
+                            <input type="text" id="mixer_profile_name" data-setting="mixer_profile_name" />
+                            <label for="mixer_profile_name">
+                                <span data-i18n="mixerProfileName"></span>
+                            </label>
+                            <div for="mixer_profile_name" class="helpicon cf_tip" data-i18n_title="profileNameHelp"></div>
+                        </div>
                         <div class="select">
                             <select id="platform-type"></select>
                             <label for="platform-type">

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -10,6 +10,15 @@
             <span class="subtab__header_label" for="subtab-mechanics" data-i18n="pidTuning_Mechanics"></span>
         </div>
         <div id="subtab-pid" class="subtab__content subtab__content--current">
+            <div class="cf_column profile-name-column">
+                <div class="number">
+                    <input type="text" id="control_profile_name" data-setting="control_profile_name" />
+                    <label for="control_profile_name">
+                        <span data-i18n="controlProfileName"></span>
+                    </label>
+                    <div for="control_profile_name" class="helpicon cf_tip" data-i18n_title="profileNameHelp"></div>
+                </div>
+            </div>
             <div class="cf_column right" style="margin-top: -6px;">
                 <div class="default_btn resetbt">
                     <a href="#" class="action-resetDefaults" data-i18n="pidTuning_SelectNewDefaults"></a>

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -14,7 +14,7 @@
                 <div class="number">
                     <input type="text" id="control_profile_name" data-setting="control_profile_name" />
                     <label for="control_profile_name">
-                        <span data-i18n="controlProfileName"></span>
+                        <span data-i18n="controlProfileName">Control profile name</span>
                     </label>
                     <div for="control_profile_name" class="helpicon cf_tip" data-i18n_title="profileNameHelp"></div>
                 </div>

--- a/tests/msp-parse-failure-recovery.test.mjs
+++ b/tests/msp-parse-failure-recovery.test.mjs
@@ -146,6 +146,7 @@ const inertGeozoneUrl = dataModule(`
 `);
 
 const realMspHelperUrl = rewriteAndWrite('js/msp/MSPHelper.js', [
+    [/^import \{ parseProfileNames \} from '\.\/\.\.\/profileNames';$/m, `import { parseProfileNames } from '${realModuleUrl('js/profileNames.js')}';`, "import parseProfileNames"],
     [/^import semver from 'semver';$/m, `import semver from '${inertDefaultUrl}';`, "import semver"],
     [/^import '\.\/\.\.\/injected_methods';$/m, `import '${realInjectedMethodsUrl}';`, "import injected_methods"],
     [/^import GUI from '\.\/\.\.\/gui';$/m, `import GUI from '${guiStubUrl}';`, "import GUI"],
@@ -528,4 +529,28 @@ test('reconnecting clears the block', () => {
     assert.equal(mspQueue.getLength(), 1, 'writes must work again after a reconnect');
 
     resetQueue();
+});
+
+// A save can finish while the initial profile-name read is still queued.
+// Exercise the real MSP retry path so this refresh cannot silently disappear.
+test('profile names refresh is retried after an in-flight read clears', async () => {
+    mspQueue.flush();
+    mspDeduplicationQueue.flush();
+    mspQueue.unlock();
+    CONFIGURATOR.cliActive = false;
+    CONFIGURATOR.connection = false;
+    MSP.parseFailures.clear();
+    const code = MSPCodes.MSP2_INAV_PROFILE_NAMES;
+    mspDeduplicationQueue.put(code);
+    try {
+        mspHelper.handleResponse(makeDataHandler(MSPCodes.MSP_EEPROM_WRITE, [], null));
+        assert.equal(mspQueue.getLength(), 0, 'duplicate is initially deferred');
+        mspDeduplicationQueue.remove(code);
+        await wait(200);
+        assert.equal(mspQueue.getLength(), 1, 'saved names must be requested again');
+        assert.equal(mspDeduplicationQueue.check(code), true);
+    } finally {
+        mspQueue.flush();
+        mspDeduplicationQueue.flush();
+    }
 });

--- a/tests/profile-names.test.mjs
+++ b/tests/profile-names.test.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Tests for parseProfileNames() / profileOptionLabel() (js/profileNames.js),
+ * the decoder for MSP2_INAV_PROFILE_NAMES used to label the header profile
+ * dropdowns.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseProfileNames, profileOptionLabel } from '../js/profileNames.js';
+
+function buildPayload(maxLength, lists) {
+    const bytes = [maxLength];
+    for (const list of lists) {
+        bytes.push(list.length);
+        for (const name of list) {
+            bytes.push(name.length);
+            for (const ch of name) {
+                bytes.push(ch.charCodeAt(0));
+            }
+        }
+    }
+    return new DataView(Uint8Array.from(bytes).buffer);
+}
+
+test('decodes three name lists with empty slots', () => {
+    const view = buildPayload(12, [['Cruise', '', 'Sport'], ['4S', '6S HV', ''], ['Quad', 'Plane']]);
+
+    assert.deepEqual(parseProfileNames(view), {
+        maxLength: 12,
+        control: ['Cruise', '', 'Sport'],
+        battery: ['4S', '6S HV', ''],
+        mixer: ['Quad', 'Plane'],
+    });
+});
+
+test('handles a single mixer profile and all-empty names', () => {
+    const view = buildPayload(12, [['', '', ''], ['', '', ''], ['']]);
+    const names = parseProfileNames(view);
+
+    assert.equal(names.mixer.length, 1);
+    assert.deepEqual(names.control, ['', '', '']);
+});
+
+test('rejects truncated, trailing and empty payloads', () => {
+    const good = buildPayload(12, [['A'], ['B'], ['C']]);
+
+    assert.equal(parseProfileNames(new DataView(good.buffer.slice(0, good.byteLength - 1))), null);
+
+    const trailing = new Uint8Array(good.byteLength + 1);
+    trailing.set(new Uint8Array(good.buffer));
+    assert.equal(parseProfileNames(new DataView(trailing.buffer)), null);
+
+    assert.equal(parseProfileNames(new DataView(new ArrayBuffer(0))), null);
+    assert.equal(parseProfileNames(null), null);
+});
+
+test('option label appends the name only when there is one', () => {
+    assert.equal(profileOptionLabel('Control Profile 1', 'Cruise'), 'Control Profile 1: Cruise');
+    assert.equal(profileOptionLabel('Control Profile 2', ''), 'Control Profile 2');
+    assert.equal(profileOptionLabel('Control Profile 3', undefined), 'Control Profile 3');
+});


### PR DESCRIPTION
## Problem
The header dropdowns show only "Control Profile 1-3", "Battery Profile 1-3" and "Mixer Profile 1-2"; with several tunes or battery packs the pilot has to remember which number is which. iNavFlight/inav#11894 (open) adds the string settings `control_profile_name`, `battery_profile_name`, `mixer_profile_name` and the read-only `MSP2_INAV_PROFILE_NAMES` (0x2082) that returns every slot name, but the configurator has no client for it. No issue is linked.

## Cause
`index.html:91-93`, `102-103` and `113-115` on maintenance-10.x fill the options from the fixed i18n keys `sensorProfile1..3`, `mixerProfile1..2`, `sensorBatteryProfile1..3`; `js/gui.js:227-230` (`updateProfileChange`) only selects the active index. `js/msp/MSPCodes.js` has no entry for 0x2082 and `js/msp/MSPHelper.js` no handler.

## Change
Adds `MSP2_INAV_PROFILE_NAMES` (0x2082) to `MSPCodes.js`, the decoder `js/profileNames.js` (uint8 max length, then per kind a uint8 count and length-prefixed names) and `FC.PROFILE_NAMES`. `MSPHelper.js` requests the names after the first `MSP_STATUS` of a connection and after every `MSP_EEPROM_WRITE`; an unsupported reply or a malformed payload leaves `FC.PROFILE_NAMES` null. `GUI.updateProfileNames()` rewrites the option text to e.g. "Control Profile 3: Cruise", keeps the plain label for empty names and runs again after a language change (`i18n.changeLanguage` now returns the i18next promise). PID tuning, Configuration (battery box) and Mixer (platform box) get a `data-setting` text input for the active profile's name, loaded and stored by the existing `Settings.configureInputs` (sets `maxlength` from the setting metadata) and `Settings.saveInputs` chain; three labels and one help text are added to `locale/en/messages.json`.

## Test
Unit tests: `tests/profile-names.test.mjs` (4 tests: lists with empty slots, single mixer profile, truncated/trailing/empty payload rejected, label helper) and one test in `tests/msp-parse-failure-recovery.test.mjs` for the re-queued refresh after `MSP_EEPROM_WRITE` while an earlier read is in flight. `node --test tests/*.test.mjs`: 104 tests, 101 pass; the 3 failures are the same as on the merge-base (99/96). The new tests also pass on a merge with current maintenance-10.x (b806f418). CI runs `yarn run make` only: upstream run https://github.com/iNavFlight/inav-configurator/actions/runs/34628257717 and fork run https://github.com/Raffi1202/inav-configurator/actions/runs/34628264075 pass on 2c38c02; SonarCloud quality gate passed. Not run on hardware. A manual check against the CI-built SITL of iNavFlight/inav#11894 is described in the first PR comment; no log is attached.

## Flash / RAM
Not applicable (Configurator).

## Docs
No documentation change needed: the configurator repository has no user documentation for the header or these tabs (`docs/` holds one development note). The three settings and `MSP2_INAV_PROFILE_NAMES` are documented in `docs/Settings.md` and `docs/development/msp/` of iNavFlight/inav#11894.
