### PR TITLE
Disable OSD elements the tab can no longer show

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6788,6 +6788,9 @@
     "osdClearLayout": {
         "message": "Layout has been cleared"
     },
+    "osdLayoutSaveFailed": {
+        "message": "The flight controller did not accept all OSD layout changes. Settings were not saved to permanent storage. Check the connection and reload the OSD tab before trying again."
+    },
     "osdElementsWithoutHardwareDisabled": {
         "message": "Switched off elements without hardware or feature: $1. They keep their position and come back switched off when the hardware is enabled again."
     },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -6788,6 +6788,9 @@
     "osdClearLayout": {
         "message": "Layout has been cleared"
     },
+    "osdElementsWithoutHardwareDisabled": {
+        "message": "Switched off elements without hardware or feature: $1. They keep their position and come back switched off when the hardware is enabled again."
+    },
     "failedToOpenSerialPort": {
         "message": "<span style=\"color: red\">Failed</span> to open serial port"
     },

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -2525,10 +2525,16 @@ OSD.get_unreachable_items = function() {
 // user's back. The position of each element is kept, so turning the hardware
 // back on brings the element back in its old spot, switched off.
 OSD.disable_unreachable_items = async function() {
-    var items = OSD.get_unreachable_items();
+    const items = OSD.get_unreachable_items();
+    const layout = OSD.data.selected_layout;
+    const positions = OSD.data.items;
     for (const item of items) {
-        OSD.data.items[item.id].isVisible = false;
-        await OSD.saveItem(item);
+        const position = positions[item.id];
+        const result = await OSD.saveItem(item, undefined, layout, { ...position, isVisible: false });
+        if (!result || result.unsupported) {
+            throw new Error('OSD layout write failed');
+        }
+        position.isVisible = false;
     }
     return items;
 };
@@ -2669,10 +2675,14 @@ OSD.saveConfig = function(callback) {
     });
 };
 
-OSD.saveItem = function(item, callback) {
-    let pos = OSD.data.items[item.id];
-    let data = OSD.msp.encodeLayoutItem(OSD.data.selected_layout, item, pos);
-    return MSP.promise(MSPCodes.MSP2_INAV_OSD_SET_LAYOUT_ITEM, data).then(callback);
+OSD.saveItem = function(item, callback, layout = OSD.data.selected_layout, pos = OSD.data.items[item.id]) {
+    const data = OSD.msp.encodeLayoutItem(layout, item, pos);
+    return new Promise(function(resolve) {
+        // A refused write returns false without calling its transport callback.
+        if (MSP.send_message(MSPCodes.MSP2_INAV_OSD_SET_LAYOUT_ITEM, data, false, resolve) === false) {
+            resolve(false);
+        }
+    }).then(callback);
 };
 
 //noinspection JSUnusedLocalSymbols
@@ -3757,12 +3767,22 @@ osdTab.initialize = function (callback) {
                 content: $('#fontmanagercontent')
             });
 
+            let saving = false;
             $('a.save').on('click', async function () {
-                var disabled = await OSD.disable_unreachable_items();
-                if (disabled.length > 0) {
-                    GUI.log(i18n.getMessage('osdElementsWithoutHardwareDisabled', [disabled.map(OSD.get_item_name).join(', ')]));
+                if (saving) return;
+                saving = true;
+                try {
+                    const disabled = await OSD.disable_unreachable_items();
+                    if (disabled.length > 0) {
+                        GUI.log(i18n.getMessage('osdElementsWithoutHardwareDisabled', [disabled.map(OSD.get_item_name).join(', ')]));
+                    }
+                    Settings.saveInputs(save_to_eeprom);
+                } catch (error) {
+                    GUI.log(i18n.getMessage('osdLayoutSaveFailed'));
+                } finally {
+                    saving = false;
+                    OSD.GUI.updatePreviews();
                 }
-                Settings.saveInputs(save_to_eeprom);
             });
 
             // Initialise guides checkbox

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -2450,7 +2450,9 @@ OSD.get_item = function(item_id) {
     return null;
 };
 
-OSD.is_item_displayed = function(item, group) {
+// Whether the connected FC knows this element at all. Says nothing about the
+// hardware or the features behind it, see OSD.is_item_displayed().
+OSD.is_item_supported = function(item) {
     if (!OSD.data.items[item.id]) {
         // FC has no data about this item, so
         // it doesn't support it.
@@ -2459,19 +2461,76 @@ OSD.is_item_displayed = function(item, group) {
     if (FC.getOsdDisabledFields().indexOf(item.name) != -1) {
         return false;
     }
+    if (item.min_version && !semver.gte(FC.CONFIG.flightControllerVersion, item.min_version)) {
+        return false;
+    }
+    return true;
+};
+
+OSD.is_item_displayed = function(item, group) {
+    if (!OSD.is_item_supported(item)) {
+        return false;
+    }
     if (!group) {
         return false;
     }
     if (typeof group.enabled === 'function' && group.enabled() === false) {
         return false;
     }
-    if (item.min_version && !semver.gte(FC.CONFIG.flightControllerVersion, item.min_version)) {
-        return false;
-    }
     if (typeof item.enabled === 'function' && item.enabled() === false) {
         return false;
     }
     return true;
+};
+
+OSD.get_item_name = function(item) {
+    var name = i18n.getMessage('osdElement_' + item.name);
+    return name ? name : titleize(item.name);
+};
+
+// Elements whose hardware or feature is gone - a pitot set to NONE, an ESC
+// telemetry port removed - are hidden from the element list and from the
+// preview, but the FC keeps drawing them and the GUI no longer offers a way to
+// switch them off. Returns the enabled items of the selected layout that are
+// unreachable for that reason. Elements the FC does not support at all, or that
+// need a newer firmware, are left untouched: the GUI hides those without
+// knowing what the id currently holds.
+OSD.get_unreachable_items = function() {
+    if (!OSD.data || !OSD.data.items) {
+        return [];
+    }
+    var reachable = [];
+    var unreachable = [];
+    OSD.constants.ALL_DISPLAY_GROUPS.forEach(function(group) {
+        group.items.forEach(function(item) {
+            if (!OSD.is_item_supported(item)) {
+                return;
+            }
+            if (OSD.is_item_displayed(item, group)) {
+                reachable.push(item.id);
+            } else if (OSD.data.items[item.id].isVisible && !unreachable.some(function(other) { return other.id == item.id; })) {
+                unreachable.push(item);
+            }
+        });
+    });
+    // The same id can be listed in several groups, and only one of them may be
+    // gated off. Such an element is still reachable, so leave it alone.
+    return unreachable.filter(function(item) {
+        return reachable.indexOf(item.id) == -1;
+    });
+};
+
+// Disables the unreachable elements of the selected layout on the FC. Only
+// called when the user saves, never on load, so nothing changes behind the
+// user's back. The position of each element is kept, so turning the hardware
+// back on brings the element back in its old spot, switched off.
+OSD.disable_unreachable_items = async function() {
+    var items = OSD.get_unreachable_items();
+    for (var ii = 0; ii < items.length; ii++) {
+        OSD.data.items[items[ii].id].isVisible = false;
+        await OSD.saveItem(items[ii]);
+    }
+    return items;
 };
 
 OSD.get_item_preview = function(item) {
@@ -3040,14 +3099,8 @@ OSD.GUI.updateFields = function(event) {
             var itemData = OSD.data.items[item.id];
             var checked = itemData.isVisible ? 'checked' : '';
             var $field = $('<div class="display-field field-' + item.id + '"/>');
-            var name = item.name;
-            var nameKey = 'osdElement_' + name;
-            var nameMessage = i18n.getMessage(nameKey);
-            if (nameMessage) {
-                name = nameMessage;
-            } else {
-                name = titleize(name);
-            }
+            var nameKey = 'osdElement_' + item.name;
+            var name = OSD.get_item_name(item);
             var searchTerm = osdSearch.val();
             if (searchTerm.length > 0 && !name.toLowerCase().includes(searchTerm.toLowerCase())) {
                 continue;
@@ -3704,7 +3757,11 @@ osdTab.initialize = function (callback) {
                 content: $('#fontmanagercontent')
             });
 
-            $('a.save').on('click', function () {
+            $('a.save').on('click', async function () {
+                var disabled = await OSD.disable_unreachable_items();
+                if (disabled.length > 0) {
+                    GUI.log(i18n.getMessage('osdElementsWithoutHardwareDisabled', [disabled.map(OSD.get_item_name).join(', ')]));
+                }
                 Settings.saveInputs(save_to_eeprom);
             });
 

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -2485,7 +2485,7 @@ OSD.is_item_displayed = function(item, group) {
 
 OSD.get_item_name = function(item) {
     var name = i18n.getMessage('osdElement_' + item.name);
-    return name ? name : titleize(item.name);
+    return name || titleize(item.name);
 };
 
 // Elements whose hardware or feature is gone - a pitot set to NONE, an ESC
@@ -2496,7 +2496,7 @@ OSD.get_item_name = function(item) {
 // need a newer firmware, are left untouched: the GUI hides those without
 // knowing what the id currently holds.
 OSD.get_unreachable_items = function() {
-    if (!OSD.data || !OSD.data.items) {
+    if (!OSD.data?.items) {
         return [];
     }
     var reachable = [];
@@ -2516,7 +2516,7 @@ OSD.get_unreachable_items = function() {
     // The same id can be listed in several groups, and only one of them may be
     // gated off. Such an element is still reachable, so leave it alone.
     return unreachable.filter(function(item) {
-        return reachable.indexOf(item.id) == -1;
+        return !reachable.includes(item.id);
     });
 };
 
@@ -2526,9 +2526,9 @@ OSD.get_unreachable_items = function() {
 // back on brings the element back in its old spot, switched off.
 OSD.disable_unreachable_items = async function() {
     var items = OSD.get_unreachable_items();
-    for (var ii = 0; ii < items.length; ii++) {
-        OSD.data.items[items[ii].id].isVisible = false;
-        await OSD.saveItem(items[ii]);
+    for (const item of items) {
+        OSD.data.items[item.id].isVisible = false;
+        await OSD.saveItem(item);
     }
     return items;
 };

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -3778,6 +3778,7 @@ osdTab.initialize = function (callback) {
                     }
                     Settings.saveInputs(save_to_eeprom);
                 } catch (error) {
+                    console.error('Failed to save OSD layout:', error);
                     GUI.log(i18n.getMessage('osdLayoutSaveFailed'));
                 } finally {
                     saving = false;


### PR DESCRIPTION
## Problem

With `pitot_hardware = VIRTUAL` and the Air Speed element enabled, setting `pitot_hardware = NONE` makes the Configurator drop Air Speed from the element list and from the preview, while the flight controller keeps drawing it on the goggles as `0` with the warning indicator, and no GUI path is left to switch it off. Reported on Configurator 9.0.1 / firmware 9.0.1, and not pitot-specific: any element behind a switchable hardware or feature gate can end up the same way. Fixes #2639.

## Cause

`OSD.is_item_displayed()` hides an element as soon as its group or item `enabled()` gate returns false — tabs/osd.js:2465 and tabs/osd.js:2471 on maintenance-10.x — so it leaves the list and the preview. The save handler at tabs/osd.js:3707 only calls `Settings.saveInputs(save_to_eeprom)` and never writes the layout, so the element's visible bit stays set on the FC.

## Change

`is_item_displayed()` is split: `is_item_supported()` takes the three checks that do not depend on hardware (id unknown to the FC, field disabled in the build, `min_version` too new), and `is_item_displayed()` keeps the gate checks on top. `get_unreachable_items()` returns the elements of the selected layout that are still visible and hidden only because a gate closed, skipping any id that is still reachable through another open group. On save those elements get their visible bit cleared and are written back with `MSP2_INAV_OSD_SET_LAYOUT_ITEM` on the layout captured before the writes start, keeping their x/y, and `GUI.log` names them. A refused or failed write aborts the save before EEPROM and logs `osdLayoutSaveFailed`.

## Test

Not run on a flight controller or in the app for this revision — no screenshot or log — and no test was added to `tests/*.test.mjs`. Cause verified by reading tabs/osd.js:2465 and tabs/osd.js:3707 on maintenance-10.x. CI is green for head `c9c24a6`: six platform builds plus the SonarCloud gate with 0 new issues — https://github.com/iNavFlight/inav-configurator/actions/runs/34618043694. Those jobs package the app; they do not exercise this path.

## Flash / RAM
Not applicable (Configurator).

## Docs

None needed. The repository's markdown covers fonts, terrain files and developer patterns; no document describes OSD element visibility or the save path.
