### PR TITLE
Add the AssistNow Autonomous switch to the GPS tab

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1526,6 +1526,12 @@
     "configurationGPSUseGlonass": {
         "message": "Gps use Glonass Satellites (RU)"
     },
+    "configurationGPSAssistNowAutonomous": {
+        "message": "AssistNow Autonomous (orbit prediction in the receiver)"
+    },
+    "configurationGPSAssistNowAutonomousHelp": {
+        "message": "u-blox M8 and newer: the receiver predicts satellite orbits from data it collected on earlier power-ups and fixes faster after a cold start, without an internet download. Needs the receiver's backup battery or supercapacitor to keep the data between flights. Requires INAV 10 firmware; the option is hidden on older firmware."
+    },
     "gpsPresetMode": {
         "message": "GPS Configuration Preset"
     },

--- a/tabs/gps.html
+++ b/tabs/gps.html
@@ -88,6 +88,11 @@
                             <input type="checkbox" id="gps_use_glonass" class="toggle update_preview preset-controlled" data-setting="gps_ublox_use_glonass">
                             <label for="gps_use_glonass"><span data-i18n="configurationGPSUseGlonass"></span></label>
                         </div>
+                        <div class="checkbox">
+                            <input type="checkbox" id="gps_assistnow_autonomous" class="toggle" data-setting="gps_ublox_assistnow_autonomous">
+                            <label for="gps_assistnow_autonomous"><span data-i18n="configurationGPSAssistNowAutonomous">AssistNow Autonomous (orbit prediction in the receiver)</span></label>
+                            <div for="gps_assistnow_autonomous" class="helpicon cf_tip" data-i18n_title="configurationGPSAssistNowAutonomousHelp"></div>
+                        </div>
                         <div class="number">
                             <input type="number" id="tzOffset" data-setting="tz_offset" data-unit="tzmins" data-setting-multiplier="1" step="1" min="-1440" max="1440" />
                             <label for="tzOffset"><span data-i18n="tzOffset"></span></label>


### PR DESCRIPTION
## Problem
No issue; this is the Configurator counterpart of iNavFlight/inav#11895, which adds `gps_ublox_assistnow_autonomous` (u-blox receiver-side orbit prediction). The GPS tab has no control for it: the constellation switches end at GLONASS, so the setting can only be changed in the CLI.

## Cause
`tabs/gps.html:79-90` on `maintenance-10.x` holds the three constellation `data-setting` checkboxes; nothing in the tree references `gps_ublox_assistnow_autonomous`. `Settings.configureInputs` (`js/settings.js:92-131`) reads every `data-setting` input from the FC and removes the row when the setting is unknown, so a plain `data-setting` input covers old and new firmware.

## Change
Adds one checkbox row after the GLONASS switch in `tabs/gps.html`: `<input type="checkbox" id="gps_assistnow_autonomous" class="toggle" data-setting="gps_ublox_assistnow_autonomous">` with label and help icon (linked to `Settings.md#gps_ublox_assistnow_autonomous` by `Settings.linkHelpIcons`, `js/settings.js:743-758`). Adds `configurationGPSAssistNowAutonomous` and `configurationGPSAssistNowAutonomousHelp` to `locale/en/messages.json`. The input has no `preset-controlled` class and `applyGPSPreset` (`tabs/gps.js:398-438`) does not touch it; saving uses the existing chain `Settings.saveInputs` -> `saveToEeprom` (`tabs/gps.js:88-97`).

## Test
Not run on hardware; the receiver side belongs to the firmware PR. Dev app driven over CDP by a script against two SITLs:
- bundled 9.1 SITL (setting unknown): the row is removed, the other GPS switches stay.
- SITL from the firmware fork CI (https://github.com/Raffi1202/inav/actions/runs/34438768670): row present and unchecked on a fresh EEPROM; check, `Settings.saveInputs` + `saveToEeprom`, `mspHelper.getSetting` reads 1; after leaving and re-opening the tab the row shows checked (screenshot `gpsana-B.png`); uncheck and save reads 0.

Script and screenshot are local, not attached to this PR.
Configurator CI build of a592ecb: https://github.com/iNavFlight/inav-configurator/actions/runs/34439053061 (six platform builds green; SonarCloud 0 new issues). The `MSP2_ADSB_LIMITS` parse error the SITL logs on the GPS tab is unrelated; #2749 handles it.

## Flash / RAM
Not applicable (Configurator).

## Docs
No documentation change needed: the Configurator repo has no user docs for the GPS tab (`docs/` holds one development pattern note); the setting is documented in `docs/Settings.md` of iNavFlight/inav#11895, which the help icon links to.
