### PR TITLE
Warn when pid_type points at the unused navigation PID bank

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -12,7 +12,7 @@ import OutputMappingCollection from './outputMapping';
 import SafehomeCollection from './safehomeCollection';
 import FwApproachCollection from './fwApproachCollection';
 import GeozoneCollection from './geozoneCollection';
-import { PLATFORM } from './model';
+import { PLATFORM, PID_TYPE } from './model';
 import VTX from './vtx';
 import BitHelper from './bitHelper';
 import { FLIGHT_MODES } from './flightModes';
@@ -103,6 +103,22 @@ var FC = {
     },
     isMultirotor: function () {
         return (this.MIXER_CONFIG.platformType == PLATFORM.MULTIROTOR || this.MIXER_CONFIG.platformType == PLATFORM.TRICOPTER);
+    },
+    // Navigation always runs on the bank that belongs to the platform type, no
+    // matter what pid_type says. Airplanes, rovers and boats use the nav_fw_*
+    // gains, every other platform the nav_mc_* ones.
+    usesFixedWingNavPids: function () {
+        return (this.MIXER_CONFIG.platformType == PLATFORM.AIRPLANE ||
+            this.MIXER_CONFIG.platformType == PLATFORM.ROVER ||
+            this.MIXER_CONFIG.platformType == PLATFORM.BOAT);
+    },
+    // The bank the FC reports over MSP2_PID follows pid_type instead, so it can
+    // point at the other set of gains than the one navigation is using.
+    usesFixedWingPidBank: function (pidType) {
+        if (pidType == PID_TYPE.AUTO) {
+            return this.usesFixedWingNavPids();
+        }
+        return (pidType == PID_TYPE.PIFF);
     },
     isRpyFfComponentUsed: function () {
         return true; // Currently all planes have roll, pitch and yaw FF

--- a/js/model.js
+++ b/js/model.js
@@ -58,6 +58,14 @@ const PLATFORM = {
     BOAT:       5
 }
 
+// Values of the pid_type setting, see pidTypeTable in the firmware
+const PID_TYPE = {
+    NONE: 0,
+    PID:  1,
+    PIFF: 2,
+    AUTO: 3
+}
+
 // generate mixer
 const mixerList = [
     // ** Multirotor
@@ -829,4 +837,4 @@ var platform = (function (platforms) {
     return publicScope;
 })(platformList);
 
-export { mixer, platform, PLATFORM, SERVO, INPUT, STABILIZED };
+export { mixer, platform, PLATFORM, PID_TYPE, SERVO, INPUT, STABILIZED };

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1814,6 +1814,9 @@
     "pidTuning_PIDother": {
         "message": "Additional PID Gains"
     },
+    "pidTuningNavPidBankMismatch": {
+        "message": "pid_type does not match the platform type. The flight controller reports the $1 gains, but navigation runs on $2. The navigation gains shown below are not the ones in use, so changing them has no effect. Set pid_type back to AUTO, or tune the $2 settings in the CLI."
+    },
     "pidTuning_SelectNewDefaults": {
         "message": "Select New Defaults"
     },

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -293,6 +293,8 @@
             </div>
             <div class="clear-both"></div>
 
+            <div id="nav-pid-bank-mismatch" class="warning-box" style="display: none;"></div>
+
             <div class="cf_column pid-section" id="the-other-pids">
                 <div class="gui_box grey">
                     <table class="pid_titlebar">

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -257,6 +257,27 @@ pidTuningTab.initialize = function (callback) {
             $('.not-for-multirotor').hide();
         }
 
+        // The FC serves the PID bank that pid_type selects, while its navigation
+        // code always uses the bank of the platform type. When the two disagree
+        // the navigation gains below belong to the bank that is not flying.
+        mspHelper.getSetting('pid_type').then(function (data) {
+            if (!data) {
+                return;
+            }
+
+            let shownBankIsFixedWing = FC.usesFixedWingPidBank(data.value);
+            if (shownBankIsFixedWing === FC.usesFixedWingNavPids()) {
+                return;
+            }
+
+            $('#nav-pid-bank-mismatch').text(i18n.getMessage('pidTuningNavPidBankMismatch', [
+                shownBankIsFixedWing ? 'nav_fw_*' : 'nav_mc_*',
+                shownBankIsFixedWing ? 'nav_mc_*' : 'nav_fw_*'
+            ])).show();
+        }).catch(function (err) {
+            console.debug('pid_tuning: pid_type setting not available:', err && err.message);
+        });
+
         $("#ez_tune_enabled").prop('checked', FC.EZ_TUNE.enabled).trigger('change');
 
         GUI.sliderize($('#ez_tune_filter_hz'), FC.EZ_TUNE.filterHz, 20, 300);

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -275,7 +275,7 @@ pidTuningTab.initialize = function (callback) {
                 shownBankIsFixedWing ? 'nav_mc_*' : 'nav_fw_*'
             ])).show();
         }).catch(function (err) {
-            console.debug('pid_tuning: pid_type setting not available:', err && err.message);
+            console.debug('pid_tuning: pid_type setting not available:', err?.message);
         });
 
         $("#ez_tune_enabled").prop('checked', FC.EZ_TUNE.enabled).trigger('change');

--- a/tests/fc-generate-aux-config.test.mjs
+++ b/tests/fc-generate-aux-config.test.mjs
@@ -64,8 +64,12 @@ const mockClassUrl = dataModule(`
     export default MockCollection;
 `);
 
+// fc.js imports PID_TYPE alongside PLATFORM (used by usesFixedWingPidBank(),
+// which generateAuxConfig() never calls). The named import still has to
+// resolve, so the stub has to provide it or fc.js fails to load.
 const mockModelUrl = dataModule(`
     export const PLATFORM = { AIRPLANE: 0, MULTIROTOR: 1, TRICOPTER: 2 };
+    export const PID_TYPE = { NONE: 0, PID: 1, PIFF: 2, AUTO: 3 };
 `);
 
 const mockVtxUrl = dataModule(`
@@ -117,7 +121,7 @@ const realFcUrl = rewriteAndWrite('js/fc.js', [
     [/^import SafehomeCollection from '\.\/safehomeCollection';$/m, `import SafehomeCollection from '${mockClassUrl}';`, "import SafehomeCollection"],
     [/^import FwApproachCollection from '\.\/fwApproachCollection';$/m, `import FwApproachCollection from '${mockClassUrl}';`, "import FwApproachCollection"],
     [/^import GeozoneCollection from '\.\/geozoneCollection';$/m, `import GeozoneCollection from '${mockClassUrl}';`, "import GeozoneCollection"],
-    [/^import \{ PLATFORM \} from '\.\/model';$/m, `import { PLATFORM } from '${mockModelUrl}';`, "import PLATFORM"],
+    [/^import \{ PLATFORM, PID_TYPE \} from '\.\/model';$/m, `import { PLATFORM, PID_TYPE } from '${mockModelUrl}';`, "import PLATFORM, PID_TYPE"],
     [/^import VTX from '\.\/vtx';$/m, `import VTX from '${mockVtxUrl}';`, "import VTX"],
     [/^import BitHelper from '\.\/bitHelper';$/m, `import BitHelper from '${mockBitHelperUrl}';`, "import BitHelper"],
     [/^import \{ FLIGHT_MODES \} from '\.\/flightModes';$/m, `import { FLIGHT_MODES } from '${realFlightModesUrl}';`, "import FLIGHT_MODES"],


### PR DESCRIPTION
## Problem
With `platform_type = MULTIROTOR` and `pid_type = PIFF` the PID tuning tab shows the Velocity Z gains as zero while altitude hold still flies; zeroing `nav_mc_vel_z_*` in the CLI does stop it. The tab shows the `nav_fw_*` navigation gains while the flight controller runs on the `nav_mc_*` ones, so editing the visible fields has no effect. Fixes #2166.

## Cause
The Configurator never picks a bank: `pid_and_rc_to_form()` fills every row straight from `FC.PIDs`, the `MSP2_PID` response, with no platform check (`tabs/pid_tuning.js:129` on `maintenance-10.x`). The firmware builds that response from `pidBank()`, which selects by `pid_type` (`src/main/flight/pid.c:2278`), while the navigation controllers always read `bank_mc` or `bank_fw` by platform type (`src/main/navigation/navigation.c:6531` and `:6589`). The two disagree for Multirotor with PIFF, and for Fixed wing with PID or NONE.

## Change
`js/model.js` exports the `PID_TYPE` values, and `js/fc.js` gains `usesFixedWingNavPids()` and `usesFixedWingPidBank()`, which mirror those two firmware selections. The tab reads the `pid_type` setting and, when the reported bank is not the one navigation uses, shows a warning box above the "Additional PID Gains" tables naming both banks. Firmware that does not expose `pid_type` gets no warning. The aux-config test fixture is updated for the new import in `js/fc.js`.

## Test
Not run in the app for this revision. The failure is the one the reporter documented with screenshots and a CLI cross-check in #2166; the bank selection was verified against the firmware lines above. `npm test` is not part of this repository's CI (`.github/workflows/ci.yml` only builds), so the updated fixture is not covered by a check. CI green on `989653f`, six platform builds plus the SonarCloud quality gate: https://github.com/iNavFlight/inav-configurator/actions/runs/34526748690

## Flash / RAM
Not applicable (Configurator).

## Docs
None changed. No Markdown file on `maintenance-10.x` mentions `pid_type` or the navigation PID banks; the warning string lives in `locale/en/messages.json`.
