### PR TITLE
Take the compass calibration time from the flight controller

### DIFF
--- a/tabs/calibration.js
+++ b/tabs/calibration.js
@@ -13,6 +13,9 @@ import jBox from 'jbox';
 
 const calibrationTab = {};
 
+// Used when the FC does not know mag_calibration_time. Matches the firmware default.
+const MAG_CALIBRATION_TIME_DEFAULT = 30;
+
 calibrationTab.model = (function () {
     var publicScope = {},
         privateScope = {};
@@ -56,7 +59,8 @@ calibrationTab.initialize = function (callback) {
         saveChainer = new MSPChainerClass(),
         modalStart,
         modalStop,
-        modalProcessing;
+        modalProcessing,
+        magCalibrationTime = MAG_CALIBRATION_TIME_DEFAULT;
 
     if (GUI.active_tab !== this) {
         GUI.active_tab = this;
@@ -64,7 +68,16 @@ calibrationTab.initialize = function (callback) {
     loadChainer.setChain([
         mspHelper.queryFcStatus,
         mspHelper.loadSensorConfig,
-        mspHelper.loadCalibrationData
+        mspHelper.loadCalibrationData,
+        function (callback) {
+            mspHelper.getSetting('mag_calibration_time').then(function (setting) {
+                if (setting && setting.value > 0) {
+                    magCalibrationTime = setting.value;
+                }
+            }).catch(function () {
+                // Firmware without the setting keeps MAG_CALIBRATION_TIME_DEFAULT.
+            }).then(callback);
+        }
     ]);
     loadChainer.setExitPoint(loadHtml);
     loadChainer.execute();
@@ -254,7 +267,8 @@ calibrationTab.initialize = function (callback) {
                 content: $('#modal-compass-processing').clone()
             }).open();
 
-            var countdown = 30;
+            var countdown = magCalibrationTime;
+            modalProcessing.content.find('.modal-compass-countdown').text(countdown);
             interval.add('compass_calibration_interval', function () {
                 countdown--;
                 if (countdown === 0) {

--- a/tabs/calibration.js
+++ b/tabs/calibration.js
@@ -70,13 +70,19 @@ calibrationTab.initialize = function (callback) {
         mspHelper.loadSensorConfig,
         mspHelper.loadCalibrationData,
         function (callback) {
-            mspHelper.getSetting('mag_calibration_time').then(function (setting) {
+            let finished = false;
+            function finish(setting) {
+                if (finished) return;
+                finished = true;
+                timeout.remove('mag_calibration_time_load');
                 if (setting && setting.value > 0) {
                     magCalibrationTime = setting.value;
                 }
-            }).catch(function () {
-                // Firmware without the setting keeps MAG_CALIBRATION_TIME_DEFAULT.
-            }).then(callback);
+                callback();
+            }
+            // getSetting can remain pending after transport retries are exhausted.
+            timeout.add('mag_calibration_time_load', () => finish(), 5000);
+            mspHelper.getSetting('mag_calibration_time').then(finish, () => finish());
         }
     ]);
     loadChainer.setExitPoint(loadHtml);
@@ -347,6 +353,7 @@ calibrationTab.initialize = function (callback) {
 };
 
 calibrationTab.cleanup = function (callback) {
+    timeout.remove('mag_calibration_time_load');
     if (callback) callback();
 };
 


### PR DESCRIPTION
## Problem
Fixes #2298. The reporter set `mag_calibration_time` to 60 in the CLI and compass calibration in the Configurator then failed; changing the countdown to 60 by hand made it work. A second commenter found it affects every value above 30: the Configurator always runs a 30 s timer, then reads the calibration data before the flight controller has finished, shows the uncalibrated values, and a Save and Reboot at that point overwrites the calibration the FC did complete.

## Cause
`tabs/calibration.js:257` on maintenance-10.x sets `var countdown = 30;` and line 266 sends `MSP_CALIBRATION_DATA` when that countdown reaches zero. `mag_calibration_time` is not read anywhere in the Configurator, so with a longer setting the result is requested while the firmware is still calibrating.

## Change
Adds a step to the tab's load chain that reads `mag_calibration_time` via `mspHelper.getSetting`, bounded by a 5 s timeout so an unanswered request cannot stall the chain; a value above 0 replaces the default of 30, otherwise the default stays. The compass countdown starts from that value and is written to the modal immediately instead of after the first tick. `cleanup` removes the load timeout. The optical flow countdown stays at 30, matching `OPFLOW_CALIBRATE_TIME_MS 30000` in firmware `src/main/sensors/opflow.c`.

## Test
Not run on hardware or SITL. Cause verified by reading `tabs/calibration.js:257-266` on maintenance-10.x. Built by CI for c5fc222, all six platform builds pass: https://github.com/iNavFlight/inav-configurator/actions/runs/34615606988. SonarCloud, 0 new issues: https://sonarcloud.io/dashboard?id=iNavFlight_inav-configurator&pullRequest=2752. The Qodo finding that an unanswered `getSetting` could leave the tab unloaded is addressed by the 5 s bound in c5fc222.

## Flash / RAM
Not applicable (Configurator).

## Docs
No file in this repository documents the Calibration tab (`docs/` holds one development pattern note). Needs a change to iNavFlight.github.io `docs/04-inav-configurator/calibration-tab.mdx` (lines 84 and 92 say "30 seconds"): state that the duration is `mag_calibration_time` (default 30) and that the Configurator countdown follows it.
