### PR TITLE
Enable the virtual pitot only for fixed wing setups

### DIFF
--- a/js/wizard_save_framework.js
+++ b/js/wizard_save_framework.js
@@ -31,7 +31,9 @@ var wizardSaveFramework = (function () {
 
                 serialPortHelper.set(config.value.port, 'GPS', config.value.baud);
                 mspHelper.saveSerialPorts(function () {
-                    features.execute(self.enableVirtulaPitot(config, callback));
+                    features.execute(function () {
+                        self.enableVirtualPitot(config, callback);
+                    });
                 });
                 break;
             case 'gpsProtocol':
@@ -43,12 +45,27 @@ var wizardSaveFramework = (function () {
         }
     };
 
-    self.enableVirtulaPitot = function (config, callback) {
-        if (config.value.port != '-1') {
-            mspHelper.setSetting('pitot_hardware', "VIRTUAL", callback);
-        } else {
+    /*
+     * The virtual pitot derives airspeed from GPS and the wind estimator, which is
+     * only of use on a fixed wing. Every other platform keeps the firmware default.
+     * An airspeed sensor that is already selected is never replaced either, so
+     * re-running the wizard does not take a pitot away from the user.
+     */
+    self.enableVirtualPitot = function (config, callback) {
+        if (config.value.port == '-1' || !FC.isAirplane()) {
             callback();
+            return;
         }
+
+        mspHelper.getSetting('pitot_hardware').then(function (data) {
+            if (data?.setting?.table?.values?.[data.value] == 'NONE') {
+                mspHelper.setSetting('pitot_hardware', "VIRTUAL", callback);
+            } else {
+                callback();
+            }
+        }).catch(function () {
+            callback();
+        });
     };
 
     self.handleSetting = function (configs, finalCallback) {


### PR DESCRIPTION
## Problem

Setting up a new copter with the defaults wizard leaves the virtual pitot sensor enabled. The reporter turns it off by hand every time and asks whether a quadcopter needs it at all. The firmware default for `pitot_hardware` is `NONE`. Fixes #2670.

## Cause

`js/wizard_save_framework.js:46-52` on `maintenance-10.x`. `enableVirtulaPitot()` writes `pitot_hardware = VIRTUAL` whenever the wizard configured a GPS port, without checking the platform type and without looking at the current value.

## Change

The write is limited to fixed wing (`FC.isAirplane()`); every other platform keeps the firmware default. The setting is read first and only written while it is still `NONE`, so re-running the wizard no longer replaces a pitot the user selected, and a failed read falls through to the callback. At the call site, `features.execute(self.enableVirtulaPitot(config, callback))` invoked the function immediately and passed its return value `undefined` as the callback; it is a closure now. The function name typo is corrected to `enableVirtualPitot`; nothing else references it.

## Test

Not run in the app for this revision. Cause verified by reading `js/wizard_save_framework.js:46-52` on `maintenance-10.x`; `FC.MIXER_CONFIG.platformType` is set in `js/defaults_dialog.js:262` before the wizard persists, so `FC.isAirplane()` is populated when the guard runs. CI green on all seven jobs of [run 34511054437](https://github.com/iNavFlight/inav-configurator/actions/runs/34511054437), which also carries the test build artifacts; SonarCloud quality gate passed.

## Flash / RAM
Not applicable (Configurator).

## Docs

None needed. No file on the target branch documents the wizard's pitot behaviour; the only `pitot`/`airspeed` match in the tracked Markdown is the OSD glyph table in `resources/osd/INAV Character Map.md`, which this change does not affect.
