### PR TITLE
Say what Select New Defaults actually overwrites

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -5760,7 +5760,7 @@
         "message": "Do you really want to reset all settings?\nATTENTION: All settings are lost! You have to setup the whole aircraft after this operation!"
     },
     "confirm_select_defaults": {
-        "message": "This will allow to select new default values for all settings. Existing PID tune and other settings might be lost!\nDo you want to continue?"
+        "message": "Continuing reboots the flight controller and reopens the setup wizard, where the model you pick applies that model's default settings. This overwrites the motor and servo mixer, the platform type, the gyro filtering and motor output settings, and the PID, rate and navigation values in all three control and battery profiles, and it cannot be undone from here. If your current configuration matters, cancel and back it up first with Diff All and Save to File on the CLI tab.\nDo you want to continue?"
     },
     "confirm_reset_pid": {
         "message": "This will reset all PID settings to firmware default values and save.\nDo you want to continue?"


### PR DESCRIPTION
## Problem
Pressing **Select New Defaults** on the Tuning tab reset the custom motor mixing and position settings of an 8 inch 6S quad. The dialog in front of that button warned only that existing PID tune and other settings "might be lost", which reads like a PID reset and never mentions the mixer; in the reporter's words it "does not suggest that my quad will violently throw itself into a spin towards myself at full throttle" - iNavFlight/inav#10883 (filed on the firmware repository, so this PR cannot close it automatically).

## Cause
`confirm_select_defaults` in `locale/en/messages.json:5847` on maintenance-10.x, shown by `tabs/pid_tuning.js:307`. That handler clears `applied_defaults`, saves and reboots; after the reconnect `js/defaults_dialog.js:33` reopens the setup wizard, which replaces the motor and servo mixer and the platform type (`js/defaults_dialog.js:256-275`) and writes the control and battery profile settings to all three profiles (`js/defaults_dialog.js:235`).

## Change
One string in `locale/en/messages.json`. The new text says that continuing reboots the flight controller and reopens the setup wizard, then names what the selected model overwrites: motor and servo mixer, platform type, gyro filtering and motor output settings, and the PID, rate and navigation values in all three control and battery profiles. It adds that this cannot be undone from here and points at Diff All and Save to File on the CLI tab. No code or behaviour change, and no other locale is touched.

## Test
Built from this branch and run; Tuning tab, **Select New Defaults**:

![Confirmation dialog with the new wording](https://raw.githubusercontent.com/Raffi1202/inav-configurator/pr-evidence/cfg-2765-dialog.png)

CI is green on `301b60a` - six platform builds plus SonarCloud: https://github.com/iNavFlight/inav-configurator/actions/runs/34532688789

## Flash / RAM
Not applicable (Configurator).

## Docs
None needed. No Markdown file on maintenance-10.x mentions this button or its warning text; the string itself is the user-facing documentation.
