### PR TITLE
Read the blackbox rate little endian and keep it selectable

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1217,15 +1217,6 @@ var mspHelper = (function () {
                 FC.SDCARD.freeSizeKB = data.getUint32(3, true);
                 FC.SDCARD.totalSizeKB = data.getUint32(7, true);
                 break;
-            case MSPCodes.MSP_BLACKBOX_CONFIG:
-                FC.BLACKBOX.supported = (data.getUint8(0) & 1) != 0;
-                FC.BLACKBOX.blackboxDevice = data.getUint8(1);
-                FC.BLACKBOX.blackboxRateNum = data.getUint8(2);
-                FC.BLACKBOX.blackboxRateDenom = data.getUint8(3);
-                break;
-            case MSPCodes.MSP_SET_BLACKBOX_CONFIG:
-                console.log("Blackbox config saved");
-                break;
             case MSPCodes.MSP_VTX_CONFIG:
                 FC.VTX_CONFIG.device_type = data.getUint8(offset++);
                 if (FC.VTX_CONFIG.device_type != VTX.DEV_UNKNOWN) {
@@ -1594,8 +1585,8 @@ var mspHelper = (function () {
             case MSPCodes.MSP2_BLACKBOX_CONFIG:
                 FC.BLACKBOX.supported = (data.getUint8(0) & 1) != 0;
                 FC.BLACKBOX.blackboxDevice = data.getUint8(1);
-                FC.BLACKBOX.blackboxRateNum = data.getUint16(2);
-                FC.BLACKBOX.blackboxRateDenom = data.getUint16(4);
+                FC.BLACKBOX.blackboxRateNum = data.getUint16(2, true);
+                FC.BLACKBOX.blackboxRateDenom = data.getUint16(4, true);
                 FC.BLACKBOX.blackboxIncludeFlags = data.getUint32(6,true);
                 break;
             case MSPCodes.MSP2_SET_BLACKBOX_CONFIG:
@@ -2598,9 +2589,8 @@ var mspHelper = (function () {
 
     self.sendBlackboxConfiguration = function (onDataCallback) {
         var buffer = [];
-        var messageId = MSPCodes.MSP_SET_BLACKBOX_CONFIG;
+        var messageId = MSPCodes.MSP2_SET_BLACKBOX_CONFIG;
         buffer.push(FC.BLACKBOX.blackboxDevice & 0xFF);
-        messageId = MSPCodes.MSP2_SET_BLACKBOX_CONFIG;
         buffer.push(BitHelper.lowByte(FC.BLACKBOX.blackboxRateNum));
         buffer.push(BitHelper.highByte(FC.BLACKBOX.blackboxRateNum));
         buffer.push(BitHelper.lowByte(FC.BLACKBOX.blackboxRateDenom));

--- a/tabs/onboard_logging.js
+++ b/tabs/onboard_logging.js
@@ -194,8 +194,18 @@ onboardLoggingTab.initialize = function (callback) {
 
     function populateLoggingRates() {
         var
-            userRateGCD = gcd(FC.BLACKBOX.blackboxRateNum, FC.BLACKBOX.blackboxRateDenom),
-            userRate = {num: FC.BLACKBOX.blackboxRateNum / userRateGCD, denom: FC.BLACKBOX.blackboxRateDenom / userRateGCD};
+            rateNum = FC.BLACKBOX.blackboxRateNum,
+            rateDenom = FC.BLACKBOX.blackboxRateDenom;
+
+        // A flight controller that reports no usable rate logs every iteration
+        if (!(rateNum > 0) || !(rateDenom > 0)) {
+            rateNum = 1;
+            rateDenom = 1;
+        }
+
+        var
+            userRateGCD = gcd(rateNum, rateDenom),
+            userRate = {num: rateNum / userRateGCD, denom: rateDenom / userRateGCD};
 
         // Offer a reasonable choice of logging rates (if people want weird steps they can use CLI)
         var
@@ -213,24 +223,31 @@ onboardLoggingTab.initialize = function (callback) {
                  {num: 7, denom: 8},
                  {num: 1, denom: 1},
             ],
-            loggingRatesSelect = $(".blackboxRate select");
+            loggingRatesSelect = $(".blackboxRate select").empty();
 
+        /* The rate configured on the aircraft may be outside that list, e.g. 1/256 set over the CLI.
+         * It has to be offered and preselected as well, otherwise the select box stays empty and
+         * saving the tab without touching it would quietly write a different rate.
+         */
         var
-            addedCurrentValue = false;
+            offeredRates = loggingRates.filter(function (rate) {
+                return rate.num != userRate.num || rate.denom != userRate.denom;
+            });
 
-        for (var i = 0; i < loggingRates.length; i++) {
-            if (!addedCurrentValue && userRate.num / userRate.denom <= loggingRates[i].num / loggingRates[i].denom) {
-                if (userRate.num / userRate.denom < loggingRates[i].num / loggingRates[i].denom) {
-                    var userPercent = Math.round(userRate.num / userRate.denom * 100);
-                    loggingRatesSelect.append('<option value="' + userRate.num + '/' + userRate.denom + '" data-percent="' + userPercent + '">'
-                            + userRate.num + '/' + userRate.denom + ' (' + userPercent + '%)</option>');
-                }
-                addedCurrentValue = true;
-            }
+        offeredRates.push(userRate);
+        offeredRates.sort(function (a, b) {
+            return a.num / a.denom - b.num / b.denom;
+        });
 
-            var percent = Math.round(loggingRates[i].num / loggingRates[i].denom * 100);
-            loggingRatesSelect.append('<option value="' + loggingRates[i].num + '/' + loggingRates[i].denom + '" data-percent="' + percent + '">'
-                + loggingRates[i].num + '/' + loggingRates[i].denom + ' (' + percent + '%)</option>');
+        for (var i = 0; i < offeredRates.length; i++) {
+            var
+                ratio = offeredRates[i].num / offeredRates[i].denom,
+                percent = Math.round(ratio * 100),
+                // Rates well below one percent would all be shown as 0%
+                label = ratio < 0.01 ? (ratio * 100).toFixed(1) : percent;
+
+            loggingRatesSelect.append('<option value="' + offeredRates[i].num + '/' + offeredRates[i].denom + '" data-percent="' + percent + '">'
+                + offeredRates[i].num + '/' + offeredRates[i].denom + ' (' + label + '%)</option>');
 
         }
         loggingRatesSelect.val(userRate.num + '/' + userRate.denom);

--- a/tabs/onboard_logging.js
+++ b/tabs/onboard_logging.js
@@ -193,22 +193,28 @@ onboardLoggingTab.initialize = function (callback) {
     }
 
     function populateLoggingRates() {
-        var
+        let
             rateNum = FC.BLACKBOX.blackboxRateNum,
             rateDenom = FC.BLACKBOX.blackboxRateDenom;
 
-        // A flight controller that reports no usable rate logs every iteration
-        if (!(rateNum > 0) || !(rateDenom > 0)) {
+        /* A flight controller that reports no usable rate logs every iteration.
+         * Written as a negated conjunction on purpose, not as rateNum <= 0: the
+         * guard has to catch a value that is not a number too. Any comparison with
+         * NaN or undefined is false, so rateNum <= 0 would not fire for those and
+         * they would reach the recursive gcd() below, which never meets its base
+         * case and recurses until the stack overflows. Please do not "simplify".
+         */
+        if (!(rateNum > 0 && rateDenom > 0)) {
             rateNum = 1;
             rateDenom = 1;
         }
 
-        var
+        const
             userRateGCD = gcd(rateNum, rateDenom),
             userRate = {num: rateNum / userRateGCD, denom: rateDenom / userRateGCD};
 
         // Offer a reasonable choice of logging rates (if people want weird steps they can use CLI)
-        var
+        const
             loggingRates = [
                  {num: 1, denom: 32},
                  {num: 1, denom: 16},
@@ -229,7 +235,7 @@ onboardLoggingTab.initialize = function (callback) {
          * It has to be offered and preselected as well, otherwise the select box stays empty and
          * saving the tab without touching it would quietly write a different rate.
          */
-        var
+        const
             offeredRates = loggingRates.filter(function (rate) {
                 return rate.num != userRate.num || rate.denom != userRate.denom;
             });
@@ -239,15 +245,15 @@ onboardLoggingTab.initialize = function (callback) {
             return a.num / a.denom - b.num / b.denom;
         });
 
-        for (var i = 0; i < offeredRates.length; i++) {
-            var
-                ratio = offeredRates[i].num / offeredRates[i].denom,
+        for (const rate of offeredRates) {
+            const
+                ratio = rate.num / rate.denom,
                 percent = Math.round(ratio * 100),
                 // Rates well below one percent would all be shown as 0%
                 label = ratio < 0.01 ? (ratio * 100).toFixed(1) : percent;
 
-            loggingRatesSelect.append('<option value="' + offeredRates[i].num + '/' + offeredRates[i].denom + '" data-percent="' + percent + '">'
-                + offeredRates[i].num + '/' + offeredRates[i].denom + ' (' + label + '%)</option>');
+            loggingRatesSelect.append('<option value="' + rate.num + '/' + rate.denom + '" data-percent="' + percent + '">'
+                + rate.num + '/' + rate.denom + ' (' + label + '%)</option>');
 
         }
         loggingRatesSelect.val(userRate.num + '/' + userRate.denom);


### PR DESCRIPTION
## Problem

With `blackbox_rate_denom` set above 255 the logging rate control in the Onboard Logging tab shows the wrong thing: at 1/256 the select box is empty, and at 1/384 it shows what the reporter described as a signed 16-bit overflow (screenshots in the report). Fixes #2581, and fixes #1156, which reported the same display errors for denominators 510 and 800.

## Cause

`js/msp/MSPHelper.js:1597-1598` on `maintenance-10.x` reads `rate_num` and `rate_denom` with `data.getUint16(2)` / `data.getUint16(4)`, i.e. big endian, while the firmware serialises them with `sbufWriteU16()` (`src/main/fc/fc_msp.c:1336-1337`, little endian). That made the decoded numerator 256 times too large. Up to denominator 255 the `gcd()` at `tabs/onboard_logging.js:197` divided the extra factor out again, above it did not: 1/256 decodes as 256/1, 1/384 as 256/32769. The offered rate list at `tabs/onboard_logging.js:202-215` also stops at 1/32, so a slower configured rate has no matching option, and the tab saves whatever the select shows (`tabs/onboard_logging.js:134`).

## Change

Read both 16-bit fields little endian, matching the `getUint32(6, true)` on the next line. `populateLoggingRates()` now clears the select before filling it, always adds the configured rate to the offered list, sorts the entries by ratio and preselects the configured one, and falls back to 1/1 when the flight controller reports no usable rate; rates below 1% get one decimal place instead of "0%". The `MSP_BLACKBOX_CONFIG` / `MSP_SET_BLACKBOX_CONFIG` decode branches are removed — no code path sends those codes.

## Test

Not run in the app or against hardware for this revision, and no unit test was added; the repo's `tests/*.test.mjs` suite is not part of CI either. The cause was verified by reading `js/msp/MSPHelper.js:1597` against the firmware's `sbufWriteU16(dst, blackboxConfig()->rate_num)`. CI builds pass on all six platforms: https://github.com/iNavFlight/inav-configurator/actions/runs/34527921313 — SonarCloud quality gate passed: https://sonarcloud.io/dashboard?id=iNavFlight_inav-configurator&pullRequest=2753

## Flash / RAM
Not applicable (Configurator).

## Docs

No documentation change is needed. Nothing in the repository documents the blackbox rate range, and the tab's only related string, `onboardLoggingBlackboxRate` in `locale/en/messages.json:1107` ("Portion of flight loop iterations to log (logging rate)"), stays correct.
