### PR TITLE
Tolerate ADSB replies without payload

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -263,6 +263,9 @@ var mspHelper = (function () {
                 if (dataHandler.unsupported || data.byteLength < 10) {
                     // firmware without ADSB (error reply, no payload): no vehicles, keep the counters at zero
                     FC.ADSB_VEHICLES.vehiclesCount = 0;
+                    FC.ADSB_VEHICLES.callsignLength = 0;
+                    FC.ADSB_VEHICLES.vehiclePacketCount = 0;
+                    FC.ADSB_VEHICLES.heartbeatPacketCount = 0;
                     break;
                 }
                 FC.ADSB_VEHICLES.vehiclesCount = data.getUint8(byteOffsetCounter++);

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -260,6 +260,11 @@ var mspHelper = (function () {
             case MSPCodes.MSP2_ADSB_VEHICLE_LIST:
                 var byteOffsetCounter = 0;
                 FC.ADSB_VEHICLES.vehicles = [];
+                if (dataHandler.unsupported || data.byteLength < 10) {
+                    // firmware without ADSB (error reply, no payload): no vehicles, keep the counters at zero
+                    FC.ADSB_VEHICLES.vehiclesCount = 0;
+                    break;
+                }
                 FC.ADSB_VEHICLES.vehiclesCount = data.getUint8(byteOffsetCounter++);
                 FC.ADSB_VEHICLES.callsignLength = data.getUint8(byteOffsetCounter++);
                 FC.ADSB_VEHICLES.vehiclePacketCount = data.getUint32(byteOffsetCounter, true); byteOffsetCounter += 4;
@@ -287,6 +292,10 @@ var mspHelper = (function () {
                 }
                 break;
             case MSPCodes.MSP2_ADSB_LIMITS:
+                if (dataHandler.unsupported || data.byteLength < 6) {
+                    // firmware without ADSB answers with an error and no payload: leave the zero defaults
+                    break;
+                }
                 FC.ADSB_LIMITS.adsb_distance_warning = data.getUint16(0, true);
                 FC.ADSB_LIMITS.adsb_distance_alert = data.getUint16(2, true);
                 FC.ADSB_LIMITS.adsb_ignore_plane_above_me_limit = data.getUint16(4, true);


### PR DESCRIPTION
## Problem
Connected to INAV 9.x firmware — the accepted range on this branch (js/data_storage.js:5-6), including the bundled 9.1.0 SITL — opening the GPS tab logs `Failed to parse MSP code 0x2091: RangeError: Offset is outside the bounds of the DataView` and the log panel reports that the MSP2_ADSB_LIMITS response could not be read and saving is disabled. Since no write pairs with that code, every unpaired write is then refused with "Not saved." until reconnect (js/msp.js:164-166, :407). No issue is filed for this.

## Cause
js/msp/MSPHelper.js on maintenance-10.x: the parser switch at line 126 runs even for an error frame (`dataHandler.unsupported`, set from the `!` direction byte at js/msp.js:236), and line 290 reads `data.getUint16(0, true)` from the empty DataView; lines 263-266 (MSP2_ADSB_VEHICLE_LIST) are unguarded the same way. inav release/9.1 does not define MSP2_ADSB_LIMITS (src/main/msp/msp_protocol_v2_inav.h lists only MSP2_ADSB_VEHICLE_LIST), so every 9.x target answers 0x2091 with an error frame and no payload; maintenance-10.x sends six zero bytes when USE_ADSB is off (src/main/fc/fc_msp.c:1097-1107).

## Change
Both ADSB cases check `dataHandler.unsupported` and the payload length before reading. MSP2_ADSB_LIMITS breaks out below 6 bytes and leaves FC.ADSB_LIMITS at its zero defaults (js/fc.js:327-331), which tabs/gps.js:742 already treats as "no warning rings". MSP2_ADSB_VEHICLE_LIST breaks out below 10 bytes and zeroes vehiclesCount, callsignLength, vehiclePacketCount and heartbeatPacketCount next to the already-cleared list, so no stale totals remain (Qodo finding, fixed in 275c87f).

## Test
Not run on hardware, and no log of a SITL run is attached to this PR. Cause verified by reading the lines above; the reproduction path is the bundled 9.1.0 SITL (resources/sitl, commit f4bb28ee), whose GPS tab load chain requests MSP2_ADSB_LIMITS on every open (tabs/gps.js:80). CI built 275c87f on all six platforms: https://github.com/iNavFlight/inav-configurator/actions/runs/34615487622. SonarCloud quality gate passed: https://sonarcloud.io/dashboard?id=iNavFlight_inav-configurator&pullRequest=2749. CI does not run `npm test` and this PR adds no test file.

## Flash / RAM
Not applicable (Configurator).

## Docs
No documentation change needed: docs/ on maintenance-10.x contains only a developer note (docs/development/patterns/msp-async-data-access.md); no user document covers ADSB or the GPS tab, and no setting is added.
