### PR TITLE
Keep the landing information when saving a mission file

### DIFF
--- a/js/missionFwApproach.js
+++ b/js/missionFwApproach.js
@@ -33,21 +33,25 @@ export function hasFwApproachData(approach) {
  * with a landing point. Landing altitude, approach altitude, approach direction
  * and the sea level reference are lost otherwise, because they are useful
  * without a landing heading. */
-export function buildFwApproachItems(approaches, maxSafehomeCount, maxFwApproachCount, landingMissionIndexes = []) {
+export function buildFwApproachItems(approaches, maxSafehomeCount, maxFwApproachCount, landingMissionIndexes = [], sourceMissionIndex = null) {
     const landingMissions = new Set(landingMissionIndexes);
     const items = [];
 
     for (let i = maxSafehomeCount; i < maxFwApproachCount; i++) {
         const approach = approaches[i];
         const missionIndex = i - maxSafehomeCount;
+        if (sourceMissionIndex !== null && missionIndex !== sourceMissionIndex) {
+            continue;
+        }
+        const fileMissionIndex = sourceMissionIndex === null ? missionIndex : 0;
 
         if (!approach || !(landingMissions.has(missionIndex) || hasFwApproachData(approach))) {
             continue;
         }
 
         items.push({ $: {
-            'index': missionIndex,
-            'no': approach.getNumber(),
+            'index': fileMissionIndex,
+            'no': maxSafehomeCount + fileMissionIndex,
             'approach-alt': approach.getApproachAltAsl(),
             'land-alt': approach.getLandAltAsl(),
             'approach-direction': approach.getApproachDirection() == 0 ? 'left' : 'right',
@@ -108,7 +112,7 @@ export function resolveFwApproachSlot(approach, maxSafehomeCount, maxFwApproachC
         slot = maxSafehomeCount + approach.index;
     } else if (Number.isInteger(approach.number) && approach.number >= 0) {
         // Elements without a mission index only carry the collection slot.
-        slot = approach.number < maxSafehomeCount ? maxSafehomeCount + approach.number : approach.number;
+        slot = approach.number;
     }
 
     return slot !== null && slot >= maxSafehomeCount && slot < maxFwApproachCount ? slot : -1;

--- a/js/missionFwApproach.js
+++ b/js/missionFwApproach.js
@@ -1,0 +1,115 @@
+'use strict';
+
+/*
+ * Serialisation of the <fwapproach> elements of a mission file.
+ *
+ * The approach collection keeps the safehome approaches first, so the approach
+ * of the mission with index n lives in slot maxSafehomeCount + n. The mission
+ * file stores that mission index in "index" and the collection slot in "no".
+ */
+
+function toInteger(value, fallback = 0) {
+    const number = parseInt(value, 10);
+
+    return Number.isFinite(number) ? number : fallback;
+}
+
+function toFlag(value, trueValues) {
+    return trueValues.test(String(value).trim()) ? 1 : 0;
+}
+
+export function hasFwApproachData(approach) {
+    if (!approach) return false;
+
+    return approach.getApproachAltAsl() != 0 ||
+        approach.getLandAltAsl() != 0 ||
+        approach.getApproachDirection() != 0 ||
+        approach.getLandHeading1() != 0 ||
+        approach.getLandHeading2() != 0 ||
+        approach.getIsSeaLevelRef() != 0;
+}
+
+/* An approach is written whenever it carries data or whenever its mission ends
+ * with a landing point. Landing altitude, approach altitude, approach direction
+ * and the sea level reference are lost otherwise, because they are useful
+ * without a landing heading. */
+export function buildFwApproachItems(approaches, maxSafehomeCount, maxFwApproachCount, landingMissionIndexes = []) {
+    const landingMissions = new Set(landingMissionIndexes);
+    const items = [];
+
+    for (let i = maxSafehomeCount; i < maxFwApproachCount; i++) {
+        const approach = approaches[i];
+        const missionIndex = i - maxSafehomeCount;
+
+        if (!approach || !(landingMissions.has(missionIndex) || hasFwApproachData(approach))) {
+            continue;
+        }
+
+        items.push({ $: {
+            'index': missionIndex,
+            'no': approach.getNumber(),
+            'approach-alt': approach.getApproachAltAsl(),
+            'land-alt': approach.getLandAltAsl(),
+            'approach-direction': approach.getApproachDirection() == 0 ? 'left' : 'right',
+            'landheading1': approach.getLandHeading1(),
+            'landheading2': approach.getLandHeading2(),
+            'sealevel-ref': approach.getIsSeaLevelRef() ? 'true' : 'false'
+        }});
+    }
+
+    return items;
+}
+
+/* Attribute names are matched loosely so that the dashless names of the first
+ * mission planner approaches ("ApproachAlt", "SeaLevelRef") are read too. */
+export function parseFwApproachAttributes(attributes) {
+    const approach = {
+        index: null,
+        number: null,
+        approachAltAsl: 0,
+        landAltAsl: 0,
+        approachDirection: 0,
+        landHeading1: 0,
+        landHeading2: 0,
+        isSeaLevelRef: 0
+    };
+
+    for (const attribute in attributes) {
+        const value = attributes[attribute];
+
+        if (/^index$/i.test(attribute)) {
+            approach.index = toInteger(value, null);
+        } else if (/^no$/i.test(attribute)) {
+            approach.number = toInteger(value, null);
+        } else if (/approach-?alt/i.test(attribute)) {
+            approach.approachAltAsl = toInteger(value);
+        } else if (/land-?alt/i.test(attribute)) {
+            approach.landAltAsl = toInteger(value);
+        } else if (/approach-?direction/i.test(attribute)) {
+            approach.approachDirection = toFlag(value, /^(right|1)$/i);
+        } else if (/landheading1/i.test(attribute)) {
+            approach.landHeading1 = toInteger(value);
+        } else if (/landheading2/i.test(attribute)) {
+            approach.landHeading2 = toInteger(value);
+        } else if (/sealevel-?ref/i.test(attribute)) {
+            approach.isSeaLevelRef = toFlag(value, /^(true|1)$/i);
+        }
+    }
+
+    return approach;
+}
+
+/* Returns the collection slot of a parsed approach, or -1 when the element
+ * addresses no usable mission slot. */
+export function resolveFwApproachSlot(approach, maxSafehomeCount, maxFwApproachCount) {
+    let slot = null;
+
+    if (Number.isInteger(approach.index) && approach.index >= 0) {
+        slot = maxSafehomeCount + approach.index;
+    } else if (Number.isInteger(approach.number) && approach.number >= 0) {
+        // Elements without a mission index only carry the collection slot.
+        slot = approach.number < maxSafehomeCount ? maxSafehomeCount + approach.number : approach.number;
+    }
+
+    return slot !== null && slot >= maxSafehomeCount && slot < maxFwApproachCount ? slot : -1;
+}

--- a/js/missionFwApproach.js
+++ b/js/missionFwApproach.js
@@ -9,7 +9,7 @@
  */
 
 function toInteger(value, fallback = 0) {
-    const number = parseInt(value, 10);
+    const number = Number.parseInt(value, 10);
 
     return Number.isFinite(number) ? number : fallback;
 }

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -78,6 +78,7 @@ import Safehome from './../js/safehome';
 import SafehomeCollection from './../js/safehomeCollection';
 import { ApproachDirection, FwApproach } from './../js/fwApproach';
 import FwApproachCollection from './../js/fwApproachCollection';
+import { buildFwApproachItems, parseFwApproachAttributes, resolveFwApproachSlot } from './../js/missionFwApproach';
 import SerialBackend from './../js/serial_backend';
 import { distanceOnLine, wrap_360, calculate_new_cooridatnes } from './../js/helpers';
 import interval from './../js/intervals';
@@ -6419,28 +6420,17 @@ function iconKey(filename) {
                                 }
                                 mission.put(point);
                             } else if (node['#name'].match(/fwapproach/i) && node.$) {
-                                var fwApproach = new FwApproach(0);
-                                var idx = -1;
-                                for (var attr in node.$) {
-                                    if (attr.match(/index/i)) {
-                                        idx = parseInt(node.$[attr]);
-                                    } else if (attr.match(/no/i)) {
-                                        fwApproach.setNumber(parseInt(node.$[attr]));
-                                    } else if (attr.match(/approach-alt/i)) {
-                                        fwApproach.setApproachAltAsl(parseInt(node.$[attr]));
-                                    } else if (attr.match(/land-alt/i)) {
-                                        fwApproach.setLandAltAsl(parseInt(node.$[attr]));
-                                    } else if (attr.match(/approach-direction/i)) {
-                                        fwApproach.setApproachDirection(node.$[attr] == 'left' ? 0 : 1);
-                                    } else if (attr.match(/landheading1/i)) {
-                                        fwApproach.setLandHeading1(parseInt(node.$[attr]));
-                                    } else if (attr.match(/landheading2/i)) {
-                                        fwApproach.setLandHeading2(parseInt(node.$[attr]));
-                                    } else if (attr.match(/sealevel-ref/i)) {
-                                        fwApproach.setIsSeaLevelRef(parseBooleans(node.$[attr]) ? 1 : 0);
-                                    }
+                                var approachData = parseFwApproachAttributes(node.$);
+                                var approachSlot = resolveFwApproachSlot(approachData, FC.SAFEHOMES.getMaxSafehomeCount(), FC.FW_APPROACH.getMaxFwApproachCount());
+                                if (approachSlot >= 0) {
+                                    FC.FW_APPROACH.updateFwApproach(new FwApproach(approachSlot,
+                                                                                   approachData.approachAltAsl,
+                                                                                   approachData.landAltAsl,
+                                                                                   approachData.approachDirection,
+                                                                                   approachData.landHeading1,
+                                                                                   approachData.landHeading2,
+                                                                                   approachData.isSeaLevelRef));
                                 }
-                                FC.FW_APPROACH.insert(fwApproach, FC.SAFEHOMES.getMaxSafehomeCount() + idx);
                             }
                         }
                     }
@@ -6516,6 +6506,7 @@ function iconKey(filename) {
 
         let missionStartWPNumber = 0;
         let missionNumber = 1;
+        let landingMissionIndexes = [];
         mission.get().forEach(function (waypoint) {
             if (waypoint.getNumber() - missionStartWPNumber == 0 && multimission) {
                 let meta = {$:{
@@ -6536,29 +6527,19 @@ function iconKey(filename) {
                     } };
             data.missionitem.push(point);
 
+            if (waypoint.getAction() == MWNP.WPTYPE.LAND) {
+                landingMissionIndexes.push(waypoint.getMultiMissionIdx());
+            }
+
             if (waypoint.getEndMission() == 0xA5) {
                 missionStartWPNumber = waypoint.getNumber() + 1;
                 missionNumber ++;
             }
         });
-        let approachIdx = 0;
-        for (let i = FC.SAFEHOMES.getMaxSafehomeCount(); i < FC.FW_APPROACH.getMaxFwApproachCount(); i++){
-            let approach = FC.FW_APPROACH.get()[i];
-            if (approach.getLandHeading1() != 0 || approach.getLandHeading2() != 0) {
-                var item = { $: {
-                    'index': approachIdx,
-                    'no': approach.getNumber(),
-                    'approach-alt': approach.getApproachAltAsl(),
-                    'land-alt': approach.getLandAltAsl(),
-                    'approach-direction': approach.getApproachDirection() == 0 ? 'left' : 'right',
-                    'landheading1': approach.getLandHeading1(),
-                    'landheading2': approach.getLandHeading2(),
-                    'sealevel-ref': approach.getIsSeaLevelRef() ? 'true' : 'false'
-                }};
-                data.fwapproach.push(item);
-            }
-            approachIdx++;
-        }
+        data.fwapproach = buildFwApproachItems(FC.FW_APPROACH.get(),
+                                               FC.SAFEHOMES.getMaxSafehomeCount(),
+                                               FC.FW_APPROACH.getMaxFwApproachCount(),
+                                               landingMissionIndexes);
 
         var builder = new xml2js.Builder({ 'rootName': 'mission', 'renderOpts': { 'pretty': true, 'indent': '\t', 'newline': '\n' } });
         var xml = builder.buildObject(data);
@@ -6935,13 +6916,6 @@ function iconKey(filename) {
             }
         }
     }
-
-    function parseBooleans (str) {
-        if (/^(?:true|false)$/i.test(str)) {
-          str = str.toLowerCase() === 'true';
-        }
-        return str;
-      };
 };
 
 missionControlTab.isBitSet = function(bits, testBit) {

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -6539,7 +6539,8 @@ function iconKey(filename) {
         data.fwapproach = buildFwApproachItems(FC.FW_APPROACH.get(),
                                                FC.SAFEHOMES.getMaxSafehomeCount(),
                                                FC.FW_APPROACH.getMaxFwApproachCount(),
-                                               landingMissionIndexes);
+                                               landingMissionIndexes,
+                                               multimission ? null : (mission.get()[0]?.getMultiMissionIdx() ?? 0));
 
         var builder = new xml2js.Builder({ 'rootName': 'mission', 'renderOpts': { 'pretty': true, 'indent': '\t', 'newline': '\n' } });
         var xml = builder.buildObject(data);

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -6420,8 +6420,8 @@ function iconKey(filename) {
                                 }
                                 mission.put(point);
                             } else if (node['#name'].match(/fwapproach/i) && node.$) {
-                                var approachData = parseFwApproachAttributes(node.$);
-                                var approachSlot = resolveFwApproachSlot(approachData, FC.SAFEHOMES.getMaxSafehomeCount(), FC.FW_APPROACH.getMaxFwApproachCount());
+                                const approachData = parseFwApproachAttributes(node.$);
+                                const approachSlot = resolveFwApproachSlot(approachData, FC.SAFEHOMES.getMaxSafehomeCount(), FC.FW_APPROACH.getMaxFwApproachCount());
                                 if (approachSlot >= 0) {
                                     FC.FW_APPROACH.updateFwApproach(new FwApproach(approachSlot,
                                                                                    approachData.approachAltAsl,

--- a/tests/mission-fwapproach-file.test.mjs
+++ b/tests/mission-fwapproach-file.test.mjs
@@ -206,3 +206,23 @@ describe('Mission file fwapproach round trip', () => {
         assert.deepEqual(values(missionApproach(loaded)), values(approach));
     });
 });
+
+test('a selected later mission exports its approach as standalone mission zero', async () => {
+    const saved = approachCollection();
+    missionApproach(saved, 0).setApproachAltAsl(1000);
+    const selected = missionApproach(saved, 2);
+    selected.setApproachAltAsl(6200);
+    selected.setLandAltAsl(400);
+    const items = buildFwApproachItems(saved, MAX_SAFEHOMES, MAX_APPROACHES, [2], 2);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].$.index, 0);
+    assert.equal(items[0].$.no, MAX_SAFEHOMES);
+    const loaded = await loadInto(approachCollection(), toMissionXml(items));
+    assert.deepEqual(values(missionApproach(loaded, 0)), values(selected));
+    assert.equal(missionApproach(loaded, 2).getApproachAltAsl(), 0);
+});
+
+test('a no-only safehome slot cannot overwrite a mission approach', async () => {
+    const loaded = await loadInto(approachCollection(), '<mission><fwapproach no="7" approach-alt="6200"/></mission>');
+    loaded.forEach(approach => assert.equal(approach.getApproachAltAsl(), 0));
+});

--- a/tests/mission-fwapproach-file.test.mjs
+++ b/tests/mission-fwapproach-file.test.mjs
@@ -1,0 +1,208 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import xml2js from 'xml2js';
+
+import { FwApproach } from '../js/fwApproach.js';
+import {
+    buildFwApproachItems,
+    parseFwApproachAttributes,
+    resolveFwApproachSlot
+} from '../js/missionFwApproach.js';
+
+const MAX_SAFEHOMES = 8;
+const MAX_APPROACHES = 17;
+
+/* The mission planner fills the collection with empty approaches on tab load */
+function approachCollection() {
+    return Array.from({ length: MAX_APPROACHES }, (unused, i) => new FwApproach(i));
+}
+
+function missionApproach(approaches, missionIndex = 0) {
+    return approaches[MAX_SAFEHOMES + missionIndex];
+}
+
+function values(approach) {
+    return {
+        approachAlt: approach.getApproachAltAsl(),
+        landAlt: approach.getLandAltAsl(),
+        direction: approach.getApproachDirection(),
+        heading1: approach.getLandHeading1(),
+        heading2: approach.getLandHeading2(),
+        seaLevelRef: approach.getIsSeaLevelRef()
+    };
+}
+
+function toMissionXml(items) {
+    return new xml2js.Builder({ rootName: 'mission' }).buildObject({
+        version: { $: { value: '2.3-pre8' } },
+        fwapproach: items
+    });
+}
+
+/* Mirrors what loadMissionFile() does with the parsed fwapproach elements */
+async function loadInto(approaches, xml) {
+    const result = await xml2js.parseStringPromise(xml, { explicitChildren: true, preserveChildrenOrder: true });
+
+    for (const node of result.mission.$$ || []) {
+        if (!/fwapproach/i.test(node['#name']) || !node.$) continue;
+
+        const parsed = parseFwApproachAttributes(node.$);
+        const slot = resolveFwApproachSlot(parsed, MAX_SAFEHOMES, MAX_APPROACHES);
+
+        if (slot >= 0) {
+            // FwApproachCollection.updateFwApproach() stores by approach number
+            approaches[slot] = new FwApproach(slot,
+                                              parsed.approachAltAsl,
+                                              parsed.landAltAsl,
+                                              parsed.approachDirection,
+                                              parsed.landHeading1,
+                                              parsed.landHeading2,
+                                              parsed.isSeaLevelRef);
+        }
+    }
+
+    return approaches;
+}
+
+describe('Mission file fwapproach writing', () => {
+    test('keeps the landing information of a landing point that has no landing heading', () => {
+        const approaches = approachCollection();
+        const approach = missionApproach(approaches);
+        approach.setApproachAltAsl(6000);
+        approach.setLandAltAsl(500);
+
+        const items = buildFwApproachItems(approaches, MAX_SAFEHOMES, MAX_APPROACHES, [0]);
+
+        assert.equal(items.length, 1);
+        assert.deepEqual(items[0].$, {
+            'index': 0,
+            'no': 8,
+            'approach-alt': 6000,
+            'land-alt': 500,
+            'approach-direction': 'left',
+            'landheading1': 0,
+            'landheading2': 0,
+            'sealevel-ref': 'false'
+        });
+    });
+
+    test('writes an entry for every mission that ends with a landing point', () => {
+        const items = buildFwApproachItems(approachCollection(), MAX_SAFEHOMES, MAX_APPROACHES, [0, 2]);
+
+        assert.deepEqual(items.map((item) => item.$.index), [0, 2]);
+        assert.deepEqual(items.map((item) => item.$.no), [8, 10]);
+    });
+
+    test('writes nothing for missions without a landing point and without approach data', () => {
+        assert.deepEqual(buildFwApproachItems(approachCollection(), MAX_SAFEHOMES, MAX_APPROACHES, []), []);
+    });
+
+    test('keeps approach data of a mission whose landing point is not part of this save', () => {
+        const approaches = approachCollection();
+        missionApproach(approaches, 1).setLandHeading1(300);
+
+        const items = buildFwApproachItems(approaches, MAX_SAFEHOMES, MAX_APPROACHES, []);
+
+        assert.deepEqual(items.map((item) => item.$.index), [1]);
+    });
+
+    test('never writes the safehome approaches', () => {
+        const approaches = approachCollection();
+        approaches[0].setLandHeading1(120);
+
+        assert.deepEqual(buildFwApproachItems(approaches, MAX_SAFEHOMES, MAX_APPROACHES, []), []);
+    });
+});
+
+describe('Mission file fwapproach reading', () => {
+    test('reads the entries written by Configurator 7.1', async () => {
+        const xml = [
+            '<mission>',
+            '<version value="2.3-pre8"/>',
+            '<fwapproach index="0" no="8" approach-alt="6000" land-alt="1000" approach-direction="left" landheading1="300" landheading2="0" sealevel-ref="false"/>',
+            '</mission>'
+        ].join('');
+
+        const approaches = await loadInto(approachCollection(), xml);
+
+        assert.deepEqual(values(missionApproach(approaches)), {
+            approachAlt: 6000,
+            landAlt: 1000,
+            direction: 0,
+            heading1: 300,
+            heading2: 0,
+            seaLevelRef: 0
+        });
+    });
+
+    test('reads entries that only carry the collection slot', async () => {
+        const xml = '<mission><fwapproach no="9" approach-alt="4000" land-alt="200" approach-direction="right" sealevel-ref="true"/></mission>';
+
+        const approaches = await loadInto(approachCollection(), xml);
+
+        assert.deepEqual(values(missionApproach(approaches, 1)), {
+            approachAlt: 4000,
+            landAlt: 200,
+            direction: 1,
+            heading1: 0,
+            heading2: 0,
+            seaLevelRef: 1
+        });
+        assert.deepEqual(values(missionApproach(approaches, 0)), values(new FwApproach(0)));
+    });
+
+    test('ignores entries that address no mission slot', async () => {
+        const xml = [
+            '<mission>',
+            '<fwapproach approach-alt="4000"/>',
+            '<fwapproach index="42" approach-alt="4000"/>',
+            '</mission>'
+        ].join('');
+
+        const approaches = await loadInto(approachCollection(), xml);
+
+        assert.equal(approaches.length, MAX_APPROACHES);
+        approaches.forEach((approach) => assert.equal(approach.getApproachAltAsl(), 0));
+    });
+
+    test('loading the same mission twice does not shift or duplicate the approaches', async () => {
+        const xml = '<mission><fwapproach index="0" no="8" approach-alt="6000" land-alt="500" approach-direction="left" landheading1="300" landheading2="0" sealevel-ref="false"/></mission>';
+
+        const approaches = await loadInto(await loadInto(approachCollection(), xml), xml);
+
+        assert.equal(approaches.length, MAX_APPROACHES);
+        assert.equal(missionApproach(approaches).getNumber(), 8);
+        assert.equal(missionApproach(approaches).getLandHeading1(), 300);
+        assert.equal(missionApproach(approaches, 1).getLandHeading1(), 0);
+    });
+});
+
+describe('Mission file fwapproach round trip', () => {
+    test('a landing point keeps every approach setting', async () => {
+        const saved = approachCollection();
+        const approach = missionApproach(saved);
+        approach.setApproachAltAsl(6000);
+        approach.setLandAltAsl(1000);
+        approach.setApproachDirection(1);
+        approach.setLandHeading1(-300);
+        approach.setLandHeading2(120);
+        approach.setIsSeaLevelRef(1);
+
+        const xml = toMissionXml(buildFwApproachItems(saved, MAX_SAFEHOMES, MAX_APPROACHES, [0]));
+        const loaded = await loadInto(approachCollection(), xml);
+
+        assert.deepEqual(values(missionApproach(loaded)), values(approach));
+    });
+
+    test('a landing point without a landing heading keeps its altitudes', async () => {
+        const saved = approachCollection();
+        const approach = missionApproach(saved);
+        approach.setApproachAltAsl(6000);
+        approach.setLandAltAsl(500);
+
+        const xml = toMissionXml(buildFwApproachItems(saved, MAX_SAFEHOMES, MAX_APPROACHES, [0]));
+        const loaded = await loadInto(approachCollection(), xml);
+
+        assert.deepEqual(values(missionApproach(loaded)), values(approach));
+    });
+});


### PR DESCRIPTION
## Problem

The reporter placed the same two waypoints in Configurator 7.1 and 8.0, the last one a landing point, and compared the saved files: the 7.1 file has an `fwapproach` line, the 8.0 file none, so approach altitude, landing altitude, approach direction and the sea level reference are gone. Fixes #2335.

## Cause

`tabs/mission_control.js:7007` on `maintenance-10.x` writes the `fwapproach` element only when a landing heading is set (`getLandHeading1() != 0 || getLandHeading2() != 0`); without a heading the other four fields go with it. On the reading side `tabs/mission_control.js:6903` calls `insert(fwApproach, maxSafehomeCount + idx)` with `idx` still `-1` when the element carries no `index`.

## Change

Reading and writing move into `js/missionFwApproach.js`. An entry is written when the approach carries data or when its mission ends with a LAND waypoint; attribute names and values are unchanged. Parsing takes the slot from `index` with `no` as fallback and ignores elements outside the mission range; loading calls `updateFwApproach()` on that slot instead of `insert()`. A single mission saved out of a multimission set is written as mission index 0.

## Test

`tests/mission-fwapproach-file.test.mjs` adds 13 tests over the new helpers: a landing point without a heading, one entry per landing mission, safehome slots never written, 7.1 files and `no`-only elements read back, out-of-range elements ignored, the same file loaded twice, and the round trip. CI packages the app and does not run the suite, so it has to be started locally with `npm test`. Not run in the app for this revision. Cause verified by reading the two lines above; builds and SonarCloud green on `7190331`: https://github.com/iNavFlight/inav-configurator/actions/runs/34615744223

## Flash / RAM
Not applicable (Configurator).

## Docs

None needed. Nothing in the repository documents the mission file format or the `fwapproach` element, and the attributes written are unchanged.
