### PR TITLE
Follow the unit setting in Mission Control

### DIFF
--- a/js/configurator_main.js
+++ b/js/configurator_main.js
@@ -8,6 +8,7 @@ import * as THREE from 'three'
 import GUI, { TABS } from './gui';
 import interval from './intervals';
 import CONFIGURATOR from './data_storage';
+import { loadOsdUnits } from './osdUnits';
 import FC  from './fc';
 import { globalSettings, UnitType } from './globalSettings';
 import { PLATFORM } from './model'
@@ -603,14 +604,14 @@ $(function() {
 
                     // Set the value of the unit type
                     // none, OSD, imperial, metric
-                    $('#ui-unit-type').on('change', function () {
+                    $('#ui-unit-type').on('change', async function () {
                         store.set('unit_type', $(this).val());
                         globalSettings.unitType = $(this).val();
 
                         // Update the osd units in global settings
                         // but only if we need it
                         if (globalSettings.unitType === UnitType.OSD) {
-                            get_osd_settings();
+                            await loadOsdUnits();
                         }
 
                         // Horrible way to reload the tab
@@ -820,23 +821,6 @@ $(function() {
 });
 
 
-function get_osd_settings() {
-    if (globalSettings.osdUnits !== undefined && globalSettings.osdUnits !== null) {
-        return;
-    }
-
-    MSP.promise(MSPCodes.MSP2_INAV_OSD_PREFERENCES).then(function (resp) {
-        var prefs = resp.data;
-        prefs.readU8();
-        prefs.readU8();
-        prefs.readU8();
-        prefs.readU8();
-        prefs.readU8();
-        prefs.readU8();
-        prefs.readU8();
-        globalSettings.osdUnits = prefs.readU8();
-    });
-}
 
 function updateProfilesHighlightColours() {
     if (globalSettings.showProfileParameters) {

--- a/js/osdUnits.js
+++ b/js/osdUnits.js
@@ -1,0 +1,27 @@
+import MSP from './msp';
+import MSPCodes from './msp/MSPCodes';
+import CONFIGURATOR from './data_storage';
+import { globalSettings, UnitType } from './globalSettings';
+
+// Resolve controller units before a tab converts its fields. A lost response
+// must not block opening the tab forever; unsupported firmware keeps raw units.
+export function loadOsdUnits() {
+    if (globalSettings.unitType !== UnitType.OSD || !CONFIGURATOR.connectionValid) {
+        return Promise.resolve();
+    }
+    return new Promise(function(resolve) {
+        let finished = false;
+        const timer = setTimeout(() => finish(false), 5000);
+        function finish(response) {
+            if (finished) return;
+            finished = true;
+            clearTimeout(timer);
+            const data = response && !response.unsupported && response.data;
+            globalSettings.osdUnits = data && data.byteLength >= 8 ? data.getUint8(7) : null;
+            resolve();
+        }
+        if (MSP.send_message(MSPCodes.MSP2_INAV_OSD_PREFERENCES, false, false, finish) === false) {
+            finish(false);
+        }
+    });
+}

--- a/js/settings.js
+++ b/js/settings.js
@@ -5,8 +5,15 @@ import mapSeries from 'promise-map-series';
 import mspHelper from './../js/msp/MSPHelper';
 import GUI from './gui';
 import FC from './fc';
-import { globalSettings, UnitType } from './globalSettings';
+import { globalSettings } from './globalSettings';
 import i18n from './localization';
+import {
+    getUnitDecimals,
+    getUnitDisplayName,
+    getUnitExpandedName,
+    getUnitMultiplier,
+    smartRound
+} from './unitConversion';
 
 function padZeros(val, length) {
     let str = val.toString();
@@ -21,49 +28,6 @@ function padZeros(val, length) {
     }
 
     return str;
-}
-
-/**
- * Round a converted value to fewer decimal places when doing so
- * changes the value by less than 1%. For example, 328.08 ft (from 100m)
- * becomes "328" and 9842.52 ft becomes "9843". Also rounds to the
- * nearest 10/100/etc when within 1 of a boundary (e.g. 999 → "1000").
- * Returns a string like toFixed().
- */
-function smartRound(value, decimalPlaces) {
-    if (decimalPlaces < 2 || value === 0) {
-        return value.toFixed(decimalPlaces);
-    }
-    // Try removing decimal places (most aggressive first)
-    let best = null;
-    for (let dp = 0; dp <= decimalPlaces - 2; dp++) {
-        let rounded = parseFloat(value.toFixed(dp));
-        if (Math.abs(rounded - value) / Math.abs(value) < 0.01) {
-            best = rounded.toFixed(dp);
-            break;
-        }
-    }
-    // Try rounding to nearest 10, 100, etc. but only when the integer
-    // value is within 1 of a boundary (e.g. 999->1000, 1001->1000).
-    // Use absolute values for boundary detection to handle negatives.
-    if (best !== null) {
-        let intVal = Math.round(Math.abs(value));
-        for (let mag = 1; mag <= 3; mag++) {
-            let factor = Math.pow(10, mag);
-            let remainder = intVal % factor;
-            if (remainder <= 1 || remainder >= factor - 1) {
-                let rounded = Math.sign(value) * Math.round(Math.abs(value) / factor) * factor;
-                if (Math.abs(rounded - value) / Math.abs(value) < 0.01) {
-                    best = rounded.toFixed(0);
-                } else {
-                    break;
-                }
-            } else {
-                break;
-            }
-        }
-    }
-    return best !== null ? best : value.toFixed(decimalPlaces);
 }
 
 var Settings = (function () {
@@ -224,326 +188,15 @@ var Settings = (function () {
      */
     self.convertToUnitSetting = function (element, inputUnit) {
 
-        // One of the following;
-        // none, OSD, imperial, metric
-        const configUnitType = globalSettings.unitType;
-
-        // Small closure to grab the unit as described by either 
-        // the app settings or the app OSD settings, confused? yeah
-        const getUnitDisplayTypeValue = () => {
-            // Try and match the values 
-            switch (configUnitType) {
-                case UnitType.imperial:
-                    return 0;
-                    break;
-                case UnitType.metric:
-                    return 1;
-                    break;
-                case UnitType.OSD: // Match the OSD value on the UI
-                    return globalSettings.osdUnits;
-                    break;
-                case UnitType.none:
-                default:
-                    return -1;
-                    break;
-            }
-        }
-
-        // Sets the int value of the way we want to display the 
-        // units. We use the OSD unit values here for easy
-        const uiUnitValue = getUnitDisplayTypeValue();
-
         const oldValue = element.val();
-
-        // Display names for the units
-        const unitDisplayNames = {
-            // Misc
-            'cw' : 'cW',
-            'percent'   : '%',
-            'cmss'      : 'cm/s/s',
-            // Time
-            'us'        : "uS",
-            'msec'      : 'ms',
-            'msec-nc'   : 'ms', // Milliseconds, but not converted.
-            'dsec'      : 'ds',
-            'sec'       : 's',
-            'mins'      : 'm',
-            'hours'     : 'h',
-            'tzmins'    : 'm',
-            'tzhours'   : 'hh:mm',
-            // Angles
-            'centideg'      : 'centi&deg;',
-            'centideg-deg'  : 'centi&deg;', // Centidegrees, but always converted to degrees by default
-            'decideg'       : 'deci&deg;',
-            'decideg-lrg'   : 'deci&deg;', // Decidegrees, but always converted to degrees by default
-            'deg'           : '&deg;',
-            'decadeg'       : 'deca&deg;',
-            // Rotational speed
-            'degps'     : '&deg; per second',
-            'decadegps' : 'deca&deg; per second',
-            // Temperature
-            'decidegc'  : 'deci&deg;C',
-            'degc'      : '&deg;C',
-            'degf'      : '&deg;F',
-            // Speed
-            'cms'       : 'cm/s',
-            'v-cms'     : 'cm/s',
-            'ms'        : 'm/s',
-            'kmh'       : 'Km/h',
-            'mph'       : 'mph',
-            'hftmin'    : 'x100 ft/min',
-            'fts'       : 'ft/s',
-            'kt'        : 'Kt',
-            // Distance
-            'cm'    : 'cm',
-            'm'     : 'm',
-            'km'    : 'Km',
-            'm-lrg' : 'm', // Metres, but converted to larger units
-            'ft'    : 'ft',
-            'mi'    : 'mi',
-            'nm'    : 'NM'
-        }
-
-        // Hover full descriptions for the units
-        const unitExpandedNames = {
-            // Misc
-            'cw'        : 'CentiWatts',
-            'percent'   : 'Percent',
-            'cmss'      : 'Centimetres per second, per second',
-            // Time
-            'us'        : "Microseconds",
-            'msec'      : 'Milliseconds',
-            'msec-nc'   : 'Milliseconds',
-            'dsec'      : 'Deciseconds',
-            'sec'       : 'Seconds',
-            'mins'      : 'Minutes',
-            'hours'     : 'Hours',
-            'tzmins'    : 'Minutes',
-            'tzhours'   : 'Hours:Minutes',
-            // Angles
-            'centideg'      : 'CentiDegrees',
-            'centideg-deg'  : 'CentiDegrees',
-            'decideg'       : 'DeciDegrees',
-            'decideg-lrg'   : 'DeciDegrees',
-            'deg'           : 'Degrees',
-            'decadeg'       : 'DecaDegrees',
-            // Rotational speed
-            'degps'     : 'Degrees per second',
-            'decadegps' : 'DecaDegrees per second',
-            // Temperature
-            'decidegc'  : 'DeciDegrees Celsius',
-            'degc'      : 'Degrees Celsius',
-            'degf'      : 'Degrees Fahrenheit',
-            // Speed
-            'cms'       : 'Centimetres per second',
-            'v-cms'     : 'Centimetres per second',
-            'ms'        : 'Metres per second',
-            'kmh'       : 'Kilometres per hour',
-            'mph'       : 'Miles per hour',
-            'hftmin'    : 'Hundred feet per minute',
-            'fts'       : 'Feet per second',
-            'kt'        : 'Knots',
-            // Distance
-            'cm'    : 'Centimetres',
-            'm'     : 'Metres',
-            'km'    : 'Kilometres',
-            'm-lrg' : 'Metres',
-            'ft'    : 'Feet',
-            'mi'    : 'Miles',
-            'nm'    : 'Nautical Miles'
-        }
 
         // Ensure we can do conversions
         if (!inputUnit || !oldValue || !element) {
             return;
         }
 
-        //this is used to get the factor in which we multiply
-        //to get the correct conversion, the first index is the from
-        //unit and the second is the too unit
-        //unitConversionTable[toUnit][fromUnit] -> factor
-        const unitRatioTable = {
-            'cm' : {
-                'm' : 100.0, 
-                'ft' : 30.48
-            },
-            'm' : {
-                'm' : 1.0,
-                'ft' : 0.3048
-            },
-            'm-lrg' : {
-                'km' : 1000.0,
-                'mi' : 1609.344,
-                'nm' : 1852.0
-            },
-            'cms' : { // Horizontal speed
-                'kmh' : 27.77777777777778, 
-                'kt': 51.44444444444457, 
-                'mph' : 44.704,
-                'ms' : 100.0
-            },
-            'v-cms' : { // Vertical speed
-                'ms' : 100.0,
-                'hftmin' : 50.8,
-                'fts' : 30.48
-            },
-            'msec-nc' : {
-                'msec-nc' : 1.0
-            },
-            'msec' : {
-                'sec' : 1000.0
-            },
-            'dsec' : {
-                'sec' : 10.0
-            },
-            'mins' : {
-                'hours' : 60.0
-            },
-            'tzmins' : {
-                'tzhours' : 'TZHOURS'
-            },
-            'centideg' : {
-                'deg' : 100
-            },
-            'centideg-deg' : {
-                'deg' : 100
-            },
-            'decideg' : {
-                'deg' : 10.0
-            },
-            'decideg-lrg' : {
-                'deg' : 10.0
-            },
-            'decadeg' : {
-                'deg' : 0.1
-            },
-            'decadegps' : {
-                'degps' : 0.1
-            },
-            'decidegc' : {
-                'degc' : 10.0,
-                'degf' : 'FAHREN'
-            },
-        };
-
-        //this holds which units get converted in which unit systems
-        const conversionTable = {
-            0: { //imperial
-                'cm' : 'ft',
-                'm' : 'ft',
-                'm-lrg' : 'mi',
-                'cms' : 'mph',
-                'v-cms' : 'fts',
-                'msec' : 'sec',
-                'dsec' : 'sec',
-                'mins' : 'hours',
-                'tzmins' : 'tzhours',
-                'decadegps' : 'degps',
-                'centideg' : 'deg',
-                'centideg-deg' : 'deg',
-                'decideg' : 'deg',
-                'decideg-lrg' : 'deg',
-                'decadeg' : 'deg',
-                'decidegc' : 'degf',
-            },
-            1: { //metric
-                'cm': 'm',
-                'm' : 'm',
-                'm-lrg' : 'km',
-                'cms' : 'kmh',
-                'v-cms' : 'ms',
-                'msec' : 'sec',
-                'dsec' : 'sec',
-                'mins' : 'hours',
-                'tzmins' : 'tzhours',
-                'decadegps' : 'degps',
-                'centideg' : 'deg',
-                'centideg-deg' : 'deg',
-                'decideg' : 'deg',
-                'decideg-lrg' : 'deg',
-                'decadeg' : 'deg',
-                'decidegc' : 'degc',
-            },
-            2: { //metric with MPH
-                'cm': 'm',
-                'm' : 'm',
-                'm-lrg' : 'km',
-                'cms' : 'mph',
-                'v-cms' : 'ms',
-                'decadegps' : 'degps',
-                'centideg' : 'deg',
-                'centideg-deg' : 'deg',
-                'decideg' : 'deg',
-                'decideg-lrg' : 'deg',
-                'decadeg' : 'deg',
-                'msec' : 'sec',
-                'dsec' : 'sec',
-                'mins' : 'hours',
-                'tzmins' : 'tzhours',
-                'decidegc' : 'degc',
-            },
-            3:{ //UK
-                'cm' : 'ft',
-                'm' : 'ft',
-                'm-lrg' : 'mi',
-                'cms' : 'mph',
-                'v-cms' : 'fts',
-                'decadegps' : 'degps',
-                'centideg' : 'deg',
-                'centideg-deg' : 'deg',
-                'decideg' : 'deg',
-                'decideg-lrg' : 'deg',
-                'decadeg' : 'deg',
-                'msec' : 'sec',
-                'dsec' : 'sec',
-                'mins' : 'hours',
-                'tzmins' : 'tzhours',
-                'decidegc' : 'degc',
-            },
-            4: { //General aviation
-                'cm' : 'ft',
-                'm' : 'ft',
-                'm-lrg' : 'nm',
-                'cms': 'kt',
-                'v-cms' : 'hftmin',
-                'decadegps' : 'degps',
-                'centideg' : 'deg',
-                'centideg-deg' : 'deg',
-                'decideg' : 'deg',
-                'decideg-lrg' : 'deg',
-                'decadeg' : 'deg',
-                'msec' : 'sec',
-                'dsec' : 'sec',
-                'mins' : 'hours',
-                'tzmins' : 'tzhours',
-                'decidegc' : 'degc',
-            },
-            default: { //show base units
-                'decadegps' : 'degps',
-                'decideg-lrg' : 'deg',
-                'centideg' : 'deg',
-                'centideg-deg' : 'deg',
-                'decadeg' : 'deg',
-                'tzmins' : 'tzhours',
-            }
-        };
-
-        //this returns the factor in which to multiply to convert a unit
-        const getUnitMultiplier = () => {
-            let uiUnits = (uiUnitValue != -1) ? uiUnitValue : 'default';
-
-            if (conversionTable[uiUnits]){
-                const fromUnits = conversionTable[uiUnits];
-                if (fromUnits[inputUnit]){
-                    const multiplier = unitRatioTable[inputUnit][fromUnits[inputUnit]];
-                    return {'multiplier':multiplier, 'unitName':fromUnits[inputUnit]};
-                }
-            }
-            return {multiplier:1, unitName:inputUnit};
-        }
-
-        // Get the default multi obj or the custom       
-        const multiObj = getUnitMultiplier();
+        // Get the default multi obj or the custom
+        const multiObj = getUnitMultiplier(inputUnit);
 
         const multiplier = multiObj.multiplier;
         const unitName = multiObj.unitName;
@@ -554,11 +207,7 @@ var Settings = (function () {
             let step = parseFloat(element.data("step")) || parseFloat(element.attr('step')) || 1;
 
             if (multiplier !== 1) { 
-                decimalPlaces = Math.min(Math.ceil(multiplier / 100), 3);
-                // Add extra decimal place for non-integer conversions.
-                if (multiplier % 1 != 0 && decimalPlaces < 3) {
-                    decimalPlaces++;
-                }
+                decimalPlaces = getUnitDecimals(multiplier);
                 step = 1 / Math.pow(10, decimalPlaces);
             } else { 
                 decimalPlaces = this.countDecimals(step);
@@ -594,7 +243,7 @@ var Settings = (function () {
         element.data('setting-multiplier', multiplier);
 
         // Now wrap the input in a display that shows the unit
-        element.wrap(`<div data-unit="${unitDisplayNames[unitName]}" title="${unitExpandedNames[unitName]}" class="unit_wrapper unit"></div>`);
+        element.wrap(`<div data-unit="${getUnitDisplayName(unitName)}" title="${getUnitExpandedName(unitName)}" class="unit_wrapper unit"></div>`);
 
         function toFahrenheit(decidegC) {
             return (decidegC / 10) * 1.8 + 32;

--- a/js/unitConversion.js
+++ b/js/unitConversion.js
@@ -1,0 +1,458 @@
+'use strict';
+
+/*
+ * Unit presentation helpers shared by the settings framework and by tabs
+ * that show firmware values outside of the data-setting mechanism.
+ *
+ * Everything in here works on firmware units: a value is converted only for
+ * display, and converted straight back before it is stored or sent.
+ */
+
+import { globalSettings, UnitType } from './globalSettings.js';
+
+/**
+ * Round a converted value to fewer decimal places when doing so
+ * changes the value by less than 1%. For example, 328.08 ft (from 100m)
+ * becomes "328" and 9842.52 ft becomes "9843". Also rounds to the
+ * nearest 10/100/etc when within 1 of a boundary (e.g. 999 → "1000").
+ * Returns a string like toFixed().
+ */
+function smartRound(value, decimalPlaces) {
+    if (decimalPlaces < 2 || value === 0) {
+        return value.toFixed(decimalPlaces);
+    }
+    // Try removing decimal places (most aggressive first)
+    let best = null;
+    for (let dp = 0; dp <= decimalPlaces - 2; dp++) {
+        let rounded = parseFloat(value.toFixed(dp));
+        if (Math.abs(rounded - value) / Math.abs(value) < 0.01) {
+            best = rounded.toFixed(dp);
+            break;
+        }
+    }
+    // Try rounding to nearest 10, 100, etc. but only when the integer
+    // value is within 1 of a boundary (e.g. 999->1000, 1001->1000).
+    // Use absolute values for boundary detection to handle negatives.
+    if (best !== null) {
+        let intVal = Math.round(Math.abs(value));
+        for (let mag = 1; mag <= 3; mag++) {
+            let factor = Math.pow(10, mag);
+            let remainder = intVal % factor;
+            if (remainder <= 1 || remainder >= factor - 1) {
+                let rounded = Math.sign(value) * Math.round(Math.abs(value) / factor) * factor;
+                if (Math.abs(rounded - value) / Math.abs(value) < 0.01) {
+                    best = rounded.toFixed(0);
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+    }
+    return best !== null ? best : value.toFixed(decimalPlaces);
+}
+
+// Display names for the units
+const unitDisplayNames = {
+    // Misc
+    'cw' : 'cW',
+    'percent'   : '%',
+    'cmss'      : 'cm/s/s',
+    // Time
+    'us'        : "uS",
+    'msec'      : 'ms',
+    'msec-nc'   : 'ms', // Milliseconds, but not converted.
+    'dsec'      : 'ds',
+    'sec'       : 's',
+    'mins'      : 'm',
+    'hours'     : 'h',
+    'tzmins'    : 'm',
+    'tzhours'   : 'hh:mm',
+    // Angles
+    'centideg'      : 'centi&deg;',
+    'centideg-deg'  : 'centi&deg;', // Centidegrees, but always converted to degrees by default
+    'decideg'       : 'deci&deg;',
+    'decideg-lrg'   : 'deci&deg;', // Decidegrees, but always converted to degrees by default
+    'deg'           : '&deg;',
+    'decadeg'       : 'deca&deg;',
+    // Rotational speed
+    'degps'     : '&deg; per second',
+    'decadegps' : 'deca&deg; per second',
+    // Temperature
+    'decidegc'  : 'deci&deg;C',
+    'degc'      : '&deg;C',
+    'degf'      : '&deg;F',
+    // Speed
+    'cms'       : 'cm/s',
+    'v-cms'     : 'cm/s',
+    'ms'        : 'm/s',
+    'kmh'       : 'Km/h',
+    'mph'       : 'mph',
+    'hftmin'    : 'x100 ft/min',
+    'fts'       : 'ft/s',
+    'kt'        : 'Kt',
+    // Distance
+    'cm'    : 'cm',
+    'm'     : 'm',
+    'km'    : 'Km',
+    'm-lrg' : 'm', // Metres, but converted to larger units
+    'ft'    : 'ft',
+    'mi'    : 'mi',
+    'nm'    : 'NM'
+}
+
+// Hover full descriptions for the units
+const unitExpandedNames = {
+    // Misc
+    'cw'        : 'CentiWatts',
+    'percent'   : 'Percent',
+    'cmss'      : 'Centimetres per second, per second',
+    // Time
+    'us'        : "Microseconds",
+    'msec'      : 'Milliseconds',
+    'msec-nc'   : 'Milliseconds',
+    'dsec'      : 'Deciseconds',
+    'sec'       : 'Seconds',
+    'mins'      : 'Minutes',
+    'hours'     : 'Hours',
+    'tzmins'    : 'Minutes',
+    'tzhours'   : 'Hours:Minutes',
+    // Angles
+    'centideg'      : 'CentiDegrees',
+    'centideg-deg'  : 'CentiDegrees',
+    'decideg'       : 'DeciDegrees',
+    'decideg-lrg'   : 'DeciDegrees',
+    'deg'           : 'Degrees',
+    'decadeg'       : 'DecaDegrees',
+    // Rotational speed
+    'degps'     : 'Degrees per second',
+    'decadegps' : 'DecaDegrees per second',
+    // Temperature
+    'decidegc'  : 'DeciDegrees Celsius',
+    'degc'      : 'Degrees Celsius',
+    'degf'      : 'Degrees Fahrenheit',
+    // Speed
+    'cms'       : 'Centimetres per second',
+    'v-cms'     : 'Centimetres per second',
+    'ms'        : 'Metres per second',
+    'kmh'       : 'Kilometres per hour',
+    'mph'       : 'Miles per hour',
+    'hftmin'    : 'Hundred feet per minute',
+    'fts'       : 'Feet per second',
+    'kt'        : 'Knots',
+    // Distance
+    'cm'    : 'Centimetres',
+    'm'     : 'Metres',
+    'km'    : 'Kilometres',
+    'm-lrg' : 'Metres',
+    'ft'    : 'Feet',
+    'mi'    : 'Miles',
+    'nm'    : 'Nautical Miles'
+}
+
+// this is used to get the factor in which we multiply
+// to get the correct conversion, the first index is the from
+// unit and the second is the too unit
+// unitConversionTable[toUnit][fromUnit] -> factor
+const unitRatioTable = {
+    'cm' : {
+        'm' : 100.0, 
+        'ft' : 30.48
+    },
+    'm' : {
+        'm' : 1.0,
+        'ft' : 0.3048
+    },
+    'm-lrg' : {
+        'km' : 1000.0,
+        'mi' : 1609.344,
+        'nm' : 1852.0
+    },
+    'cms' : { // Horizontal speed
+        'kmh' : 27.77777777777778, 
+        'kt': 51.44444444444457, 
+        'mph' : 44.704,
+        'ms' : 100.0
+    },
+    'v-cms' : { // Vertical speed
+        'ms' : 100.0,
+        'hftmin' : 50.8,
+        'fts' : 30.48
+    },
+    'msec-nc' : {
+        'msec-nc' : 1.0
+    },
+    'msec' : {
+        'sec' : 1000.0
+    },
+    'dsec' : {
+        'sec' : 10.0
+    },
+    'mins' : {
+        'hours' : 60.0
+    },
+    'tzmins' : {
+        'tzhours' : 'TZHOURS'
+    },
+    'centideg' : {
+        'deg' : 100
+    },
+    'centideg-deg' : {
+        'deg' : 100
+    },
+    'decideg' : {
+        'deg' : 10.0
+    },
+    'decideg-lrg' : {
+        'deg' : 10.0
+    },
+    'decadeg' : {
+        'deg' : 0.1
+    },
+    'decadegps' : {
+        'degps' : 0.1
+    },
+    'decidegc' : {
+        'degc' : 10.0,
+        'degf' : 'FAHREN'
+    },
+};
+
+// this holds which units get converted in which unit systems
+const conversionTable = {
+    0: { //imperial
+        'cm' : 'ft',
+        'm' : 'ft',
+        'm-lrg' : 'mi',
+        'cms' : 'mph',
+        'v-cms' : 'fts',
+        'msec' : 'sec',
+        'dsec' : 'sec',
+        'mins' : 'hours',
+        'tzmins' : 'tzhours',
+        'decadegps' : 'degps',
+        'centideg' : 'deg',
+        'centideg-deg' : 'deg',
+        'decideg' : 'deg',
+        'decideg-lrg' : 'deg',
+        'decadeg' : 'deg',
+        'decidegc' : 'degf',
+    },
+    1: { //metric
+        'cm': 'm',
+        'm' : 'm',
+        'm-lrg' : 'km',
+        'cms' : 'kmh',
+        'v-cms' : 'ms',
+        'msec' : 'sec',
+        'dsec' : 'sec',
+        'mins' : 'hours',
+        'tzmins' : 'tzhours',
+        'decadegps' : 'degps',
+        'centideg' : 'deg',
+        'centideg-deg' : 'deg',
+        'decideg' : 'deg',
+        'decideg-lrg' : 'deg',
+        'decadeg' : 'deg',
+        'decidegc' : 'degc',
+    },
+    2: { //metric with MPH
+        'cm': 'm',
+        'm' : 'm',
+        'm-lrg' : 'km',
+        'cms' : 'mph',
+        'v-cms' : 'ms',
+        'decadegps' : 'degps',
+        'centideg' : 'deg',
+        'centideg-deg' : 'deg',
+        'decideg' : 'deg',
+        'decideg-lrg' : 'deg',
+        'decadeg' : 'deg',
+        'msec' : 'sec',
+        'dsec' : 'sec',
+        'mins' : 'hours',
+        'tzmins' : 'tzhours',
+        'decidegc' : 'degc',
+    },
+    3:{ //UK
+        'cm' : 'ft',
+        'm' : 'ft',
+        'm-lrg' : 'mi',
+        'cms' : 'mph',
+        'v-cms' : 'fts',
+        'decadegps' : 'degps',
+        'centideg' : 'deg',
+        'centideg-deg' : 'deg',
+        'decideg' : 'deg',
+        'decideg-lrg' : 'deg',
+        'decadeg' : 'deg',
+        'msec' : 'sec',
+        'dsec' : 'sec',
+        'mins' : 'hours',
+        'tzmins' : 'tzhours',
+        'decidegc' : 'degc',
+    },
+    4: { //General aviation
+        'cm' : 'ft',
+        'm' : 'ft',
+        'm-lrg' : 'nm',
+        'cms': 'kt',
+        'v-cms' : 'hftmin',
+        'decadegps' : 'degps',
+        'centideg' : 'deg',
+        'centideg-deg' : 'deg',
+        'decideg' : 'deg',
+        'decideg-lrg' : 'deg',
+        'decadeg' : 'deg',
+        'msec' : 'sec',
+        'dsec' : 'sec',
+        'mins' : 'hours',
+        'tzmins' : 'tzhours',
+        'decidegc' : 'degc',
+    },
+    default: { //show base units
+        'decadegps' : 'degps',
+        'decideg-lrg' : 'deg',
+        'centideg' : 'deg',
+        'centideg-deg' : 'deg',
+        'decadeg' : 'deg',
+        'tzmins' : 'tzhours',
+    }
+};
+
+/**
+ * The unit system currently selected in the Configurator options, expressed
+ * with the OSD unit numbering (0 imperial, 1 metric, 2 metric/MPH, 3 UK,
+ * 4 general aviation). -1 means "leave the firmware units alone".
+ */
+function getUnitSystem() {
+    switch (globalSettings.unitType) {
+        case UnitType.imperial:
+            return 0;
+        case UnitType.metric:
+            return 1;
+        case UnitType.OSD: // Match the OSD value on the UI
+            return globalSettings.osdUnits;
+        case UnitType.none:
+        default:
+            return -1;
+    }
+}
+
+/**
+ * Returns the factor a firmware value has to be divided by to reach the
+ * display unit, together with the name of that display unit. A multiplier of
+ * 1 means the firmware unit is shown unchanged.
+ */
+function getUnitMultiplier(inputUnit) {
+    const uiUnitValue = getUnitSystem();
+    const uiUnits = (uiUnitValue != -1) ? uiUnitValue : 'default';
+
+    if (conversionTable[uiUnits]) {
+        const fromUnits = conversionTable[uiUnits];
+        if (fromUnits[inputUnit]) {
+            const multiplier = unitRatioTable[inputUnit][fromUnits[inputUnit]];
+            return {'multiplier': multiplier, 'unitName': fromUnits[inputUnit]};
+        }
+    }
+    return {multiplier: 1, unitName: inputUnit};
+}
+
+/** Short symbol of a display unit, e.g. "ft". */
+function getUnitDisplayName(unitName) {
+    return unitDisplayNames[unitName];
+}
+
+/** Long description of a display unit, used for hover titles. */
+function getUnitExpandedName(unitName) {
+    return unitExpandedNames[unitName];
+}
+
+/**
+ * Number of decimal places a converted value is shown with. Mirrors what
+ * Settings.convertToUnitSetting() derives for the input step.
+ */
+function getUnitDecimals(multiplier) {
+    if (typeof multiplier !== 'number' || multiplier === 1) {
+        return 0;
+    }
+
+    let decimalPlaces = Math.min(Math.ceil(multiplier / 100), 3);
+    // Add extra decimal place for non-integer conversions.
+    if (multiplier % 1 != 0 && decimalPlaces < 3) {
+        decimalPlaces++;
+    }
+    return decimalPlaces;
+}
+
+/**
+ * Converts a firmware value for display.
+ *
+ * The returned object carries the numeric value, the same value already
+ * formatted for an input field, and the unit it is expressed in. Units with
+ * a non numeric conversion (temperature, time zones) are passed through
+ * untouched, they never appear outside of the settings framework.
+ */
+function toDisplayUnits(value, inputUnit) {
+    const converted = getUnitMultiplier(inputUnit);
+    const multiplier = converted.multiplier;
+    const numeric = Number(value);
+
+    if (typeof multiplier !== 'number' || !isFinite(numeric)) {
+        return {
+            value: numeric,
+            text: String(value),
+            unitName: inputUnit,
+            displayName: getUnitDisplayName(inputUnit),
+            multiplier: 1,
+            decimals: 0
+        };
+    }
+
+    const decimals = getUnitDecimals(multiplier);
+    const displayValue = numeric / multiplier;
+
+    return {
+        value: displayValue,
+        text: smartRound(displayValue, decimals),
+        unitName: converted.unitName,
+        displayName: getUnitDisplayName(converted.unitName),
+        multiplier: multiplier,
+        decimals: decimals
+    };
+}
+
+/**
+ * Converts a value the user typed in the display unit back to firmware
+ * units. precision is the number of decimals the firmware unit itself
+ * supports and defaults to 0, which is what whole cm/cm per s fields need.
+ */
+function fromDisplayUnits(value, inputUnit, precision = 0) {
+    const converted = getUnitMultiplier(inputUnit);
+    const multiplier = converted.multiplier;
+    const numeric = Number(value);
+
+    if (typeof multiplier !== 'number' || !isFinite(numeric)) {
+        return numeric;
+    }
+
+    const raw = numeric * multiplier;
+    if (precision <= 0) {
+        return Math.round(raw);
+    }
+
+    const factor = Math.pow(10, precision);
+    return Math.round(raw * factor) / factor;
+}
+
+export {
+    fromDisplayUnits,
+    getUnitDecimals,
+    getUnitDisplayName,
+    getUnitExpandedName,
+    getUnitMultiplier,
+    smartRound,
+    toDisplayUnits
+};
+

--- a/js/unitConversion.js
+++ b/js/unitConversion.js
@@ -11,6 +11,33 @@
 import { globalSettings, UnitType } from './globalSettings.js';
 
 /**
+ * Round to the nearest 10, 100, etc. but only while the integer value is
+ * within 1 of a boundary (e.g. 999->1000, 1001->1000) and rounding changes
+ * the value by less than 1%. Absolute values are used for the boundary
+ * detection so negatives behave the same. Returns the roundest match as a
+ * string, or fallback when no magnitude fits.
+ */
+function roundToMagnitude(value, fallback) {
+    let best = fallback;
+    let intVal = Math.round(Math.abs(value));
+    for (let mag = 1; mag <= 3; mag++) {
+        let factor = Math.pow(10, mag);
+        let remainder = intVal % factor;
+        if (remainder <= 1 || remainder >= factor - 1) {
+            let rounded = Math.sign(value) * Math.round(Math.abs(value) / factor) * factor;
+            if (Math.abs(rounded - value) / Math.abs(value) < 0.01) {
+                best = rounded.toFixed(0);
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return best;
+}
+
+/**
  * Round a converted value to fewer decimal places when doing so
  * changes the value by less than 1%. For example, 328.08 ft (from 100m)
  * becomes "328" and 9842.52 ft becomes "9843". Also rounds to the
@@ -24,31 +51,14 @@ function smartRound(value, decimalPlaces) {
     // Try removing decimal places (most aggressive first)
     let best = null;
     for (let dp = 0; dp <= decimalPlaces - 2; dp++) {
-        let rounded = parseFloat(value.toFixed(dp));
+        let rounded = Number.parseFloat(value.toFixed(dp));
         if (Math.abs(rounded - value) / Math.abs(value) < 0.01) {
             best = rounded.toFixed(dp);
             break;
         }
     }
-    // Try rounding to nearest 10, 100, etc. but only when the integer
-    // value is within 1 of a boundary (e.g. 999->1000, 1001->1000).
-    // Use absolute values for boundary detection to handle negatives.
     if (best !== null) {
-        let intVal = Math.round(Math.abs(value));
-        for (let mag = 1; mag <= 3; mag++) {
-            let factor = Math.pow(10, mag);
-            let remainder = intVal % factor;
-            if (remainder <= 1 || remainder >= factor - 1) {
-                let rounded = Math.sign(value) * Math.round(Math.abs(value) / factor) * factor;
-                if (Math.abs(rounded - value) / Math.abs(value) < 0.01) {
-                    best = rounded.toFixed(0);
-                } else {
-                    break;
-                }
-            } else {
-                break;
-            }
-        }
+        best = roundToMagnitude(value, best);
     }
     return best !== null ? best : value.toFixed(decimalPlaces);
 }
@@ -399,7 +409,7 @@ function toDisplayUnits(value, inputUnit) {
     const multiplier = converted.multiplier;
     const numeric = Number(value);
 
-    if (typeof multiplier !== 'number' || !isFinite(numeric)) {
+    if (typeof multiplier !== 'number' || !Number.isFinite(numeric)) {
         return {
             value: numeric,
             text: String(value),
@@ -433,7 +443,7 @@ function fromDisplayUnits(value, inputUnit, precision = 0) {
     const multiplier = converted.multiplier;
     const numeric = Number(value);
 
-    if (typeof multiplier !== 'number' || !isFinite(numeric)) {
+    if (typeof multiplier !== 'number' || !Number.isFinite(numeric)) {
         return numeric;
     }
 

--- a/locale/bg/messages.json
+++ b/locale/bg/messages.json
@@ -4559,7 +4559,7 @@
     "message": "Зареден файл:"
   },
   "missionTotalInfoDistance": {
-    "message": "Разстояние (m):"
+    "message": "Разстояние:"
   },
   "missionTotalInfoAvailablePoints": {
     "message": "Налични точки"
@@ -4568,10 +4568,10 @@
     "message": "Мисията е валидна"
   },
   "missionDefaultPointAlt": {
-    "message": "Височина (cm): "
+    "message": "Височина: "
   },
   "missionDefaultPointSpeed": {
-    "message": "Скорост (cm/s): "
+    "message": "Скорост: "
   },
   "missionDefaultSafeRangeSH": {
     "message": "Радиус (m): "
@@ -4703,10 +4703,10 @@
     "message": "Настройки за кацане на самолети:"
   },
   "missionFwApproachAlt": {
-    "message": "Височина на подход: (cm):"
+    "message": "Височина на подход:"
   },
   "missionFwLandAlt": {
-    "message": "Височина за кацане: (cm):"
+    "message": "Височина за кацане:"
   },
   "missionFwApproachDir": {
     "message": "Посока на подход:"

--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -4866,7 +4866,7 @@
         "message": "Geladene Datei:"
     },
     "missionTotalInfoDistance": {
-        "message": "Distanz (m):"
+        "message": "Distanz:"
     },
     "missionTotalInfoAvailablePoints": {
         "message": "Verfügbare Punkte"
@@ -4875,10 +4875,10 @@
         "message": "Mission gültig"
     },
     "missionDefaultPointAlt": {
-        "message": "Höhe (cm): "
+        "message": "Höhe: "
     },
     "missionDefaultPointSpeed": {
-        "message": "Geschwindigkeit (cm/s): "
+        "message": "Geschwindigkeit: "
     },
     "missionDefaultSafeRangeSH": {
         "message": "Radius (m): "
@@ -5025,10 +5025,10 @@
         "message": "Fixed Wing Landeeinstellungen:"
     },
     "missionFwApproachAlt": {
-        "message": "Anflughöhe: (cm):"
+        "message": "Anflughöhe:"
     },
     "missionFwLandAlt": {
-        "message": "Landehöhe: (cm):"
+        "message": "Landehöhe:"
     },
     "missionFwApproachDir": {
         "message": "Anflugrichtung:"

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5208,7 +5208,7 @@
         "message": "Filename loaded:"
     },
     "missionTotalInfoDistance": {
-        "message": "Distance (m):"
+        "message": "Distance:"
     },
     "missionTotalInfoAvailablePoints": {
         "message": "Available Points"
@@ -5217,10 +5217,10 @@
         "message": "Mission valid"
     },
     "missionDefaultPointAlt": {
-        "message": "Alt (cm): "
+        "message": "Alt: "
     },
     "missionDefaultPointSpeed": {
-        "message": "Speed (cm/s): "
+        "message": "Speed: "
     },
     "missionDefaultSafeRangeSH": {
         "message": "Radius (m): "
@@ -5367,10 +5367,10 @@
         "message": "Fixed Wing landing settings:"
     },
     "missionFwApproachAlt": {
-        "message": "Approach Alt: (cm):"
+        "message": "Approach Alt:"
     },
     "missionFwLandAlt": {
-        "message": "Land Alt: (cm):"
+        "message": "Land Alt:"
     },
     "missionFwApproachDir": {
         "message": "Approach direction:"

--- a/locale/it/messages.json
+++ b/locale/it/messages.json
@@ -4528,7 +4528,7 @@
         "message": "Nome file caricato:"
     },
     "missionTotalInfoDistance": {
-        "message": "Distanza (m):"
+        "message": "Distanza:"
     },
     "missionTotalInfoAvailablePoints": {
         "message": "Punti Disponibili"
@@ -4537,10 +4537,10 @@
         "message": "Missione valida"
     },
     "missionDefaultPointAlt": {
-        "message": "Alt (cm): "
+        "message": "Alt: "
     },
     "missionDefaultPointSpeed": {
-        "message": "Velocità (cm/s): "
+        "message": "Velocità: "
     },
     "missionDefaultSafeRangeSH": {
         "message": "Raggio (m): "
@@ -4672,10 +4672,10 @@
         "message": "Impostazioni atterraggio ala fissa:"
     },
     "missionFwApproachAlt": {
-        "message": "Alt Approccio: (cm):"
+        "message": "Alt Approccio:"
     },
     "missionFwLandAlt": {
-        "message": "Alt Atterraggio: (cm):"
+        "message": "Alt Atterraggio:"
     },
     "missionFwApproachDir": {
         "message": "Direzione approccio:"

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -4570,7 +4570,7 @@
         "message": "読み込まれたファイル名: "
     },
     "missionTotalInfoDistance": {
-        "message": "距離 (m):"
+        "message": "距離:"
     },
     "missionTotalInfoAvailablePoints": {
         "message": "利用可能なポイント"
@@ -4579,10 +4579,10 @@
         "message": "ミッションが有効"
     },
     "missionDefaultPointAlt": {
-        "message": "高度 (cm): "
+        "message": "高度: "
     },
     "missionDefaultPointSpeed": {
-        "message": "速度 (cm/s): "
+        "message": "速度: "
     },
     "missionDefaultSafeRangeSH": {
         "message": "半径 (m): "
@@ -4714,10 +4714,10 @@
         "message": "固定翼機 着陸設定: "
     },
     "missionFwApproachAlt": {
-        "message": "進入高度 (cm): "
+        "message": "進入高度: "
     },
     "missionFwLandAlt": {
-        "message": "着陸高度 (cm): "
+        "message": "着陸高度: "
     },
     "missionFwApproachDir": {
         "message": "進入方向: "

--- a/locale/ru/messages.json
+++ b/locale/ru/messages.json
@@ -361,7 +361,7 @@
         "message": "Аналоговый вход RSSI"
     },
     "missionTotalInfoDistance": {
-        "message": "Расстояние (м):"
+        "message": "Расстояние:"
     },
     "sitlSimulator": {
         "message": "Симулятор"
@@ -1102,7 +1102,7 @@
         "message": "Миссия действительна"
     },
     "missionFwApproachAlt": {
-        "message": "Высота захода на посадку (см):"
+        "message": "Высота захода на посадку:"
     },
     "proxyLayer": {
         "message": "Слой MapProxy"
@@ -3422,7 +3422,7 @@
         "message": "Загрузить файл"
     },
     "missionFwLandAlt": {
-        "message": "Высота приземления (см):"
+        "message": "Высота приземления:"
     },
     "configurationVTXNoBandHelp": {
         "message": "Частота VTX установлена вручную. Выбор диапазона приведёт к перезаписи настроенной частоты."
@@ -4236,7 +4236,7 @@
         "message": "Выбранный вручную"
     },
     "missionDefaultPointSpeed": {
-        "message": "Скорость (см/с): "
+        "message": "Скорость: "
     },
     "osd_camera_fov_h": {
         "message": "Гориз. угол обзора камеры"
@@ -6007,7 +6007,7 @@
         "message": "Максимальный угол крена в навигационных режимах. Ограничен максимальным углом крена на вкладке «PID настройки»."
     },
     "missionDefaultPointAlt": {
-        "message": "Высота (см): "
+        "message": "Высота: "
     },
     "functionFlags": {
         "message": "Флаги"

--- a/locale/uk/messages.json
+++ b/locale/uk/messages.json
@@ -4582,7 +4582,7 @@
         "message": "Завантажено файл:"
     },
     "missionTotalInfoDistance": {
-        "message": "Відстань (м):"
+        "message": "Відстань:"
     },
     "missionTotalInfoAvailablePoints": {
         "message": "Доступні точки"
@@ -4591,10 +4591,10 @@
         "message": "Місія дійсна"
     },
     "missionDefaultPointAlt": {
-        "message": "Висота (см):"
+        "message": "Висота:"
     },
     "missionDefaultPointSpeed": {
-        "message": "Швидкість (см/с):"
+        "message": "Швидкість:"
     },
     "missionDefaultSafeRangeSH": {
         "message": "Радіус (м):"
@@ -4726,10 +4726,10 @@
         "message": "Налаштування посадки для фіксованого крила:"
     },
     "missionFwApproachAlt": {
-        "message": "Висота наближення: (см):"
+        "message": "Висота наближення:"
     },
     "missionFwLandAlt": {
-        "message": "Висота приземлення: (см):"
+        "message": "Висота приземлення:"
     },
     "missionFwApproachDir": {
         "message": "Напрямок наближення:"

--- a/locale/zh_CN/messages.json
+++ b/locale/zh_CN/messages.json
@@ -4596,7 +4596,7 @@
         "message": "已加载文件:"
     },
     "missionTotalInfoDistance": {
-        "message": "距离 (m):"
+        "message": "距离:"
     },
     "missionTotalInfoAvailablePoints": {
         "message": "可用航点"
@@ -4605,10 +4605,10 @@
         "message": "有效任务"
     },
     "missionDefaultPointAlt": {
-        "message": "高度 (cm): "
+        "message": "高度: "
     },
     "missionDefaultPointSpeed": {
-        "message": "速度 (cm/s): "
+        "message": "速度: "
     },
     "missionDefaultSafeRangeSH": {
         "message": "半径 (m): "
@@ -4740,10 +4740,10 @@
         "message": "固定翼着陆设置:"
     },
     "missionFwApproachAlt": {
-        "message": "进场高度: (厘米):"
+        "message": "进场高度:"
     },
     "missionFwLandAlt": {
-        "message": "着陆高度: (厘米):"
+        "message": "着陆高度:"
     },
     "missionFwApproachDir": {
         "message": "进场方向:"

--- a/tabs/mission_control.html
+++ b/tabs/mission_control.html
@@ -169,23 +169,23 @@
                     <div class="spacer">
                         <div class="point">
                             <label class="point-label" for="MPdefaultPointAlt" data-i18n="missionDefaultPointAlt"></label>
-                            <input id="MPdefaultPointAlt" type="text" value="0" required>
+                            <input id="MPdefaultPointAlt" type="text" value="0" required><span class="input-unit" id="MPdefaultPointAltUnit"></span>
                         </div>
                         <div class="point">
                             <label class="point-label" for="MPdefaultPointSpeed" data-i18n="missionDefaultPointSpeed"></label>
-                            <input id="MPdefaultPointSpeed" type="text" value="0" required>
+                            <input id="MPdefaultPointSpeed" type="text" value="0" required><span class="input-unit" id="MPdefaultPointSpeedUnit"></span>
                         </div>
                         <div class="point">
                             <label class="point-label" for="MPdefaultSafeRangeSH" data-i18n="missionDefaultSafeRangeSH"></label>
                             <input id="MPdefaultSafeRangeSH" type="text" value="0" required>
                         </div>
                         <div class="point">
-                            <label class="point-label" for="MPdefaultFwApproachAlt">FW Approach Alt (m): </label>
-                            <input id="MPdefaultFwApproachAlt" type="text" value="0" required>
+                            <label class="point-label" for="MPdefaultFwApproachAlt">FW Approach Alt: </label>
+                            <input id="MPdefaultFwApproachAlt" type="text" value="0" required><span class="input-unit" id="MPdefaultFwApproachAltUnit"></span>
                         </div>
                         <div class="point">
-                            <label class="point-label" for="MPdefaultLandAlt">FW Land Alt (m): </label>
-                            <input id="MPdefaultLandAlt" type="text" value="0" required>
+                            <label class="point-label" for="MPdefaultLandAlt">FW Land Alt: </label>
+                            <input id="MPdefaultLandAlt" type="text" value="0" required><span class="input-unit" id="MPdefaultLandAltUnit"></span>
                         </div>
                     </div>
                 </div>

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -79,6 +79,7 @@ import SafehomeCollection from './../js/safehomeCollection';
 import { ApproachDirection, FwApproach } from './../js/fwApproach';
 import FwApproachCollection from './../js/fwApproachCollection';
 import SerialBackend from './../js/serial_backend';
+import { loadOsdUnits } from './../js/osdUnits';
 import { distanceOnLine, wrap_360, calculate_new_cooridatnes } from './../js/helpers';
 import interval from './../js/intervals';
 import { Geozone, GeozoneVertex, GeozoneType, GeozoneShapes, GeozoneFenceAction }  from './../js/geozone';
@@ -1203,7 +1204,9 @@ missionControlTab.initialize = function (callback) {
                 }).then(callback);
             }
         ]);
-        loadChainer.setExitPoint(loadHtml);
+        loadChainer.setExitPoint(function () {
+            loadOsdUnits().then(loadHtml);
+        });
         loadChainer.execute();
     } else {
 

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -136,7 +136,7 @@ var dictOfLabelParameterPoint = {
 // setting. Their unit is appended to the label above and the field is
 // converted on the way in and out; every other parameter keeps the unit
 // spelled out in its own label.
-var dictOfUnitParameterPoint = {
+const dictOfUnitParameterPoint = {
     1:  {parameter1: MISSION_UNIT_SPEED},
     3:  {parameter2: MISSION_UNIT_SPEED},
     8:  {parameter1: MISSION_UNIT_SPEED}
@@ -4820,7 +4820,6 @@ function iconKey(filename) {
                 (async () => {
                     const elevationAtWP = await selectedMarker.getElevation(globalSettings);
                     $('#elevationValueAtWP').text(elevationAtWP);
-                    var altitude = altitudeFromDisplay($('#pointAlt').val());
 
                     if (P3Value != selectedMarker.getP3()) {
                         selectedMarker.setP3(P3Value);

--- a/tabs/mission_control.js
+++ b/tabs/mission_control.js
@@ -84,6 +84,7 @@ import interval from './../js/intervals';
 import { Geozone, GeozoneVertex, GeozoneType, GeozoneShapes, GeozoneFenceAction }  from './../js/geozone';
 import store from './../js/store';
 import dialog from '../js/dialog';
+import { fromDisplayUnits, getUnitDisplayName, getUnitMultiplier, toDisplayUnits } from './../js/unitConversion';
 import {
     getMission3DPlannedHeight,
     getMission3DPointLabel,
@@ -112,17 +113,101 @@ class KMZ extends KML {
 
 var MAX_NEG_FW_LAND_ALT = -2000; // cm
 
+// Firmware units behind the mission planner fields. Missions are stored and
+// sent in these units, only what the user reads and types is converted, so a
+// value typed in feet comes back unchanged after a save and a reload.
+const MISSION_UNIT_ALT = 'cm';
+const MISSION_UNIT_SPEED = 'cms';
+const MISSION_UNIT_DIST = 'm';
+
 // Dictionary of Parameter 1,2,3 definition depending on type of action selected (refer to MWNP.WPTYPE)
 var dictOfLabelParameterPoint = {
-    1:  {parameter1: 'Speed (cm/s)', parameter2: '', parameter3: 'Sea level Ref'},
+    1:  {parameter1: 'Speed', parameter2: '', parameter3: 'Sea level Ref'},
     2:  {parameter1: '', parameter2: '', parameter3: ''},
-    3:  {parameter1: 'Wait time (s)', parameter2: 'Speed (cm/s)', parameter3: 'Sea level Ref'},
+    3:  {parameter1: 'Wait time (s)', parameter2: 'Speed', parameter3: 'Sea level Ref'},
     4:  {parameter1: 'Force land (non zero)', parameter2: '', parameter3: ''},
     5:  {parameter1: '', parameter2: '', parameter3: ''},
     6:  {parameter1: 'Target WP number', parameter2: 'Number of repeat (-1: infinite)', parameter3: ''},
     7:  {parameter1: 'Heading (deg)', parameter2: '', parameter3: ''},
-    8:  {parameter1: 'Speed (cm/s)', parameter2: '', parameter3: 'Sea level Ref'}
+    8:  {parameter1: 'Speed', parameter2: '', parameter3: 'Sea level Ref'}
 };
+
+// Parameters that carry a firmware value which has to follow the unit
+// setting. Their unit is appended to the label above and the field is
+// converted on the way in and out; every other parameter keeps the unit
+// spelled out in its own label.
+var dictOfUnitParameterPoint = {
+    1:  {parameter1: MISSION_UNIT_SPEED},
+    3:  {parameter2: MISSION_UNIT_SPEED},
+    8:  {parameter1: MISSION_UNIT_SPEED}
+};
+
+/* Symbol of the unit a firmware unit is currently displayed in. */
+function missionUnitLabel(firmwareUnit) {
+    return getUnitDisplayName(getUnitMultiplier(firmwareUnit).unitName);
+}
+
+/* Waypoint and approach altitudes, held in centimetres by the firmware. */
+function altitudeToDisplay(centimetres) {
+    return toDisplayUnits(centimetres, MISSION_UNIT_ALT).text;
+}
+
+function altitudeFromDisplay(value) {
+    return fromDisplayUnits(value, MISSION_UNIT_ALT);
+}
+
+/*
+ * Readout next to an altitude field. Without a unit system the field still
+ * holds centimetres, so the metre value stays the hint it has always been.
+ * Once a unit system is selected the field itself is converted and only the
+ * unit name is missing.
+ */
+function altitudeReadout(centimetres) {
+    const converted = toDisplayUnits(centimetres, MISSION_UNIT_ALT);
+
+    if (converted.multiplier === 1) {
+        // The field itself is in centimetres, so keep showing the metre
+        // value that has always been spelled out next to it.
+        return ' cm (' + (Number(centimetres) / 100) + ' m)';
+    }
+    return ' ' + converted.displayName;
+}
+
+/* Unit of a waypoint parameter, undefined when it does not follow the setting. */
+function parameterUnit(action, parameterKey) {
+    return dictOfUnitParameterPoint[action] ? dictOfUnitParameterPoint[action][parameterKey] : undefined;
+}
+
+/* Label of a waypoint parameter, with its unit appended when it has one. */
+function parameterLabel(action, parameterKey) {
+    const label = dictOfLabelParameterPoint[action][parameterKey];
+    const unit = parameterUnit(action, parameterKey);
+
+    if (label === '' || !unit) {
+        return label;
+    }
+    return label + ' (' + missionUnitLabel(unit) + ')';
+}
+
+/* Waypoint parameter for display, unchanged when it has no unit. */
+function parameterToDisplay(action, parameterKey, value) {
+    const unit = parameterUnit(action, parameterKey);
+    return unit ? toDisplayUnits(value, unit).text : value;
+}
+
+/* Waypoint parameter back in firmware units. */
+function parameterFromDisplay(action, parameterKey, value) {
+    const unit = parameterUnit(action, parameterKey);
+    return unit ? fromDisplayUnits(value, unit) : Number(value);
+}
+
+/* Total mission length, always shown with the unit it is expressed in. */
+function missionDistanceText(metres) {
+    const converted = toDisplayUnits(metres, MISSION_UNIT_DIST);
+    const text = converted.multiplier === 1 ? Number(metres).toFixed(1) : converted.text;
+
+    return text + ' ' + converted.displayName;
+}
 
 var waypointOptions = ['JUMP','SET_HEAD','RTH'];
 
@@ -2041,7 +2126,7 @@ function iconKey(filename) {
         $('#pointP1').val('');
         $('#pointP2').val('');
         $('#pointP3Alt').val('');
-        $('#missionDistance').text(0);
+        $('#missionDistance').text(missionDistanceText(0));
         $('#MPeditPoint').fadeOut(300);
     }
 
@@ -2073,11 +2158,16 @@ function iconKey(filename) {
     }
 
     function refreshSettings() {
-        $('#MPdefaultPointAlt').val(String(settings.alt));
-        $('#MPdefaultPointSpeed').val(String(settings.speed));
+        $('#MPdefaultPointAlt').val(altitudeToDisplay(settings.alt));
+        $('#MPdefaultPointSpeed').val(toDisplayUnits(settings.speed, MISSION_UNIT_SPEED).text);
         $('#MPdefaultSafeRangeSH').val(String(settings.safeRadiusSH));
-        $('#MPdefaultFwApproachAlt').val(String(settings.fwApproachAlt));
-        $('#MPdefaultLandAlt').val(String(settings.fwLandAlt));
+        $('#MPdefaultFwApproachAlt').val(toDisplayUnits(settings.fwApproachAlt, MISSION_UNIT_DIST).text);
+        $('#MPdefaultLandAlt').val(toDisplayUnits(settings.fwLandAlt, MISSION_UNIT_DIST).text);
+
+        $('#MPdefaultPointAltUnit').text(missionUnitLabel(MISSION_UNIT_ALT));
+        $('#MPdefaultPointSpeedUnit').text(missionUnitLabel(MISSION_UNIT_SPEED));
+        $('#MPdefaultFwApproachAltUnit').text(missionUnitLabel(MISSION_UNIT_DIST));
+        $('#MPdefaultLandAltUnit').text(missionUnitLabel(MISSION_UNIT_DIST));
     }
 
     function closeSettingsPanel() {
@@ -3208,7 +3298,7 @@ function iconKey(filename) {
             multiMissionWPNum = 0;
         let activatePoi = false;
         let activateHead = false;
-        $('#missionDistance').text(0);
+        $('#missionDistance').text(missionDistanceText(0));
         cleanLines();
         mission.get().forEach(function (element) {
             if (!element.isAttached()) {
@@ -3351,7 +3441,7 @@ function iconKey(filename) {
             $('#missionDistance').text('N/A');
         } else {
             if (lengthMission.length >= 1) {
-                $('#missionDistance').text(lengthMission[lengthMission.length -1].toFixed(1));
+                $('#missionDistance').text(missionDistanceText(lengthMission[lengthMission.length -1]));
             } else {
                 $('#missionDistance').text('infinite');
             }
@@ -3505,15 +3595,15 @@ function iconKey(filename) {
             $('#safehomeLatitude').val(selectedSafehome.getLatMap());
             $('#safehomeLongitude').val(selectedSafehome.getLonMap());
             changeSwitch($('#safehomeSeaLevelRef'), selectedFwApproachSh.getIsSeaLevelRef());
-            $('#safehomeApproachAlt').val(selectedFwApproachSh.getApproachAltAsl());
-            $('#safehomeLandAlt').val(selectedFwApproachSh.getLandAltAsl());
+            $('#safehomeApproachAlt').val(altitudeToDisplay(selectedFwApproachSh.getApproachAltAsl()));
+            $('#safehomeLandAlt').val(altitudeToDisplay(selectedFwApproachSh.getLandAltAsl()));
             $('#geozoneApproachDirection').val(selectedFwApproachSh.getApproachDirection());
             $('#safehomeLandHeading1').val(Math.abs(selectedFwApproachSh.getLandHeading1()));
             changeSwitch($('#safehomeLandHeading1Excl'), selectedFwApproachSh.getLandHeading1() < 0);
             $('#safehomeLandHeading2').val(Math.abs(selectedFwApproachSh.getLandHeading2()));
             changeSwitch($('#safehomeLandHeading2Excl'), selectedFwApproachSh.getLandHeading2() < 0);
-            $('#safehomeLandAltM').text(selectedFwApproachSh.getLandAltAsl() / 100 + " m");
-            $('#safehomeApproachAltM').text(selectedFwApproachSh.getApproachAltAsl() / 100 + " m");
+            $('#safehomeLandAltM').text(altitudeReadout(selectedFwApproachSh.getLandAltAsl()));
+            $('#safehomeApproachAltM').text(altitudeReadout(selectedFwApproachSh.getApproachAltAsl()));
             lockShExclHeading = false;
         } else {
             $('#SafehomeContentBox').hide();
@@ -3768,10 +3858,6 @@ function iconKey(filename) {
                 this.previousCursor_ = undefined;
             }
         }
-
-        app.ConvertCentimetersToMeters = function (val) {
-            return parseInt(val) / 100;
-        };
 
         class PlannerSettingsControl extends Control {
             
@@ -4086,10 +4172,10 @@ function iconKey(filename) {
                                     approach.setLandAltAsl(approach.getLandAltAsl() - approach.getElevation() + elevationAtWP * 100);
                                 }
                                 approach.setElevation(elevationAtWP * 100);
-                                $('#wpApproachAlt').val(approach.getApproachAltAsl());
-                                $('#wpLandAlt').val(approach.getLandAltAsl);
-                                $('#wpLandAltM').text(approach.getLandAltAsl() / 100 + " m");
-                                $('#wpApproachAltM').text(approach.getApproachAltAsl() / 100 + " m");
+                                $('#wpApproachAlt').val(altitudeToDisplay(approach.getApproachAltAsl()));
+                                $('#wpLandAlt').val(altitudeToDisplay(approach.getLandAltAsl()));
+                                $('#wpLandAltM').text(altitudeReadout(approach.getLandAltAsl()));
+                                $('#wpApproachAltM').text(altitudeReadout(approach.getApproachAltAsl()));
                             }
                         }
 
@@ -4400,8 +4486,6 @@ function iconKey(filename) {
                 changeSwitch($('#pointP3UserAction3'), missionControlTab.isBitSet(P3Value, MWNP.P3.USER_ACTION_3));
                 changeSwitch($('#pointP3UserAction4'), missionControlTab.isBitSet(P3Value, MWNP.P3.USER_ACTION_4));
 
-                const altitudeMeters = app.ConvertCentimetersToMeters(selectedMarker.getAlt());
-
                 if (selectedMarker.getAction() == MWNP.WPTYPE.LAND) {
                     $('#wpFwLanding').fadeIn(300);
                 } else  {
@@ -4425,10 +4509,10 @@ function iconKey(filename) {
                         }
                         */
                         selectedFwApproachWp.setIsSeaLevelRef(missionControlTab.isBitSet(P3Value, MWNP.P3.ALT_TYPE) ? 1 : 0);
-                        $('#wpApproachAlt').val(selectedFwApproachWp.getApproachAltAsl());
-                        $('#wpLandAlt').val(selectedFwApproachWp.getLandAltAsl);
-                        $('#wpLandAltM').text(selectedFwApproachWp.getLandAltAsl() / 100 + " m");
-                        $('#wpApproachAltM').text(selectedFwApproachWp.getApproachAltAsl() / 100 + " m");
+                        $('#wpApproachAlt').val(altitudeToDisplay(selectedFwApproachWp.getApproachAltAsl()));
+                        $('#wpLandAlt').val(altitudeToDisplay(selectedFwApproachWp.getLandAltAsl()));
+                        $('#wpLandAltM').text(altitudeReadout(selectedFwApproachWp.getLandAltAsl()));
+                        $('#wpApproachAltM').text(altitudeReadout(selectedFwApproachWp.getApproachAltAsl()));
 
                         plotElevation();
                     })()
@@ -4436,14 +4520,14 @@ function iconKey(filename) {
                 $('#elevationAtWP').fadeIn();
                 $('#groundClearanceAtWP').fadeIn();
 
-                $('#altitudeInMeters').text(` ${altitudeMeters}m`);
+                $('#altitudeInMeters').text(altitudeReadout(selectedMarker.getAlt()));
                 $('#pointLon').val(Math.round(coord[0] * 10000000) / 10000000);
                 $('#pointLat').val(Math.round(coord[1] * 10000000) / 10000000);
-                $('#pointAlt').val(selectedMarker.getAlt());
+                $('#pointAlt').val(altitudeToDisplay(selectedMarker.getAlt()));
                 $('#pointType').val(selectedMarker.getAction());
                 // Change SpeedValue to Parameter1, 2, 3
-                $('#pointP1').val(selectedMarker.getP1());
-                $('#pointP2').val(selectedMarker.getP2());
+                $('#pointP1').val(parameterToDisplay(selectedMarker.getAction(), 'parameter1', selectedMarker.getP1()));
+                $('#pointP2').val(parameterToDisplay(selectedMarker.getAction(), 'parameter2', selectedMarker.getP2()));
 
 
 
@@ -4466,7 +4550,7 @@ function iconKey(filename) {
                 for (var j in dictOfLabelParameterPoint[selectedMarker.getAction()]) {
                     if (dictOfLabelParameterPoint[selectedMarker.getAction()][j] != '') {
                         $('#pointP'+String(j).slice(-1)+'class').fadeIn(300);
-                        $('label[for=pointP'+String(j).slice(-1)+']').html(dictOfLabelParameterPoint[selectedMarker.getAction()][j]);
+                        $('label[for=pointP'+String(j).slice(-1)+']').html(parameterLabel(selectedMarker.getAction(), j));
                     }
                     else {$('#pointP'+String(j).slice(-1)+'class').fadeOut(300);}
                 }
@@ -4593,8 +4677,7 @@ function iconKey(filename) {
         // Update Alt display in meters on ALT field keypress up
         //////////////////////////////////////////////////////////////////////////
         $('#pointAlt').on('keyup', () => {
-            let altitudeMeters = app.ConvertCentimetersToMeters($('#pointAlt').val());
-            $('#altitudeInMeters').text(` ${altitudeMeters}m`);
+            $('#altitudeInMeters').text(altitudeReadout(altitudeFromDisplay($('#pointAlt').val())));
         });
 
         /////////////////////////////////////////////
@@ -4653,10 +4736,12 @@ function iconKey(filename) {
                 for (var j in dictOfLabelParameterPoint[selectedMarker.getAction()]) {
                     if (dictOfLabelParameterPoint[selectedMarker.getAction()][j] != '') {
                         $('#pointP'+String(j).slice(-1)+'class').fadeIn(300);
-                        $('label[for=pointP'+String(j).slice(-1)+']').html(dictOfLabelParameterPoint[selectedMarker.getAction()][j]);
+                        $('label[for=pointP'+String(j).slice(-1)+']').html(parameterLabel(selectedMarker.getAction(), j));
                     }
                     else {$('#pointP'+String(j).slice(-1)+'class').fadeOut(300);}
                 }
+                $('#pointP1').val(parameterToDisplay(selectedMarker.getAction(), 'parameter1', selectedMarker.getP1()));
+                $('#pointP2').val(parameterToDisplay(selectedMarker.getAction(), 'parameter2', selectedMarker.getP2()));
                 mission.updateWaypoint(selectedMarker);
                 mission.update(singleMissionActive());
                 redrawLayer();
@@ -4690,7 +4775,7 @@ function iconKey(filename) {
         $('#pointAlt').on('change', function (event) {
             if (selectedMarker) {
                 const elevationAtWP = Number($('#elevationValueAtWP').text());
-                const returnAltitude = checkAltElevSanity(true, Number($('#pointAlt').val()), elevationAtWP, selectedMarker.getP3());
+                const returnAltitude = checkAltElevSanity(true, altitudeFromDisplay($('#pointAlt').val()), elevationAtWP, selectedMarker.getP3());
                 selectedMarker.setAlt(returnAltitude);
                 mission.updateWaypoint(selectedMarker);
                 mission.update(singleMissionActive());
@@ -4704,7 +4789,7 @@ function iconKey(filename) {
                 if (selectedMarker.getAction() != MWNP.WPTYPE.SET_HEAD) {
                     $('#pointP1').val(Math.abs(Number($('#pointP1').val())));
                 }
-                selectedMarker.setP1(Number($('#pointP1').val()));
+                selectedMarker.setP1(parameterFromDisplay(selectedMarker.getAction(), 'parameter1', $('#pointP1').val()));
                 mission.updateWaypoint(selectedMarker);
                 mission.update(singleMissionActive());
                 redrawLayer();
@@ -4716,7 +4801,7 @@ function iconKey(filename) {
                 if (selectedMarker.getAction() == MWNP.WPTYPE.POSHOLD_TIME) {
                     $('#pointP2').val(Math.abs(Number($('#pointP2').val())));
                 }
-                selectedMarker.setP2(Number($('#pointP2').val()));
+                selectedMarker.setP2(parameterFromDisplay(selectedMarker.getAction(), 'parameter2', $('#pointP2').val()));
                 mission.updateWaypoint(selectedMarker);
                 mission.update(singleMissionActive());
                 redrawLayer();
@@ -4735,7 +4820,7 @@ function iconKey(filename) {
                 (async () => {
                     const elevationAtWP = await selectedMarker.getElevation(globalSettings);
                     $('#elevationValueAtWP').text(elevationAtWP);
-                    var altitude = Number($('#pointAlt').val());
+                    var altitude = altitudeFromDisplay($('#pointAlt').val());
 
                     if (P3Value != selectedMarker.getP3()) {
                         selectedMarker.setP3(P3Value);
@@ -4771,20 +4856,19 @@ function iconKey(filename) {
                             }
                             selectedFwApproachWp.setElevation(elevationAtWP * 100);
                             selectedFwApproachWp.setIsSeaLevelRef($('#pointP3Alt').prop("checked") ? 1 : 0);
-                            $('#wpApproachAlt').val(selectedFwApproachWp.getApproachAltAsl());
-                            $('#wpLandAlt').val(selectedFwApproachWp.getLandAltAsl());
+                            $('#wpApproachAlt').val(altitudeToDisplay(selectedFwApproachWp.getApproachAltAsl()));
+                            $('#wpLandAlt').val(altitudeToDisplay(selectedFwApproachWp.getLandAltAsl()));
                         }
 
                     }
 
                     const returnAltitude = checkAltElevSanity(false, selectedMarker.getAlt(), elevationAtWP, selectedMarker.getP3());
                     selectedMarker.setAlt(returnAltitude);
-                    $('#pointAlt').val(selectedMarker.getAlt());
-                    let altitudeMeters = app.ConvertCentimetersToMeters(selectedMarker.getAlt());
-                    $('#altitudeInMeters').text(` ${altitudeMeters}m`);
+                    $('#pointAlt').val(altitudeToDisplay(selectedMarker.getAlt()));
+                    $('#altitudeInMeters').text(altitudeReadout(selectedMarker.getAlt()));
 
-                    $('#wpLandAltM').text(selectedFwApproachWp.getLandAltAsl() / 100 + " m");
-                    $('#wpApproachAltM').text(selectedFwApproachWp.getApproachAltAsl() / 100 + " m");
+                    $('#wpLandAltM').text(altitudeReadout(selectedFwApproachWp.getLandAltAsl()));
+                    $('#wpApproachAltM').text(altitudeReadout(selectedFwApproachWp.getApproachAltAsl()));
 
                     if (selectedFwApproachWp && selectedFwApproachWp.getIsSeaLevelRef() != $('#pointP3Alt').prop("checked")) {
                         selectedFwApproachWp.setIsSeaLevelRef($('#pointP3Alt').prop("checked"));
@@ -4797,12 +4881,12 @@ function iconKey(filename) {
                             selectedFwApproachWp.setLandAltAsl(selectedFwApproachWp.getLandAltAsl() - elevationAtWP * 100);
                         }
 
-                        $('#wpApproachAlt').val(selectedFwApproachWp.getApproachAltAsl());
-                        $('#wpLandAlt').val(selectedFwApproachWp.getLandAltAsl());
+                        $('#wpApproachAlt').val(altitudeToDisplay(selectedFwApproachWp.getApproachAltAsl()));
+                        $('#wpLandAlt').val(altitudeToDisplay(selectedFwApproachWp.getLandAltAsl()));
                     }
 
-                    $('#wpLandAltM').text(selectedFwApproachWp.getLandAltAsl() / 100 + " m");
-                    $('#wpApproachAltM').text(selectedFwApproachWp.getApproachAltAsl() / 100 + " m");
+                    $('#wpLandAltM').text(altitudeReadout(selectedFwApproachWp.getLandAltAsl()));
+                    $('#wpApproachAltM').text(altitudeReadout(selectedFwApproachWp.getApproachAltAsl()));
 
                     mission.updateWaypoint(selectedMarker);
                     mission.update(singleMissionActive());
@@ -4874,20 +4958,20 @@ function iconKey(filename) {
 
         $('#wpApproachAlt').on('change', (event) => {
             if (selectedMarker && selectedFwApproachWp) {
-                let altitude = Number($(event.currentTarget).val());
+                let altitude = altitudeFromDisplay($(event.currentTarget).val());
                 if (checkApproachAltitude(altitude, $('#pointP3Alt').prop('checked'), Number($('#elevationValueAtWP').text()))) {
-                    selectedFwApproachWp.setApproachAltAsl(Number($(event.currentTarget).val()));
-                    $('#wpApproachAltM').text(selectedFwApproachWp.getApproachAltAsl() / 100 + " m");
+                    selectedFwApproachWp.setApproachAltAsl(altitude);
+                    $('#wpApproachAltM').text(altitudeReadout(selectedFwApproachWp.getApproachAltAsl()));
                 }
             }
         });
 
         $('#wpLandAlt').on('change', (event) => {
             if (selectedMarker && selectedFwApproachWp) {
-                let altitude = Number($(event.currentTarget).val());
+                let altitude = altitudeFromDisplay($(event.currentTarget).val());
                 if (checkLandingAltitude(altitude, $('#pointP3Alt').prop('checked'), Number($('#elevationValueAtWP').text()))) {
-                    selectedFwApproachWp.setLandAltAsl(Number($(event.currentTarget).val()));
-                    $('#wpLandAltM').text(selectedFwApproachWp.getLandAltAsl() / 100 + " m");
+                    selectedFwApproachWp.setLandAltAsl(altitude);
+                    $('#wpLandAltM').text(altitudeReadout(selectedFwApproachWp.getLandAltAsl()));
                 }
             }
         });
@@ -5130,10 +5214,10 @@ function iconKey(filename) {
                     }
 
                     $('#safehomeElevation').text(elevation / 100);
-                    $('#safehomeApproachAlt').val(selectedFwApproachSh.getApproachAltAsl());
-                    $('#safehomeLandAlt').val(selectedFwApproachSh.getLandAltAsl());
-                    $('#safehomeLandAltM').text(selectedFwApproachSh.getLandAltAsl() / 100 + " m");
-                    $('#safehomeApproachAltM').text(selectedFwApproachSh.getApproachAltAsl() / 100 + " m");
+                    $('#safehomeApproachAlt').val(altitudeToDisplay(selectedFwApproachSh.getApproachAltAsl()));
+                    $('#safehomeLandAlt').val(altitudeToDisplay(selectedFwApproachSh.getLandAltAsl()));
+                    $('#safehomeLandAltM').text(altitudeReadout(selectedFwApproachSh.getLandAltAsl()));
+                    $('#safehomeApproachAltM').text(altitudeReadout(selectedFwApproachSh.getApproachAltAsl()));
 
                     renderSafeHomeOptions();
                 })();
@@ -5143,15 +5227,15 @@ function iconKey(filename) {
         $('#safehomeApproachAlt').on('change', event => {
 
             if (selectedFwApproachSh) {
-                let altitude = Number($(event.currentTarget).val());
+                let altitude = altitudeFromDisplay($(event.currentTarget).val());
                 if (checkApproachAltitude(altitude, $('#safehomeSeaLevelRef').prop('checked'), Number($('#safehomeElevation').text()))) {
-                    selectedFwApproachSh.setApproachAltAsl(Number($(event.currentTarget).val()));
-                    $('#safehomeApproachAltM').text(selectedFwApproachSh.getApproachAltAsl() / 100 + " m");
+                    selectedFwApproachSh.setApproachAltAsl(altitude);
+                    $('#safehomeApproachAltM').text(altitudeReadout(selectedFwApproachSh.getApproachAltAsl()));
                     cleanSafehomeLayers();
                     renderSafehomesOnMap();
                     renderHomeTable();
                 }
-                $('#safehomeApproachAlt').val(selectedFwApproachSh.getApproachAltAsl());
+                $('#safehomeApproachAlt').val(altitudeToDisplay(selectedFwApproachSh.getApproachAltAsl()));
             }
 
         });
@@ -5159,15 +5243,15 @@ function iconKey(filename) {
         $('#safehomeLandAlt').on('change', event => {
 
             if (selectedFwApproachSh) {
-                let altitude = Number($(event.currentTarget).val());
+                let altitude = altitudeFromDisplay($(event.currentTarget).val());
                 if (checkLandingAltitude(altitude, $('#safehomeSeaLevelRef').prop('checked'), Number($('#safehomeElevation').text()))) {
                     selectedFwApproachSh.setLandAltAsl(altitude);
-                    $('#safehomeLandAltM').text(selectedFwApproachSh.getLandAltAsl() / 100 + " m");
+                    $('#safehomeLandAltM').text(altitudeReadout(selectedFwApproachSh.getLandAltAsl()));
                     cleanSafehomeLayers();
                     renderSafehomesOnMap();
                     renderHomeTable();
                 } else {
-                    $('#safehomeLandAlt').val(selectedFwApproachSh.getLandAltAsl());
+                    $('#safehomeLandAlt').val(altitudeToDisplay(selectedFwApproachSh.getLandAltAsl()));
                 }
             }
         });
@@ -6054,8 +6138,6 @@ function iconKey(filename) {
             changeSwitch($('#pointP3UserAction3'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_3));
             changeSwitch($('#pointP3UserAction4'), TABS.mission_control.isBitSet(P3Value, MWNP.P3.USER_ACTION_4));
 
-            const altitudeMeters = selectedMarker.getAlt() / 100;
-
             if (selectedMarker.getAction() == MWNP.WPTYPE.LAND) {
                 $('#wpFwLanding').fadeIn(300);
             } else {
@@ -6073,16 +6155,16 @@ function iconKey(filename) {
             $('#elevationAtWP').fadeIn();
             $('#groundClearanceAtWP').fadeIn();
 
-            $('#altitudeInMeters').text(` ${altitudeMeters}m`);
+            $('#altitudeInMeters').text(altitudeReadout(selectedMarker.getAlt()));
             $('#pointLon').val(Math.round(coord[0] * 10000000) / 10000000);
             $('#pointLat').val(Math.round(coord[1] * 10000000) / 10000000);
-            $('#pointAlt').val(selectedMarker.getAlt());
+            $('#pointAlt').val(altitudeToDisplay(selectedMarker.getAlt()));
             $('#pointType').val(selectedMarker.getAction());
-            $('#pointP1').val(selectedMarker.getP1());
-            $('#pointP2').val(selectedMarker.getP2());
+            $('#pointP1').val(parameterToDisplay(selectedMarker.getAction(), 'parameter1', selectedMarker.getP1()));
+            $('#pointP2').val(parameterToDisplay(selectedMarker.getAction(), 'parameter2', selectedMarker.getP2()));
 
             for (const j in dictOfLabelParameterPoint[selectedMarker.getAction()]) {
-                const labelText = dictOfLabelParameterPoint[selectedMarker.getAction()][j];
+                const labelText = parameterLabel(selectedMarker.getAction(), j);
                 const parameterSuffix = String(j).slice(-1);
 
                 if (labelText === '') {
@@ -6279,11 +6361,11 @@ function iconKey(filename) {
             let oldSafeRadiusSH = settings.safeRadiusSH;
 
             // update only default settings
-            settings.alt = Number($('#MPdefaultPointAlt').val());
-            settings.speed = Number($('#MPdefaultPointSpeed').val());
+            settings.alt = altitudeFromDisplay($('#MPdefaultPointAlt').val());
+            settings.speed = fromDisplayUnits($('#MPdefaultPointSpeed').val(), MISSION_UNIT_SPEED);
             settings.safeRadiusSH = Number($('#MPdefaultSafeRangeSH').val());
-            settings.fwApproachAlt = Number($('#MPdefaultFwApproachAlt').val());
-            settings.fwLandAlt = Number($('#MPdefaultLandAlt').val());
+            settings.fwApproachAlt = fromDisplayUnits($('#MPdefaultFwApproachAlt').val(), MISSION_UNIT_DIST, 2);
+            settings.fwLandAlt = fromDisplayUnits($('#MPdefaultLandAlt').val(), MISSION_UNIT_DIST, 2);
 
             saveSettings();
 
@@ -6731,9 +6813,8 @@ function iconKey(filename) {
             }
             groundClearance = altitude / 100 + (elevationAtHome - elevation);
         }
-        $('#pointAlt').val(altitude);
-        let altitudeMeters = parseInt(altitude) / 100;
-        $('#altitudeInMeters').text(` ${altitudeMeters}m`);
+        $('#pointAlt').val(altitudeToDisplay(altitude));
+        $('#altitudeInMeters').text(altitudeReadout(altitude));
         document.getElementById('groundClearanceAtWP').style.color = groundClearance < (settings.alt / 100) ? "#FF0000" : "#303030";
         $('#groundClearanceValueAtWP').text(` ${groundClearance}`);
 

--- a/tests/unit-conversion.test.mjs
+++ b/tests/unit-conversion.test.mjs
@@ -11,7 +11,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import { globalSettings, UnitType } from '../js/globalSettings.js';
-import { fromDisplayUnits, getUnitMultiplier, toDisplayUnits } from '../js/unitConversion.js';
+import { fromDisplayUnits, getUnitMultiplier, smartRound, toDisplayUnits } from '../js/unitConversion.js';
 
 function withUnits(unitType, osdUnits, body) {
     const previousType = globalSettings.unitType;
@@ -128,4 +128,18 @@ test('values that cannot be converted are passed through', () => {
         assert.equal(toDisplayUnits('N/A', 'cm').text, 'N/A');
         assert.equal(Number.isNaN(fromDisplayUnits('N/A', 'cm')), true);
     });
+});
+
+test('display rounding hides conversion noise and snaps to round numbers', () => {
+    // 100 m is 328.08 ft, and the decimals move the value by well under 1%.
+    assert.equal(smartRound(328.08, 2), '328');
+    assert.equal(smartRound(9842.52, 2), '9843');
+
+    // Within 1 of a 10/100/1000 boundary the value snaps onto it, negative
+    // values included.
+    assert.equal(smartRound(999.4, 2), '1000');
+    assert.equal(smartRound(-999.4, 2), '-1000');
+
+    // Below two decimal places the value is left to toFixed().
+    assert.equal(smartRound(12.34, 1), '12.3');
 });

--- a/tests/unit-conversion.test.mjs
+++ b/tests/unit-conversion.test.mjs
@@ -1,0 +1,131 @@
+/**
+ * Tests for the unit presentation helpers the mission planner uses
+ * (iNavFlight/inav-configurator#2108).
+ *
+ * Mission Control keeps storing and sending firmware units, so the important
+ * property is that a value the user types survives being converted for
+ * display and converted back again.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { globalSettings, UnitType } from '../js/globalSettings.js';
+import { fromDisplayUnits, getUnitMultiplier, toDisplayUnits } from '../js/unitConversion.js';
+
+function withUnits(unitType, osdUnits, body) {
+    const previousType = globalSettings.unitType;
+    const previousOsdUnits = globalSettings.osdUnits;
+
+    globalSettings.unitType = unitType;
+    globalSettings.osdUnits = osdUnits;
+    try {
+        body();
+    } finally {
+        globalSettings.unitType = previousType;
+        globalSettings.osdUnits = previousOsdUnits;
+    }
+}
+
+test('without a unit system the firmware units are shown unchanged', () => {
+    withUnits(UnitType.none, null, () => {
+        const altitude = toDisplayUnits(3000, 'cm');
+        assert.equal(altitude.multiplier, 1);
+        assert.equal(altitude.text, '3000');
+        assert.equal(altitude.displayName, 'cm');
+
+        const speed = toDisplayUnits(500, 'cms');
+        assert.equal(speed.multiplier, 1);
+        assert.equal(speed.text, '500');
+        assert.equal(speed.displayName, 'cm/s');
+
+        assert.equal(fromDisplayUnits(3000, 'cm'), 3000);
+        assert.equal(fromDisplayUnits(500, 'cms'), 500);
+    });
+});
+
+test('imperial shows altitudes in feet and speeds in mph', () => {
+    withUnits(UnitType.imperial, null, () => {
+        assert.equal(getUnitMultiplier('cm').unitName, 'ft');
+        assert.equal(getUnitMultiplier('cms').unitName, 'mph');
+
+        assert.equal(toDisplayUnits(15240, 'cm').text, '500');
+        assert.equal(toDisplayUnits(500, 'cms').text, '11.18');
+    });
+});
+
+test('metric shows altitudes in metres and speeds in km/h', () => {
+    withUnits(UnitType.metric, null, () => {
+        assert.equal(toDisplayUnits(3000, 'cm').text, '30.0');
+        assert.equal(toDisplayUnits(3000, 'cm').displayName, 'm');
+        assert.equal(toDisplayUnits(500, 'cms').text, '18');
+        assert.equal(toDisplayUnits(500, 'cms').displayName, 'Km/h');
+    });
+});
+
+test('the OSD unit type follows the unit preference read from the FC', () => {
+    withUnits(UnitType.OSD, 0, () => {
+        assert.equal(getUnitMultiplier('cm').unitName, 'ft');
+    });
+    withUnits(UnitType.OSD, 1, () => {
+        assert.equal(getUnitMultiplier('cm').unitName, 'm');
+    });
+    withUnits(UnitType.OSD, 4, () => {
+        assert.equal(getUnitMultiplier('cm').unitName, 'ft');
+        assert.equal(getUnitMultiplier('cms').unitName, 'kt');
+    });
+});
+
+test('a typed altitude survives storing and reloading in imperial', () => {
+    withUnits(UnitType.imperial, null, () => {
+        for (const typed of [25, 100, 328, 500, 1640, 3280]) {
+            const stored = fromDisplayUnits(typed, 'cm');
+
+            assert.equal(Number.isInteger(stored), true, typed + ' ft did not give whole centimetres');
+            assert.equal(toDisplayUnits(stored, 'cm').text, String(typed),
+                typed + ' ft did not come back unchanged');
+            assert.equal(fromDisplayUnits(toDisplayUnits(stored, 'cm').text, 'cm'), stored,
+                typed + ' ft drifted on a second round trip');
+        }
+    });
+});
+
+test('a typed speed survives storing and reloading in imperial', () => {
+    withUnits(UnitType.imperial, null, () => {
+        for (const typed of [5, 11.18, 22.37, 50]) {
+            const stored = fromDisplayUnits(typed, 'cms');
+
+            assert.equal(Number.isInteger(stored), true, typed + ' mph did not give whole cm/s');
+            assert.equal(fromDisplayUnits(toDisplayUnits(stored, 'cms').text, 'cms'), stored,
+                typed + ' mph drifted on a round trip');
+        }
+    });
+});
+
+test('metre based planner defaults keep two decimals of precision', () => {
+    withUnits(UnitType.imperial, null, () => {
+        // Approach and landing altitude are held in whole metres by the
+        // planner settings, so they are converted with a finer precision.
+        const stored = fromDisplayUnits('16.40', 'm', 2);
+        assert.equal(stored, 5);
+        assert.equal(toDisplayUnits(stored, 'm').text, '16.40');
+    });
+});
+
+test('mission length is converted from metres', () => {
+    withUnits(UnitType.metric, null, () => {
+        assert.equal(toDisplayUnits(1234, 'm').multiplier, 1);
+        assert.equal(toDisplayUnits(1234, 'm').displayName, 'm');
+    });
+    withUnits(UnitType.imperial, null, () => {
+        assert.equal(toDisplayUnits(1234, 'm').displayName, 'ft');
+        assert.equal(toDisplayUnits(1234, 'm').text, '4050');
+    });
+});
+
+test('values that cannot be converted are passed through', () => {
+    withUnits(UnitType.imperial, null, () => {
+        assert.equal(toDisplayUnits('N/A', 'cm').text, 'N/A');
+        assert.equal(Number.isNaN(fromDisplayUnits('N/A', 'cm')), true);
+    });
+});


### PR DESCRIPTION
## Problem
With the Configurator set to imperial, Mission Control stays metric. The reporter switched units on iNav 6.1.1, saw Advanced Tuning and the OSD tab change while the mission planner kept centimetres, and had to convert every waypoint altitude to feet by hand before flying; breadoven replied on the issue that units do not apply in Mission Control and need adding. Fixes #2108.

## Cause
Mission Control writes firmware values straight into its fields: `tabs/mission_control.js:4869` on `maintenance-10.x` does `$('#pointAlt').val(selectedMarker.getAlt())`, which is centimetres. The conversion exists only inside `Settings.convertToUnitSetting()`, which `js/settings.js:92` and `js/settings.js:197` apply to `[data-setting]` inputs — `tabs/mission_control.html` has none.

## Change
The unit tables, the multiplier lookup and `smartRound()` move out of `js/settings.js` (-363 lines) into a new `js/unitConversion.js` that both callers share. Mission Control converts waypoint altitude and speed, the approach and landing altitudes for waypoints and safehomes, the planner defaults and the total mission distance for display and back again before anything is stored, so the model, MSP and the `.mission` file keep firmware units; five labels lose their hardcoded unit in all eight locales and the unit now sits next to the field, and `js/osdUnits.js` resolves the controller's OSD units before the tab renders. Geozones, the grid survey panel, safehome radius and the elevation and ground clearance readouts are untouched, because those readouts parse metres back out of the DOM text (`tabs/mission_control.js:5170`).

## Test
`node --test tests/unit-conversion.test.mjs` at `210528e`: 10 tests, all pass — no unit system, imperial, metric, OSD units read from the FC, both round trips, metre defaults, mission length and display rounding. CI does not run the suite (`ci.yml` only builds); locally at the same commit it is 162 tests with 161 passing, and that one failure also fails on unmodified `maintenance-10.x`. All six platform builds and SonarCloud are green: https://github.com/iNavFlight/inav-configurator/actions/runs/34761911735. Not run in the app for this revision.

## Flash / RAM
Not applicable (Configurator).

## Docs
None needed. No file in this repository documents Mission Control units; `README.md` mentions the tab only for offline map caching.
