### PR TITLE
Keep the approach length read from the flight controller

### DIFF
--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -2057,11 +2057,11 @@ function iconKey(filename) {
     function loadSettings() {
         // These are read from the FC every time this tab is opened, the stored copy
         // is only a fallback for the offline case.
-        const fcProvidedSettings = ['fwApproachLength', 'maxDistSH', 'fwLoiterRadius'];
+        const fcProvidedSettings = new Set(['fwApproachLength', 'maxDistSH', 'fwLoiterRadius']);
         const missionPlannerSettings = store.get('missionPlannerSettings', false);
         if (missionPlannerSettings) {
             Object.keys(missionPlannerSettings).forEach(function (key) {
-                if (!isOffline && fcProvidedSettings.includes(key) && Number.isFinite(settings[key])) {
+                if (!isOffline && fcProvidedSettings.has(key) && Number.isFinite(settings[key])) {
                     // Keep the value just read from the FC, the stored one is outdated
                     // as soon as the setting was changed on another tab.
                     return;

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -729,7 +729,7 @@ missionControlTab.initialize = function (callback) {
     let $geozoneContent;
     let invalidGeoZones = false;
     let isGeozoneEnabeld = false;
-    let settings = {speed: 0, alt: 5000, safeRadiusSH: 50, fwApproachAlt: 60, fwLandAlt: 5, maxDistSH: 0, fwApproachLength: 0, fwLoiterRadius: 0};
+    const settings = {speed: 0, alt: 5000, safeRadiusSH: 50, fwApproachAlt: 60, fwLandAlt: 5, maxDistSH: 0, fwApproachLength: 0, fwLoiterRadius: 0};
     let googleLocationRequestStarted = false;
     let conditionsFetched = false;
     let activeWeatherSource = null;
@@ -2055,15 +2055,20 @@ function iconKey(filename) {
     //
     /////////////////////////////////////////////
     function loadSettings() {
+        // These are read from the FC every time this tab is opened, the stored copy
+        // is only a fallback for the offline case.
+        const fcProvidedSettings = ['fwApproachLength', 'maxDistSH', 'fwLoiterRadius'];
         const missionPlannerSettings = store.get('missionPlannerSettings', false);
         if (missionPlannerSettings) {
-            if (!missionPlannerSettings.fwApproachLength && settings.fwApproachLength) {
-                missionPlannerSettings.fwApproachLength = settings.fwApproachLength;
-                missionPlannerSettings.maxDistSH = settings.maxDistSH;
-                missionPlannerSettings.fwLoiterRadius = settings.fwLoiterRadius;
-            }
+            Object.keys(missionPlannerSettings).forEach(function (key) {
+                if (!isOffline && fcProvidedSettings.includes(key) && Number.isFinite(settings[key])) {
+                    // Keep the value just read from the FC, the stored one is outdated
+                    // as soon as the setting was changed on another tab.
+                    return;
+                }
+                settings[key] = missionPlannerSettings[key];
+            });
             saveSettings();
-            settings = missionPlannerSettings;
         }
         refreshSettings();
     }

--- a/tests/mission-control-settings-refresh.test.mjs
+++ b/tests/mission-control-settings-refresh.test.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Regression test for the stale fixed wing approach length in Mission Control
+ * (inav-configurator issue #2313).
+ *
+ * Mission Control keeps two kinds of values in the same `settings` object:
+ *   - the mission planner defaults the user edits in the settings panel
+ *     (alt, speed, safeRadiusSH, fwApproachAlt, fwLandAlt), persisted with
+ *     `store.set('missionPlannerSettings', settings)`
+ *   - values read from the FC on every tab entry (fwApproachLength from
+ *     nav_fw_land_approach_length, maxDistSH from safehome_max_distance,
+ *     fwLoiterRadius from nav_fw_loiter_radius)
+ *
+ * The FC values are re-read by the load chainer of every `initialize()`, but
+ * `loadSettings()` used to replace the whole object with the persisted copy
+ * (`settings = missionPlannerSettings`) right after writing the fresh values
+ * to the store. So the map was always painted with the values of the previous
+ * tab visit: after changing nav_fw_land_approach_length in Advanced Tuning and
+ * rebooting, the approach lines kept their old length until the tab was left
+ * and entered a second time.
+ *
+ * The test runs the real `loadSettings()` and `saveSettings()` source out of
+ * tabs/mission_control.js inside a stand-in for the tab closure, so a future
+ * change that reintroduces the overwrite fails here.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const missionControlPath = path.join(testDir, '..', 'tabs', 'mission_control.js');
+const missionControlSource = readFileSync(missionControlPath, 'utf8');
+
+function extractFunction(source, header) {
+    const start = source.indexOf(header);
+    assert.notEqual(start, -1, header + ' not found in tabs/mission_control.js');
+    let depth = 0;
+    for (let i = start + header.length - 1; i < source.length; i++) {
+        if (source[i] === '{') {
+            depth++;
+        } else if (source[i] === '}') {
+            depth--;
+            if (depth === 0) {
+                return source.slice(start, i + 1);
+            }
+        }
+    }
+    throw new Error('unbalanced braces while extracting ' + header);
+}
+
+const loadSettingsSource = extractFunction(missionControlSource, 'function loadSettings() {');
+const saveSettingsSource = extractFunction(missionControlSource, 'function saveSettings() {');
+
+// Values the FC returns for a stock autoland setup, in the units the tab uses.
+const APPROACH_LENGTH_OLD = 35000;
+const APPROACH_LENGTH_NEW = 10000;
+
+function fcSettings(overrides) {
+    return Object.assign({
+        speed: 0,
+        alt: 5000,
+        safeRadiusSH: 50,
+        fwApproachAlt: 60,
+        fwLandAlt: 5,
+        maxDistSH: 50,
+        fwApproachLength: APPROACH_LENGTH_NEW,
+        fwLoiterRadius: 5000,
+    }, overrides);
+}
+
+function storedSettings(overrides) {
+    return Object.assign({
+        speed: 500,
+        alt: 3000,
+        safeRadiusSH: 70,
+        fwApproachAlt: 80,
+        fwLandAlt: 10,
+        maxDistSH: 20,
+        fwApproachLength: APPROACH_LENGTH_OLD,
+        fwLoiterRadius: 2000,
+    }, overrides);
+}
+
+/**
+ * Stand-in for the tab closure: `settings` is a closure variable exactly as in
+ * missionControlTab.initialize(), so a `settings = ...` assignment inside
+ * loadSettings() is visible to the caller the same way it is in the tab.
+ */
+function runLoadSettings(initialSettings, stored, isOffline = false) {
+    const storeData = {};
+    if (stored) {
+        storeData.missionPlannerSettings = stored;
+    }
+    const store = {
+        get(key, fallback) {
+            return Object.prototype.hasOwnProperty.call(storeData, key) ? storeData[key] : fallback;
+        },
+        set(key, value) {
+            storeData[key] = JSON.parse(JSON.stringify(value));
+        },
+    };
+
+    const factory = new Function('store', 'initialSettings', 'isOffline', `
+        let settings = initialSettings;
+        function refreshSettings() { }
+        ${saveSettingsSource}
+        ${loadSettingsSource}
+        loadSettings();
+        return settings;
+    `);
+
+    return {
+        settings: factory(store, initialSettings, isOffline),
+        stored: storeData.missionPlannerSettings,
+    };
+}
+
+describe('Mission Control settings: FC values versus the stored copy', () => {
+    test('the approach length just read from the FC survives loadSettings()', () => {
+        const result = runLoadSettings(fcSettings(), storedSettings());
+        assert.equal(result.settings.fwApproachLength, APPROACH_LENGTH_NEW);
+    });
+
+    test('the other FC provided values survive as well', () => {
+        const result = runLoadSettings(fcSettings(), storedSettings());
+        assert.equal(result.settings.maxDistSH, 50);
+        assert.equal(result.settings.fwLoiterRadius, 5000);
+    });
+
+    test('the stored mission planner defaults still win over the built in ones', () => {
+        const result = runLoadSettings(fcSettings(), storedSettings());
+        assert.equal(result.settings.alt, 3000);
+        assert.equal(result.settings.speed, 500);
+        assert.equal(result.settings.safeRadiusSH, 70);
+        assert.equal(result.settings.fwApproachAlt, 80);
+        assert.equal(result.settings.fwLandAlt, 10);
+    });
+
+    test('the fresh FC values are written back to the store', () => {
+        const result = runLoadSettings(fcSettings(), storedSettings());
+        assert.equal(result.stored.fwApproachLength, APPROACH_LENGTH_NEW);
+        assert.equal(result.stored.maxDistSH, 50);
+        assert.equal(result.stored.fwLoiterRadius, 5000);
+    });
+
+    test('without a stored copy the FC values are kept unchanged', () => {
+        const result = runLoadSettings(fcSettings(), null);
+        assert.equal(result.settings.fwApproachLength, APPROACH_LENGTH_NEW);
+        assert.equal(result.settings.alt, 5000);
+    });
+
+    test('offline (no FC read, values still 0) the stored copy is the fallback', () => {
+        const offline = fcSettings({ fwApproachLength: 0, maxDistSH: 0, fwLoiterRadius: 0 });
+        const result = runLoadSettings(offline, storedSettings(), true);
+        assert.equal(result.settings.fwApproachLength, APPROACH_LENGTH_OLD);
+        assert.equal(result.settings.maxDistSH, 20);
+        assert.equal(result.settings.fwLoiterRadius, 2000);
+    });
+
+    test('connected, a value the FC really reports as 0 is not replaced by the stored one', () => {
+        // safehome_max_distance and nav_fw_loiter_radius may legitimately be 0.
+        const zeroed = fcSettings({ maxDistSH: 0, fwLoiterRadius: 0 });
+        const result = runLoadSettings(zeroed, storedSettings());
+        assert.equal(result.settings.maxDistSH, 0);
+        assert.equal(result.settings.fwLoiterRadius, 0);
+    });
+
+    test('a stored copy from an older version keeps every value it does not know', () => {
+        const old = storedSettings();
+        delete old.fwApproachLength;
+        delete old.fwLoiterRadius;
+        const result = runLoadSettings(fcSettings(), old);
+        assert.equal(result.settings.fwApproachLength, APPROACH_LENGTH_NEW);
+        assert.equal(result.settings.fwLoiterRadius, 5000);
+        assert.equal(result.settings.alt, 3000);
+    });
+
+    test('entering the tab twice with the same FC value changes nothing', () => {
+        const first = runLoadSettings(fcSettings(), storedSettings());
+        const second = runLoadSettings(fcSettings(), first.stored);
+        assert.deepEqual(second.settings, first.settings);
+    });
+});


### PR DESCRIPTION
## Problem

Change the fixed wing approach length in Advanced Tuning, save and reboot, then go straight back to Mission Control: the approach estimation line is still drawn at the old length, and only after switching to another tab and back is it correct (reported on the 8.0 nightly under Windows). Fixes #2313.

## Cause

`tabs/mission_control.js:2274` on `maintenance-10.x`. Every tab entry reads `nav_fw_land_approach_length`, `safehome_max_distance` and `nav_fw_loiter_radius` from the flight controller into `settings` (line 1177 ff.) and then calls `loadSettings()` (line 1309). `loadSettings()` writes those fresh values to the store and afterwards replaces the whole object with the copy the store held before that write (`settings = missionPlannerSettings`), so the map is painted with the previous visit's value.

## Change

`loadSettings()` copies the stored keys into the existing `settings` object instead of replacing it, and keeps `fwApproachLength`, `maxDistSH` and `fwLoiterRadius` as read from the flight controller while connected. The guard is `!isOffline` plus `Number.isFinite`, so a genuine `0` for safehome distance or loiter radius is not overwritten by the store, while offline the stored copy stays the fallback. `settings` becomes `const`, because nothing reassigns it any more. Keys missing from an older stored copy are no longer dropped.

## Test

Not run in the app for this revision. `tests/mission-control-settings-refresh.test.mjs` runs the `loadSettings()`/`saveSettings()` source straight out of the tab: 4 of its 9 cases fail against unmodified `maintenance-10.x`, all 9 pass here. Full suite (`node --test tests/*.test.mjs tests/transpiler/*.test.mjs`): 154 tests with 3 failures on `maintenance-10.x`, 163 tests with the same 3 pre-existing failures on this branch. CI green for 18abab8: https://github.com/iNavFlight/inav-configurator/actions/runs/34761776980 (SonarCloud quality gate passed).

## Flash / RAM
Not applicable (Configurator).

## Docs

None needed: no markdown file on `maintenance-10.x` documents the Mission Control settings store or the approach length.
