### PR TITLE
Import MSPChainerClass and mspHelper in the logic conditions collection

### DIFF
--- a/js/logicConditionsCollection.js
+++ b/js/logicConditionsCollection.js
@@ -1,5 +1,8 @@
 'use strict';
 
+import mspHelper from './msp/MSPHelper';
+import MSPChainerClass from './msp/MSPchainer';
+
 var LogicConditionsCollection = function () {
 
     let self = {},


### PR DESCRIPTION
## Problem

From the Mixer tab, opening the Logic Conditions overlay, changing a condition and clicking Save does not save: the Configurator drops the connection and the log shows `Unexpected error: MSPChainerClass is not defined`. The same edit through the CLI `logic` command works, and saving from the Programming tab works. Confirmed in the report by @mmosca and @b14ckyy, both only from the Mixer tab. Fixes #2294.

## Cause

`js/logicConditionsCollection.js` has no imports. `self.onSave` calls `new MSPChainerClass()` at `js/logicConditionsCollection.js:52` and `mspHelper.sendLogicConditions` / `mspHelper.saveToEeprom` at lines 55-56. Both became default exports with the move to ES modules (`js/msp/MSPchainer.js:37`, `js/msp/MSPHelper.js:3951`), so neither bare name exists in module scope and the handler throws. Only the Mixer overlay reaches it: the handler is bound to `.logic__save` at line 69, and that element exists only in `tabs/mixer.html:194`; the Programming tab saves through its own chainer in `tabs/programming.js`.

## Change

Adds the two missing imports at the top of `js/logicConditionsCollection.js`, with the same extensionless specifiers already used in `js/defaults_dialog.js:7-8`. One file, three lines added, nothing else.

## Test

Not run in the app for this revision. Reproduction is the one in #2294 (reporter log and screenshots, confirmed independently by two maintainers). Cause verified by reading the call sites above. All eight checks are green on 3254e77, including the six platform builds, which bundle this file via `js/fc.js:5` and would fail on an unresolved specifier: https://github.com/iNavFlight/inav-configurator/actions/runs/34516145829. The unit tests do not cover this path — `tests/fc-generate-aux-config.test.mjs:110` replaces the collection with a mock — and CI does not run them.

## Flash / RAM
Not applicable (Configurator).

## Docs

None needed. Nothing in the Markdown tree on `maintenance-10.x` describes the Logic Conditions save path or this module's imports.
