### PR TITLE
Base the ACRO indicator on the selected modes

### DIFF
--- a/tabs/auxiliary.js
+++ b/tabs/auxiliary.js
@@ -395,10 +395,10 @@ auxiliaryTab.initialize = function (callback) {
         function update_ui() {
             let hasUsedMode = false;
             let acroEnabled = true;
-            let acroFail = ["ANGLE", "HORIZON", "MANUAL", "ANGLE HOLD", "NAV RTH", "NAV POSHOLD", "NAV CRUISE", "NAV COURSE HOLD", "NAV WP", "GCS NAV"];
+            let acroFail = new Set(["ANGLE", "HORIZON", "MANUAL", "ANGLE HOLD", "NAV RTH", "NAV POSHOLD", "NAV CRUISE", "NAV COURSE HOLD", "NAV WP", "GCS NAV"]);
             // The flight controller reports these modes as active for as long as the Configurator
             // is connected, so only the selected channel range can make them block ACRO.
-            let acroFailOnlyWhenSelected = ["MANUAL"];
+            let acroFailOnlyWhenSelected = new Set(["MANUAL"]);
 
             var auxChannelCount = FC.RC.active_channels - 4;
 
@@ -436,14 +436,14 @@ auxiliaryTab.initialize = function (callback) {
                     // The flight controller can activate the mode
                     $('.mode .name').eq(modeElement.data('index')).data('modeElement').addClass('on').removeClass('inRange').removeClass('off');
 
-                    if (jQuery.inArray(modeElement.data('modeName'), acroFail) !== -1 &&
-                        (inRange || jQuery.inArray(modeElement.data('modeName'), acroFailOnlyWhenSelected) === -1)) {
+                    if (acroFail.has(modeElement.data('modeName')) &&
+                        (inRange || !acroFailOnlyWhenSelected.has(modeElement.data('modeName')))) {
                         acroEnabled = false;
                     }
                 } else if (inRange) {
                     $('.mode .name').eq(modeElement.data('index')).data('modeElement').removeClass('on').addClass('inRange').removeClass('off');
 
-                    if (jQuery.inArray(modeElement.data('modeName'), acroFail) !== -1) {
+                    if (acroFail.has(modeElement.data('modeName'))) {
                         acroEnabled = false;
                     }
                 } else {

--- a/tabs/auxiliary.js
+++ b/tabs/auxiliary.js
@@ -396,6 +396,9 @@ auxiliaryTab.initialize = function (callback) {
             let hasUsedMode = false;
             let acroEnabled = true;
             let acroFail = ["ANGLE", "HORIZON", "MANUAL", "ANGLE HOLD", "NAV RTH", "NAV POSHOLD", "NAV CRUISE", "NAV COURSE HOLD", "NAV WP", "GCS NAV"];
+            // The flight controller reports these modes as active for as long as the Configurator
+            // is connected, so only the selected channel range can make them block ACRO.
+            let acroFailOnlyWhenSelected = ["MANUAL"];
 
             var auxChannelCount = FC.RC.active_channels - 4;
 
@@ -413,40 +416,39 @@ auxiliaryTab.initialize = function (callback) {
                     continue;
                 }
 
+                // Check to see if the mode is in range
+                var modeRanges = modeElement.find(' .range');
+                for (let r = 0; r < modeRanges.length; r++) {
+                    var rangeLow = $(modeRanges[r]).find('.lowerLimitValue').html();
+                    var rangeHigh = $(modeRanges[r]).find('.upperLimitValue').html();
+                    var markerPosition = $(modeRanges[r]).find('.marker')[0].style.left;
+                    markerPosition = markerPosition.substring(0, markerPosition.length-1);
+
+                    rangeLow = (rangeLow - 900) / (2100-900) * 100;
+                    rangeHigh = (rangeHigh - 900) / (2100-900) * 100;
+
+                    if ((markerPosition >= rangeLow) && (markerPosition <= rangeHigh)) {
+                        inRange = true;
+                    }
+                }
+
                 if (FC.isModeBitSet(modeElement.data('origId'))) {
                     // The flight controller can activate the mode
                     $('.mode .name').eq(modeElement.data('index')).data('modeElement').addClass('on').removeClass('inRange').removeClass('off');
+
+                    if (jQuery.inArray(modeElement.data('modeName'), acroFail) !== -1 &&
+                        (inRange || jQuery.inArray(modeElement.data('modeName'), acroFailOnlyWhenSelected) === -1)) {
+                        acroEnabled = false;
+                    }
+                } else if (inRange) {
+                    $('.mode .name').eq(modeElement.data('index')).data('modeElement').removeClass('on').addClass('inRange').removeClass('off');
 
                     if (jQuery.inArray(modeElement.data('modeName'), acroFail) !== -1) {
                         acroEnabled = false;
                     }
                 } else {
-                    // Check to see if the mode is in range
-                    var modeRanges = modeElement.find(' .range');
-                    for (let r = 0; r < modeRanges.length; r++) {
-                        var rangeLow = $(modeRanges[r]).find('.lowerLimitValue').html();
-                        var rangeHigh = $(modeRanges[r]).find('.upperLimitValue').html();
-                        var markerPosition = $(modeRanges[r]).find('.marker')[0].style.left;
-                        markerPosition = markerPosition.substring(0, markerPosition.length-1);
-
-                        rangeLow = (rangeLow - 900) / (2100-900) * 100;
-                        rangeHigh = (rangeHigh - 900) / (2100-900) * 100;
-
-                        if ((markerPosition >= rangeLow) && (markerPosition <= rangeHigh)) {
-                            inRange = true;
-                        }
-                    }
-
-                    if (inRange) {
-                        $('.mode .name').eq(modeElement.data('index')).data('modeElement').removeClass('on').addClass('inRange').removeClass('off');
-
-                        if (jQuery.inArray(modeElement.data('modeName'), acroFail) !== -1) {
-                            acroEnabled = false;
-                        }
-                    } else {
-                        // If not, it is shown as disabled.
-                        $('.mode .name').eq(modeElement.data('index')).data('modeElement').removeClass('on').removeClass('inRange').addClass('off');
-                    }
+                    // If not, it is shown as disabled.
+                    $('.mode .name').eq(modeElement.data('index')).data('modeElement').removeClass('on').removeClass('inRange').addClass('off');
                 }
                 hasUsedMode = true;
             }

--- a/tabs/auxiliary.js
+++ b/tabs/auxiliary.js
@@ -419,10 +419,17 @@ auxiliaryTab.initialize = function (callback) {
                 // Check to see if the mode is in range
                 var modeRanges = modeElement.find(' .range');
                 for (let r = 0; r < modeRanges.length; r++) {
+                    const channel = Number.parseInt($(modeRanges[r]).find('.channel').val(), 10);
+                    if (!Number.isInteger(channel) || channel < 0 || channel >= auxChannelCount) {
+                        continue;
+                    }
                     var rangeLow = $(modeRanges[r]).find('.lowerLimitValue').html();
                     var rangeHigh = $(modeRanges[r]).find('.upperLimitValue').html();
                     var markerPosition = $(modeRanges[r]).find('.marker')[0].style.left;
-                    markerPosition = markerPosition.substring(0, markerPosition.length-1);
+                    markerPosition = Number.parseFloat(markerPosition);
+                    if (!Number.isFinite(markerPosition)) {
+                        continue;
+                    }
 
                     rangeLow = (rangeLow - 900) / (2100-900) * 100;
                     rangeHigh = (rangeHigh - 900) / (2100-900) * 100;


### PR DESCRIPTION
## Problem

A range assigned to MANUAL makes the Modes tab show ACRO as unavailable even when the switch is nowhere near that range, so the indicator suggests ACRO cannot be activated while no other mode is active. Without a range on MANUAL the indicator is correct. Fixes #2723.

## Cause

`update_ui()` tests `FC.isModeBitSet()` first and clears `acroEnabled` for every mode in `acroFail` - `tabs/auxiliary.js:416-421` on maintenance-10.x. The channel-range loop sits in the `else` branch (lines 425-438), so it never runs for a mode the flight controller reports as active, and the FC reports MANUAL as active whenever the Configurator is connected.

## Change

The range loop now runs before the mode-bit check, so `inRange` is known in both branches. A mode in the new `acroFailOnlyWhenSelected` set - currently only MANUAL - clears `acroEnabled` only when its range is selected; the other `acroFail` entries keep their behaviour. Ranges on a channel outside the receiver's aux channels, or with a marker position that does not parse as a number, are skipped instead of counting as selected. The per-mode row classes are untouched and the two mode lists are now `Set`s.

## Test

Not run in the app for this revision; the reproduction, with screenshots, is the reporter's in #2723. Cause verified by reading `tabs/auxiliary.js:416-438`, and `node --check tabs/auxiliary.js` passes on the head commit. CI is green on `d833634`: [six platform builds](https://github.com/iNavFlight/inav-configurator/actions/runs/34615547870) and [SonarCloud](https://sonarcloud.io/dashboard?id=iNavFlight_inav-configurator&pullRequest=2751), 0 new issues. The one Qodo correctness finding, ranges on an unavailable channel counting as selected, is what `d833634` fixes. No automated test covers `update_ui()`.

## Flash / RAM
Not applicable (Configurator).

## Docs

None. No Markdown file on maintenance-10.x mentions the Modes tab or the ACRO indicator.
