### PR TITLE
Do not print the leftover MSP response in the CLI

### DIFF
--- a/js/msp.js
+++ b/js/msp.js
@@ -192,16 +192,32 @@ var MSP = {
         this.processData = cb;
     },
 
-    read: function (readInfo) {
+    /**
+     * Decodes incoming bytes and returns how many of them were consumed.
+     *
+     * With stopWhenIdle set, decoding stops as soon as the decoder sits between
+     * frames. A caller that takes the port over while a frame is half decoded
+     * (the CLI tab does, on tab entry) can use that to let the decoder finish
+     * the frame in progress and keep only the bytes after it.
+     *
+     * @param {{data: ArrayBuffer|Uint8Array}} readInfo
+     * @param {boolean} [stopWhenIdle]
+     * @returns {number} bytes taken from the front of readInfo.data
+     */
+    read: function (readInfo, stopWhenIdle) {
         var data;
         try {
             data = new Uint8Array(readInfo.data);
         } catch (e) {
             console.error('MSP read: Failed to create Uint8Array from readInfo.data:', e, 'readInfo:', readInfo);
-            return;
+            return 0;
         }
 
-        for (var i = 0; i < data.length; i++) {
+        var i = 0;
+        for (; i < data.length; i++) {
+            if (stopWhenIdle && this.state == this.decoder_states.IDLE) {
+                break;
+            }
             switch (this.state) {
                 case this.decoder_states.IDLE: // sync char 1
                     if (data[i] == this.symbols.BEGIN) {
@@ -346,6 +362,8 @@ var MSP = {
             }
         }
         this.last_received_timestamp = Date.now();
+
+        return i;
     },
 
     _initialize_read_buffer() {

--- a/js/msp.js
+++ b/js/msp.js
@@ -192,32 +192,16 @@ var MSP = {
         this.processData = cb;
     },
 
-    /**
-     * Decodes incoming bytes and returns how many of them were consumed.
-     *
-     * With stopWhenIdle set, decoding stops as soon as the decoder sits between
-     * frames. A caller that takes the port over while a frame is half decoded
-     * (the CLI tab does, on tab entry) can use that to let the decoder finish
-     * the frame in progress and keep only the bytes after it.
-     *
-     * @param {{data: ArrayBuffer|Uint8Array}} readInfo
-     * @param {boolean} [stopWhenIdle]
-     * @returns {number} bytes taken from the front of readInfo.data
-     */
-    read: function (readInfo, stopWhenIdle) {
+    read: function (readInfo) {
         var data;
         try {
             data = new Uint8Array(readInfo.data);
         } catch (e) {
             console.error('MSP read: Failed to create Uint8Array from readInfo.data:', e, 'readInfo:', readInfo);
-            return 0;
+            return;
         }
 
-        var i = 0;
-        for (; i < data.length; i++) {
-            if (stopWhenIdle && this.state == this.decoder_states.IDLE) {
-                break;
-            }
+        for (var i = 0; i < data.length; i++) {
             switch (this.state) {
                 case this.decoder_states.IDLE: // sync char 1
                     if (data[i] == this.symbols.BEGIN) {
@@ -362,8 +346,38 @@ var MSP = {
             }
         }
         this.last_received_timestamp = Date.now();
+    },
 
-        return i;
+    /**
+     * Feeds bytes to read() for as long as a frame is still being decoded and
+     * returns how many of them were taken.
+     *
+     * A caller that takes the port over while a frame is only half decoded (the
+     * CLI tab does, on tab entry) can use this to let the decoder finish the
+     * frame in progress - which also completes the request that was in flight -
+     * and keep the bytes that follow for itself. The bytes are handed over one
+     * at a time because only the decoder knows where the frame ends: it returns
+     * to the IDLE state as soon as it has dispatched the frame.
+     *
+     * @param {{data: ArrayBuffer|Uint8Array}} readInfo
+     * @returns {number} bytes taken from the front of readInfo.data
+     */
+    read_until_idle: function (readInfo) {
+        var data;
+        try {
+            data = new Uint8Array(readInfo.data);
+        } catch (e) {
+            console.error('MSP read_until_idle: Failed to create Uint8Array from readInfo.data:', e, 'readInfo:', readInfo);
+            return 0;
+        }
+
+        var consumed = 0;
+        while (consumed < data.length && this.state != this.decoder_states.IDLE) {
+            this.read({ data: data.subarray(consumed, consumed + 1) });
+            consumed++;
+        }
+
+        return consumed;
     },
 
     _initialize_read_buffer() {

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -583,7 +583,7 @@ var SerialBackend = (function () {
         // hand the CLI tab only what follows, instead of printing the tail of an
         // MSP response as junk. Nothing is taken once the FC has answered with
         // the CLI banner: from there on every byte is CLI output.
-        var mspBytes = CONFIGURATOR.cliValid ? 0 : MSP.read(info, true);
+        var mspBytes = CONFIGURATOR.cliValid ? 0 : MSP.read_until_idle(info);
         if (mspBytes === 0) {
             cliTab.read(info);
             return;
@@ -591,7 +591,7 @@ var SerialBackend = (function () {
 
         var rest = info.data.slice(mspBytes);
         if (rest.byteLength > 0) {
-            cliTab.read(Object.assign({}, info, { data: rest }));
+            cliTab.read({ ...info, data: rest });
         }
     }
 

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -572,8 +572,26 @@ var SerialBackend = (function () {
     publicScope.read_serial = function (info) {
         if (!CONFIGURATOR.cliActive) {
             MSP.read(info);
-        } else if (CONFIGURATOR.cliActive) {
+            return;
+        }
+
+        // The FC only switches to CLI mode once it sees the '#', so the response
+        // to a request sent just before the tab was opened can still be arriving,
+        // and the decoder can already hold the front half of it. Those trailing
+        // bytes belong to that frame, not to the CLI session: let the decoder
+        // finish it - which also completes the request that was in flight - and
+        // hand the CLI tab only what follows, instead of printing the tail of an
+        // MSP response as junk. Nothing is taken once the FC has answered with
+        // the CLI banner: from there on every byte is CLI output.
+        var mspBytes = CONFIGURATOR.cliValid ? 0 : MSP.read(info, true);
+        if (mspBytes === 0) {
             cliTab.read(info);
+            return;
+        }
+
+        var rest = info.data.slice(mspBytes);
+        if (rest.byteLength > 0) {
+            cliTab.read(Object.assign({}, info, { data: rest }));
         }
     }
 


### PR DESCRIPTION
## Problem

Opening the CLI tab prints a run of stray characters before the flight controller banner. The
reporter saw "funny characters, including the string `$M<`" on INAV 9, which @stronnag identified as
a left-over MSP response. Fixes #2529.

## Cause

`js/serial_backend.js:572` routes each received chunk as a whole, on `CONFIGURATOR.cliActive`: to
`MSP.read()` before, to `cliTab.read()` after. `tabs/cli.js:191` sets that flag synchronously on tab
entry, but the `#` that puts the FC into CLI mode is only sent 250 ms later (`tabs/cli.js:461-469`),
so a reply already in flight can straddle the switch - its header sits in the MSP decoder while the
payload and checksum bytes that follow are printed by the CLI. `removeMspFrames()`
(`tabs/cli.js:58`) drops only complete frames starting with `$`, so that headless remainder passes
through it.

## Change

`js/msp.js` gains `read_until_idle()`, which feeds `read()` one byte at a time while the decoder is
not IDLE and returns how many bytes it took; `read()` itself is unchanged. In `read_serial()`, while
the CLI is active but not yet confirmed (`!CONFIGURATOR.cliValid`), the decoder finishes the frame it
started and only the rest of the chunk goes to `cliTab.read()`; the completed frame is dispatched
normally and closes the pending request. An idle decoder takes nothing, so CLI text beginning with
`$` still reaches the tab in full.

## Test

Not run in the app for this revision, and the diff adds no unit test. Cause verified by reading
`js/serial_backend.js:572` and `tabs/cli.js:191`/`461` on `maintenance-10.x`. CI green on `6e886c5`
(six platform builds, plus a test build of that commit):
https://github.com/iNavFlight/inav-configurator/actions/runs/34526807655
SonarCloud quality gate passed:
https://sonarcloud.io/dashboard?id=iNavFlight_inav-configurator&pullRequest=2756

## Flash / RAM
Not applicable (Configurator).

## Docs

None needed - no document describes the byte routing at CLI entry.
