### PR TITLE
Fail the Alignment Tool safely when its load chain stalls

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -2615,6 +2615,9 @@
     "magnetometerHead": {
         "message": "Alignment Tool"
     },
+    "magnetometerLoadFailed": {
+        "message": "The Alignment Tool did not receive its configuration from the flight controller. The tab was not opened, the connection is unchanged."
+    },
     "magnetometerHelp": {
         "message": "1. Adjust Flight Controller orientation to match physical orientation on the aircraft <u>according to \"direction\" arrow on the Flight Controller</u>.<br/>2. Adjust magnetometer model, or magnetometer chip, or magnetometer axes orientation to match physical orientation on the aircraft.<br/><strong>Note:</strong> Magnetometer orientation preset (align_mag) is relative to FC. Make sure to align FC first (align_board_pitch, align_board_roll, align_board_yaw).<br/>If preset is not used (orientation is set using align_mag_roll, align_mag_pitch and align_mag_yaw), then magnetometer orientation is independent."
     },

--- a/tabs/magnetometer.js
+++ b/tabs/magnetometer.js
@@ -14,8 +14,15 @@ import GUI from './../js/gui';
 import i18n from './../js/localization';
 import { mixer } from './../js/model';
 import interval from './../js/intervals';
+import timeout from './../js/timeouts';
 
 const magnetometerTab = {};
+
+// The load chain has no error path: a request that is never answered (a setting
+// the firmware does not know, a dropped MSP frame) leaves the tab on the loading
+// spinner and GUI.content_ready() is never reached, which keeps the tab switcher
+// blocked. Give up after this many milliseconds and show a message instead.
+const LOAD_TIMEOUT = 10000;
 
 
 magnetometerTab.initialize = function (callback) {
@@ -94,9 +101,13 @@ magnetometerTab.initialize = function (callback) {
         }
     ];
 
+    self.loadFinished = false;
+
     loadChainer.setChain(loadChain);
     loadChainer.setExitPoint(load_html);
     loadChainer.execute();
+
+    timeout.add('magnetometer_load', load_timed_out, LOAD_TIMEOUT);
 
     function areAnglesZero() {
         return self.alignmentConfig.pitch === 0 && self.alignmentConfig.roll === 0 && self.alignmentConfig.yaw === 0
@@ -173,7 +184,37 @@ magnetometerTab.initialize = function (callback) {
     }
 
     function load_html() {
+        if (self.loadFinished) {
+            return;
+        }
+        self.loadFinished = true;
+        timeout.remove('magnetometer_load');
+
         import('./magnetometer.html?raw').then(({default: html}) => GUI.load(html, process_html));
+    }
+
+    function load_timed_out() {
+        if (self.loadFinished) {
+            return;
+        }
+
+        // A hidden window throttles the timers that drive the MSP queue, so the
+        // chain is allowed to take longer than LOAD_TIMEOUT while the window is
+        // in the background. Only give up on a window the user can see.
+        if (document.hidden) {
+            timeout.add('magnetometer_load', load_timed_out, LOAD_TIMEOUT);
+            return;
+        }
+
+        self.loadFinished = true;
+
+        GUI.log(i18n.getMessage('magnetometerLoadFailed'));
+
+        // Hand the tab back to the user instead of leaving it loading forever.
+        GUI.load('<div class="tab-magnetometer"><div class="content_wrapper"><div class="note"><p data-i18n="magnetometerLoadFailed"></p></div></div></div>', function () {
+            i18n.localize();
+            GUI.content_ready(callback);
+        });
     }
 
     function generateRange(min, max, step) {
@@ -724,7 +765,10 @@ magnetometerTab.initialize3D = function () {
             GUI.log("<span style='color: red; font-weight: bolder'><strong>" + i18n.getMessage("mixerNotConfigured") + "</strong></span>");
         }
         else {
-            model_file = mixer.getById(FC.MIXER_CONFIG.appliedMixerPreset).model;
+            // A flight controller can report a preset this Configurator does not
+            // know; use the generic model rather than throwing out of the tab.
+            const appliedMixer = mixer.getById(FC.MIXER_CONFIG.appliedMixerPreset);
+            model_file = appliedMixer ? appliedMixer.model : 'fallback';
         }
     }
     else {
@@ -892,7 +936,12 @@ magnetometerTab.initialize3D = function () {
 
 
 magnetometerTab.cleanup = function (callback) {
-    $(window).off('resize', this.resize3D);
+    timeout.remove('magnetometer_load');
+
+    // Without the handler, off() would drop every resize listener on the window.
+    if (this.resize3D) {
+        $(window).off('resize', this.resize3D);
+    }
 
     if (callback) callback();
 };

--- a/tests/alignment-tool-load-guard.test.mjs
+++ b/tests/alignment-tool-load-guard.test.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for the Alignment Tool (magnetometer tab) load guard.
+ *
+ * The tab's MSP load chain has no error path: a request that is never answered
+ * used to leave the tab on the loading spinner forever, and GUI.content_ready()
+ * was never reached. These tests mirror the guard added to tabs/magnetometer.js
+ * and check that the real file keeps it wired up.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const tabSource = readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'tabs', 'magnetometer.js'),
+    'utf8'
+);
+
+// Mirrors the load_html() / load_timed_out() pair in tabs/magnetometer.js
+function createLoadGuard(isHidden) {
+    const state = { loadFinished: false, loaded: 0, failed: 0, timers: 0 };
+
+    function armTimer() {
+        state.timers++;
+    }
+
+    return {
+        state,
+        chainFinished() {
+            if (state.loadFinished) {
+                return;
+            }
+            state.loadFinished = true;
+            state.loaded++;
+        },
+        timedOut() {
+            if (state.loadFinished) {
+                return;
+            }
+            if (isHidden()) {
+                armTimer();
+                return;
+            }
+            state.loadFinished = true;
+            state.failed++;
+        }
+    };
+}
+
+// Mirrors the model selection in magnetometerTab.initialize3D()
+function selectModel(appliedMixerPreset, knownPresets) {
+    if (appliedMixerPreset === -1) {
+        return 'fallback';
+    }
+    const appliedMixer = knownPresets[appliedMixerPreset];
+    return appliedMixer ? appliedMixer.model : 'fallback';
+}
+
+describe('Alignment Tool load guard', () => {
+
+    test('a completed chain loads the tab once and a late timeout does nothing', () => {
+        const guard = createLoadGuard(() => false);
+        guard.chainFinished();
+        guard.timedOut();
+        guard.chainFinished();
+        assert.equal(guard.state.loaded, 1);
+        assert.equal(guard.state.failed, 0);
+    });
+
+    test('a stalled chain gives up once and does not load the tab afterwards', () => {
+        const guard = createLoadGuard(() => false);
+        guard.timedOut();
+        guard.chainFinished();
+        guard.timedOut();
+        assert.equal(guard.state.failed, 1);
+        assert.equal(guard.state.loaded, 0);
+    });
+
+    test('a hidden window re-arms the timer instead of giving up', () => {
+        let hidden = true;
+        const guard = createLoadGuard(() => hidden);
+        guard.timedOut();
+        guard.timedOut();
+        assert.equal(guard.state.failed, 0);
+        assert.equal(guard.state.timers, 2);
+
+        // Once the window is back on screen the chain is still allowed to finish.
+        hidden = false;
+        guard.chainFinished();
+        assert.equal(guard.state.loaded, 1);
+        assert.equal(guard.state.failed, 0);
+    });
+
+    test('an unknown mixer preset falls back to the generic model', () => {
+        const knownPresets = { 3: { model: 'quad_x' } };
+        assert.equal(selectModel(3, knownPresets), 'quad_x');
+        assert.equal(selectModel(-1, knownPresets), 'fallback');
+        assert.equal(selectModel(99, knownPresets), 'fallback');
+    });
+
+    test('the tab arms the load timeout and drops it again', () => {
+        assert.match(tabSource, /timeout\.add\('magnetometer_load'/);
+        assert.match(tabSource, /timeout\.remove\('magnetometer_load'\)/);
+        // cleanup() has to drop the timer, otherwise it fires into the next tab
+        const cleanup = tabSource.slice(tabSource.indexOf('magnetometerTab.cleanup'));
+        assert.match(cleanup, /timeout\.remove\('magnetometer_load'\)/);
+    });
+});


### PR DESCRIPTION
## Problem

Two users report in [#2380](https://github.com/iNavFlight/inav-configurator/issues/2380) that clicking the Alignment Tool in demo mode on 8.0.1 ends the session within a second: the log shows `Error: read ECONNRESET`, the connection closes and the Configurator restarts, while the other tabs work normally. That crash is already fixed on `maintenance-10.x` — the `align_mag_*` load steps got a null guard and a `.catch()` in `ef74611e` and `2ab4caea` — so this PR does not close the issue. What remains is that the tab has no error path at all: an MSP request that is never answered leaves it on the loading spinner.

## Cause

`tabs/magnetometer.js:99` starts the load chain with `load_html` as its only exit point, and `MSPChainerClass` (`js/msp/MSPchainer.js`) advances only when a step calls back, so an unanswered request never reaches that exit point, `GUI.content_ready()` is never called and the tab switcher stays blocked. Two more faults sit on the same path: `tabs/magnetometer.js:727` dereferences `mixer.getById(...)`, which returns `undefined` for a preset this Configurator does not know, and `tabs/magnetometer.js:895` calls `off('resize', this.resize3D)` with no handler registered, which makes jQuery remove every resize listener on the window.

## Change

A 10 s timeout is armed next to `loadChainer.execute()`. If the chain has not finished by then, the tab logs the new `magnetometerLoadFailed` message, renders it and calls `GUI.content_ready(callback)` instead of staying on the spinner; the connection is not touched. While `document.hidden` is set the timer is re-armed instead of firing, because a background window throttles the timers that drive the MSP queue. An unknown mixer preset falls back to the generic model, and `cleanup()` clears the timer and removes the resize handler only when one was registered.

## Test

`node --test tests/alignment-tool-load-guard.test.mjs` at `59c1269`: 5 tests, all pass — single load, single give-up, re-arm while hidden, mixer fallback, and the timer wiring including `cleanup`. Full suite `node --test tests/*.test.mjs`: 104 tests, 101 pass, 3 fail, all three in test files this PR does not touch. Not run in the app for this revision; the stall path was verified by reading the files named above. All six CI build jobs are green: https://github.com/iNavFlight/inav-configurator/actions/runs/34530154145 (CI builds only, it does not run the test suite).

## Flash / RAM
Not applicable (Configurator).

## Docs

None needed. No Markdown file on `maintenance-10.x` describes the Alignment Tool's load behaviour, so nothing there becomes wrong. The only user-visible text is the new `magnetometerLoadFailed` string in `locale/en/messages.json`, which is part of this change.
