### PR TITLE
Fail the macOS arm64 build instead of uploading nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
               with:
                 name: pr-number
                 path: pr_number.txt
+                if-no-files-found: error
 
     build-linux:
         runs-on: ubuntu-24.04
@@ -69,16 +70,19 @@ jobs:
               with:
                 name: ${{ env.BUILD_NAME }}_DEB
                 path: ./out/make/deb/x64/*.deb
+                if-no-files-found: error
             - name: Upload Linux rpm
               uses: actions/upload-artifact@v4
               with:
                 name: ${{ env.BUILD_NAME }}_RPM
                 path: ./out/make/rpm/x64/*.rpm
+                if-no-files-found: error
             - name: Upload Linux zip
               uses: actions/upload-artifact@v4
               with:
                 name: ${{ env.BUILD_NAME }}_ZIP
                 path: ./out/make/zip/linux/x64/*.zip
+                if-no-files-found: error
 
     build-linux-aarch64:
         runs-on: ubuntu-24.04
@@ -122,16 +126,19 @@ jobs:
               with:
                 name: ${{ env.BUILD_NAME }}_DEB
                 path: ./out/make/deb/arm64/*.deb
+                if-no-files-found: error
             - name: Upload Linux rpm
               uses: actions/upload-artifact@v4
               with:
                 name: ${{ env.BUILD_NAME }}_RPM
                 path: ./out/make/rpm/arm64/*.rpm
+                if-no-files-found: error
             - name: Upload Linux zip
               uses: actions/upload-artifact@v4
               with:
                 name: ${{ env.BUILD_NAME }}_ZIP
                 path: ./out/make/zip/linux/arm64/*.zip
+                if-no-files-found: error
 
     build-mac-arm64:
         runs-on: macos-15
@@ -169,17 +176,21 @@ jobs:
             timeout_minutes: 10
             on_retry_command: rm -rfv node_modules
         - name: Build MacOS arm64
+          env:
+            NODE_OPTIONS: --max-old-space-size=4096
           run: yarn run make -- --arch="arm64"
         - name: Upload MacOS arm64 zip
           uses: actions/upload-artifact@v4
           with:
             name: ${{env.BUILD_NAMEarm64}}_ZIP
             path: ./out/make/zip/darwin/arm64/*.zip
+            if-no-files-found: error
         - name: Upload MacOS arm64 dmg
           uses: actions/upload-artifact@v4
           with:
             name: ${{env.BUILD_NAMEarm64}}_DMG
             path: ./out/make/*arm64*.dmg
+            if-no-files-found: error
 
     build-mac:
         runs-on: macos-15-intel
@@ -225,11 +236,13 @@ jobs:
           with:
             name: ${{env.BUILD_NAMEx64}}_ZIP
             path: ./out/make/zip/darwin/x64/*.zip
+            if-no-files-found: error
         - name: Upload MacOS x64 dmg
           uses: actions/upload-artifact@v4
           with:
             name: ${{env.BUILD_NAMEx64}}_DMG
             path: ./out/make/*x64*.dmg
+            if-no-files-found: error
 
     build-windows:
         runs-on: windows-latest
@@ -278,11 +291,13 @@ jobs:
               with:
                 name: ${{env.BUILD_NAMEx64}}_ZIP
                 path: ./out/make/zip/win32/x64/*.zip
+                if-no-files-found: error
             - name: Upload Windows x64 msi
               uses: actions/upload-artifact@v4
               with:
                 name: ${{env.BUILD_NAMEx64}}_MSI
                 path: ./out/make/wix/x64/*.msi
+                if-no-files-found: error
 
     build-windows-win32:
         runs-on: windows-latest
@@ -331,9 +346,11 @@ jobs:
               with:
                 name: ${{env.BUILD_NAMEia32}}_ZIP
                 path: ./out/make/zip/win32/ia32/*.zip
+                if-no-files-found: error
             - name: Upload Windows ia32 msi
               uses: actions/upload-artifact@v4
               with:
                 name: ${{env.BUILD_NAMEia32}}_MSI
                 path: ./out/make/wix/ia32/*.msi
+                if-no-files-found: error
  


### PR DESCRIPTION
## Problem
The macOS arm64 job in `ci.yml` runs out of Node heap while packaging, yet still reports success and uploads no `MacOS_arm64` artifact, so PR test builds quietly ship without arm64 downloads. The reporter spotted it by the runtime: roughly 80 seconds for arm64 against 4-5 minutes for x64 (https://github.com/iNavFlight/inav-configurator/issues/2701).

## Cause
At this branch's base commit `a4e6b175`, `.github/workflows/ci.yml:171` runs `Build MacOS arm64` with no `env:` block, while `Build MacOS x64` at line 220 already sets `NODE_OPTIONS: --max-old-space-size=4096`. No `upload-artifact` step in that file set `if-no-files-found`, and the action's default `warn` lets an upload of nothing pass as success.

## Change
Adds `NODE_OPTIONS: --max-old-space-size=4096` to the arm64 build step, matching x64. Sets `if-no-files-found: error` on all 15 `upload-artifact` steps: PR number, Linux x64 and aarch64, macOS x64 and arm64, Windows x64 and ia32. The identical lines have meanwhile reached `maintenance-10.x` through the merge of #2725 on 2026-09-13 (`b806f418`), so this diff no longer changes the branch head.

## Test
No app run; the change affects CI only. Run https://github.com/iNavFlight/inav-configurator/actions/runs/34511555323 at `bdb41af` passed all eight checks: `build-mac-arm64` took 3m48s instead of the ~80s failure signature and produced `MacOS_arm64` DMG (148.8 MB) and ZIP (148.4 MB), with all 15 artifacts present. SonarCloud reported 0 new issues.

## Flash / RAM
Not applicable (Configurator).

## Docs
None needed. `README.md` covers local `yarn run make`; these are runner environment and upload-action inputs only.
