### PR TITLE
Let numeric fields be typed into again

### DIFF
--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -675,17 +675,25 @@ $(function() {
             }
         });
 
+        // Keep letters and punctuation out of numeric fields, but only those.
+        // A keyCode whitelist cannot express "any shortcut", so it used to
+        // swallow select all, copy, paste, cut, undo, Home and End as well,
+        // which left overwriting an existing value to backspace alone.
         $content.on('keydown', 'input[type="number"]', function (e) {
-            // whitelist all that we need for numeric control
-            var whitelist = [
-                96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, // numpad and standard number keypad
-                109, 189, // minus on numpad and in standard keyboard
-                8, 46, 9, // backspace, delete, tab
-                190, 110, // decimal point
-                37, 38, 39, 40, 13 // arrows and enter
-            ];
+            // Shortcuts carry a modifier, the browser handles them.
+            if (e.ctrlKey || e.metaKey || e.altKey) {
+                return;
+            }
 
-            if (whitelist.indexOf(e.keyCode) == -1) {
+            // Keys that do not insert text report a name rather than a single
+            // character: arrows, Home, End, backspace, delete, tab, enter.
+            if (typeof e.key !== 'string' || e.key.length > 1) {
+                return;
+            }
+
+            // What is left are the characters a number may consist of. The
+            // comma is the decimal separator the numpad emits on many layouts.
+            if (!/[0-9.,-]/.test(e.key)) {
                 e.preventDefault();
             }
         });


### PR DESCRIPTION
## Problem

Numeric fields in the OSD tab cannot be filled in from the keypad: the values can only be changed
with the up/down arrows of the spinner, typing digits straight into a field does not take effect
(#2528).

## Cause

`js/configurator_main.js:678-691` on `maintenance-10.x`. A delegated `keydown` handler covers every
`input[type="number"]` under `#content`, matches each keystroke against a keyCode whitelist
(680-686) and calls `preventDefault()` on everything else (688). A keyCode list cannot express "key
held with a modifier", so Ctrl+A, Ctrl+V, Home and End are blocked along with the letters, leaving
no way to select a pre-filled value and type over it.

## Change

The filter works on the character instead of the keyCode. Events carrying `ctrlKey`, `metaKey` or
`altKey` return early, as do events whose `e.key` is longer than one character - arrows, Home, End,
Backspace, Delete, Tab, Enter. Of the remaining single characters only `[0-9.,-]` passes, everything
else is still rejected with `preventDefault()`. The comma is kept because the old list allowed
keyCode 110, the numpad decimal key, which emits `,` on many layouts; the `focus` and `change`
handlers, including the min/max clamping, are unchanged.

## Test

Not verified in the running app for this revision - no screenshot or log is attached, and no unit
test covers this handler. The cause was verified by reading `js/configurator_main.js:678-691` on
`maintenance-10.x`. CI is green on `7e5b348`, six platform builds and the SonarCloud quality gate:
https://github.com/iNavFlight/inav-configurator/actions/runs/34513199916 - that run also carries the
platform test builds.

## Flash / RAM
Not applicable (Configurator).

## Docs

None needed. No documentation on `maintenance-10.x` describes the numeric-field key filter; a grep
of the markdown files for `keyCode`, `whitelist`, `keydown` and `keypad` returns nothing.
